### PR TITLE
feat/explicit opensearch classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **Improve documentation** Update the README's.
 * **Explicit Opensearch classes** For the connector registry entries for opensearch, use only opensearch specific classes rather than any elasticsearch ones. 
+* **Add missing fsspec destination precheck** check connection in precheck for all fsspec-based destination connectors
 
 ## 0.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.0.3-dev0
+## 0.0.3-dev1
 
 ### Enhancements
 
 * **Improve documentation** Update the README's.
+* **Explicit Opensearch classes** For the connector registry entries for opensearch, use only opensearch specific classes rather than any elasticsearch ones. 
 
 ## 0.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.3-dev1
+## 0.0.3
 
 ### Enhancements
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.3-dev1"  # pragma: no cover
+__version__ = "0.0.3"  # pragma: no cover

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.3-dev0"  # pragma: no cover
+__version__ = "0.0.3-dev1"  # pragma: no cover

--- a/unstructured_ingest/v2/interfaces/process.py
+++ b/unstructured_ingest/v2/interfaces/process.py
@@ -17,7 +17,3 @@ class BaseProcess(ABC):
 
     async def run_async(self, **kwargs: Any) -> Any:
         return self.run(**kwargs)
-
-    def check_connection(self):
-        # If the process requires external connections, run a quick check
-        pass

--- a/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
@@ -75,6 +75,10 @@ class AzureIndexer(FsspecIndexer):
     index_config: AzureIndexerConfig
     connector_type: str = CONNECTOR_TYPE
 
+    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
+    def precheck(self) -> None:
+        super().precheck()
+
     def sterilize_info(self, path) -> dict:
         info = self.fs.info(path=path)
         return sterilize_dict(data=info, default=azure_json_serial)
@@ -119,6 +123,10 @@ class AzureUploader(FsspecUploader):
     @requires_dependencies(["adlfs", "fsspec"], extras="azure")
     def __post_init__(self):
         super().__post_init__()
