### PR TITLE
bugfix/Fix local indexer to not include directories

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,7 +87,7 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         OCTOAI_API_KEY: ${{ secrets.OCTOAI_API_KEY }}
         PINECONE_API_KEY: ${{secrets.PINECONE_API_KEY}}
-        ASTRA_DB_APPLICATION_TOKEN: ${{secrets.ASTRA_DB_TOKEN}}
+        ASTRA_DB_APPLICATION_TOKEN: ${{secrets.ASTRA_DB_APPLICATION_TOKEN}}
         ASTRA_DB_API_ENDPOINT: ${{secrets.ASTRA_DB_ENDPOINT}}
         TABLE_OCR: "tesseract"
         OCR_AGENT: "unstructured.partition.utils.ocr_models.tesseract_ocr.OCRAgentTesseract"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.5-dev1
+## 0.0.5-dev2
 
 ### Enhancements
 
@@ -7,6 +7,7 @@
 ### Fixes
 
 * **AstraDB connector configs** Configs had dataclass annotation removed since they're now pydantic data models. 
+* **Local indexer recursive behavior** Local indexer was indexing directories as well as files. This was filtered out.
 
 ## 0.0.4
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.5-dev1"  # pragma: no cover
+__version__ = "0.0.5-dev2"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/local.py
+++ b/unstructured_ingest/v2/processes/connectors/local.py
@@ -71,9 +71,12 @@ class LocalIndexer(Indexer):
         input_path = self.index_config.path
         if input_path.is_file():
             return [Path(s) for s in glob.glob(f"{self.index_config.path}")]
+        files = []
         if self.index_config.recursive:
-            return list(input_path.rglob("*"))
-        return list(input_path.glob("*"))
+            files.extend(list(input_path.rglob("*")))
+        else:
+            files.extend(list(input_path.glob("*")))
+        return [f for f in files if f.is_file()]
 
     def get_file_metadata(self, path: Path) -> FileDataSourceMetadata:
         stats = path.stat()


### PR DESCRIPTION
### Description
The local indexer was returning pointers to directories along with the files in them when the recursive flag was being passed in. This added a filter to that list to make sure to only return file content. 