+
+    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
+    def precheck(self) -> None:
+        super().precheck()
 
     @requires_dependencies(["adlfs", "fsspec"], extras="azure")
     def run(self, contents: list[UploadContent], **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/box.py
@@ -70,6 +70,10 @@ class BoxIndexer(FsspecIndexer):
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
         return super().run(**kwargs)
 
+    @requires_dependencies(["boxfs"], extras="box")
+    def precheck(self) -> None:
+        super().precheck()
+
 
 @dataclass
 class BoxDownloaderConfig(FsspecDownloaderConfig):
@@ -106,6 +110,10 @@ class BoxUploader(FsspecUploader):
     @requires_dependencies(["boxfs"], extras="box")
     def __post_init__(self):
         super().__post_init__()
+
+    @requires_dependencies(["boxfs"], extras="box")
+    def precheck(self) -> None:
+        super().precheck()
 
     @requires_dependencies(["boxfs"], extras="box")
     def run(self, contents: list[UploadContent], **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/dropbox.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/dropbox.py
@@ -58,6 +58,10 @@ class DropboxIndexer(FsspecIndexer):
             self.index_config.path_without_protocol = "/" + self.index_config.path_without_protocol
 
     @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
+    def precheck(self) -> None:
+        super().precheck()
+
+    @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
         return super().run(**kwargs)
 
@@ -105,6 +109,10 @@ class DropboxUploader(FsspecUploader):
     @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
     def __post_init__(self):
         super().__post_init__()
+
+    @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
+    def precheck(self) -> None:
+        super().precheck()
 
     @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
     def run(self, contents: list[UploadContent], **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -311,7 +311,8 @@ class FsspecUploader(Uploader):
             fs = get_filesystem_class(self.upload_config.protocol)(
                 **self.connection_config.get_access_config(),
             )
-            fs.ls(path=self.upload_config.path_without_protocol, detail=False)
+            root_dir = self.upload_config.path_without_protocol.split("/")[0]
+            fs.ls(path=root_dir, detail=False)
         except Exception as e:
             logger.error(f"failed to validate connection: {e}", exc_info=True)
             raise DestinationConnectionError(f"failed to validate connection: {e}")

--- a/unstructured_ingest/v2/processes/connectors/fsspec/gcs.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/gcs.py
@@ -80,6 +80,10 @@ class GcsIndexer(FsspecIndexer):
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
         return super().run(**kwargs)
 
+    @requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
+    def precheck(self) -> None:
+        super().precheck()
+
 
 @dataclass
 class GcsDownloaderConfig(FsspecDownloaderConfig):
@@ -116,6 +120,10 @@ class GcsUploader(FsspecUploader):
     @requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
     def __post_init__(self):
         super().__post_init__()
+
+    @requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
+    def precheck(self) -> None:
+        super().precheck()
 
     @requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
     def run(self, contents: list[UploadContent], **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
@@ -111,6 +111,10 @@ class S3Indexer(FsspecIndexer):
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
         return super().run(**kwargs)
 
+    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
+    def precheck(self) -> None:
+        super().precheck()
+
 
 @dataclass
 class S3DownloaderConfig(FsspecDownloaderConfig):
@@ -143,6 +147,10 @@ class S3Uploader(FsspecUploader):
     connector_type: str = CONNECTOR_TYPE
     connection_config: S3ConnectionConfig
     upload_config: S3UploaderConfig = field(default=None)
+
+    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
+    def precheck(self) -> None:
+        super().precheck()
 
     @requires_dependencies(["s3fs", "fsspec"], extras="s3")
     def __post_init__(self):

--- a/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
@@ -91,6 +91,10 @@ class SftpIndexer(FsspecIndexer):
             file.identifier = new_identifier
             yield file
 
+    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
+    def precheck(self) -> None:
+        super().precheck()
+
 
 @dataclass
 class SftpDownloaderConfig(FsspecDownloaderConfig):
@@ -141,6 +145,10 @@ class SftpUploader(FsspecUploader):
     @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
     def __post_init__(self):
         super().__post_init__()
+
+    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
+    def precheck(self) -> None:
+        super().precheck()
 
     @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
     def run(self, contents: list[UploadContent], **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/opensearch.py
+++ b/unstructured_ingest/v2/processes/connectors/opensearch.py
@@ -101,8 +101,14 @@ class OpenSearchConnectionConfig(ConnectionConfig):
 
 
 @dataclass
+class OpensearchIndexerConfig(ElasticsearchIndexerConfig):
+    pass
+
+
+@dataclass
 class OpenSearchIndexer(ElasticsearchIndexer):
     connection_config: OpenSearchConnectionConfig
+    index_config: OpensearchIndexerConfig
     client: "OpenSearch" = field(init=False)
 
     @requires_dependencies(["opensearchpy"], extras="opensearch")
@@ -113,8 +119,14 @@ class OpenSearchIndexer(ElasticsearchIndexer):
 
 
 @dataclass
+class OpensearchDownloaderConfig(ElasticsearchDownloaderConfig):
+    pass
+
+
+@dataclass
 class OpenSearchDownloader(ElasticsearchDownloader):
     connection_config: OpenSearchConnectionConfig
+    download_config: OpensearchDownloaderConfig
     connector_type: str = CONNECTOR_TYPE
 
     @requires_dependencies(["opensearchpy"], extras="opensearch")
@@ -126,8 +138,19 @@ class OpenSearchDownloader(ElasticsearchDownloader):
 
 
 @dataclass
+class OpensearchUploaderConfig(ElasticsearchUploaderConfig):
+    pass
+
+
+@dataclass
+class OpensearchUploaderConfig(ElasticsearchUploaderConfig):
+    pass
+
+
+@dataclass
 class OpenSearchUploader(ElasticsearchUploader):
     connection_config: OpenSearchConnectionConfig
+    upload_config: OpensearchUploaderConfig
     connector_type: str = CONNECTOR_TYPE
 
     @requires_dependencies(["opensearchpy"], extras="opensearch")
@@ -137,19 +160,29 @@ class OpenSearchUploader(ElasticsearchUploader):
         return parallel_bulk
 
 
+@dataclass
+class OpensearchUploadStagerConfig(ElasticsearchUploadStagerConfig):
+    pass
+
+
+@dataclass
+class OpensearchUploadStager(ElasticsearchUploadStager):
+    upload_stager_config: OpensearchUploadStagerConfig
+
+
 opensearch_source_entry = SourceRegistryEntry(
     connection_config=OpenSearchConnectionConfig,
     indexer=OpenSearchIndexer,
-    indexer_config=ElasticsearchIndexerConfig,
+    indexer_config=OpensearchIndexerConfig,
     downloader=OpenSearchDownloader,
-    downloader_config=ElasticsearchDownloaderConfig,
+    downloader_config=OpensearchDownloaderConfig,
 )
 
 
 opensearch_destination_entry = DestinationRegistryEntry(
     connection_config=OpenSearchConnectionConfig,
-    upload_stager_config=ElasticsearchUploadStagerConfig,
-    upload_stager=ElasticsearchUploadStager,
-    uploader_config=ElasticsearchUploaderConfig,
+    upload_stager_config=OpensearchUploadStagerConfig,
+    upload_stager=OpensearchUploadStager,
+    uploader_config=OpensearchUploaderConfig,
     uploader=OpenSearchUploader,
 )

--- a/unstructured_ingest/v2/processes/connectors/opensearch.py
+++ b/unstructured_ingest/v2/processes/connectors/opensearch.py
@@ -143,11 +143,6 @@ class OpensearchUploaderConfig(ElasticsearchUploaderConfig):
 
 
 @dataclass
-class OpensearchUploaderConfig(ElasticsearchUploaderConfig):
-    pass
-
-
-@dataclass
 class OpenSearchUploader(ElasticsearchUploader):
     connection_config: OpenSearchConnectionConfig
     upload_config: OpensearchUploaderConfig


### PR DESCRIPTION
### Description
To avoid confusion, define explicit config classes for the opensearch connectors rather than reusing the elasticsearch ones when creating the registry entries.

Additional update:
* Add missing fsspec destination precheck