### PR TITLE
fix: Update calls to unstructured-client for forward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.6
+
+### Enhancements
+
+### Fixes
+
+* **unstructured-client compatibility fix** Update the calls to `unstructured_client.general.partion` to avoid a breaking change in the newest version.
+
 ## 0.0.5
 
 ### Enhancements

--- a/requirements/remote/client.in
+++ b/requirements/remote/client.in
@@ -1,3 +1,3 @@
 -r ../common/base.in
 
-unstructured-client
+unstructured-client >= 0.23.0

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.5"  # pragma: no cover
+__version__ = "0.0.6"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/chunker.py
+++ b/unstructured_ingest/v2/processes/chunker.py
@@ -112,8 +112,8 @@ class Chunker(BaseProcess, ABC):
     @requires_dependencies(dependencies=["unstructured_client"], extras="remote")
     async def run_async(self, elements_filepath: Path, **kwargs: Any) -> list[dict]:
         from unstructured_client import UnstructuredClient
-        from unstructured_client.models.shared import Files, PartitionParameters
         from unstructured_client.models.operations import PartitionRequest
+        from unstructured_client.models.shared import Files, PartitionParameters
 
         client = UnstructuredClient(
             api_key_auth=self.config.chunk_api_key.get_secret_value(),

--- a/unstructured_ingest/v2/processes/chunker.py
+++ b/unstructured_ingest/v2/processes/chunker.py
@@ -113,6 +113,7 @@ class Chunker(BaseProcess, ABC):
     async def run_async(self, elements_filepath: Path, **kwargs: Any) -> list[dict]:
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.shared import Files, PartitionParameters
+        from unstructured_client.models.operations import PartitionRequest
 
         client = UnstructuredClient(
             api_key_auth=self.config.chunk_api_key.get_secret_value(),
@@ -137,7 +138,8 @@ class Chunker(BaseProcess, ABC):
             )
             filtered_partition_request["files"] = files
             partition_params = PartitionParameters(**filtered_partition_request)
-        resp = client.general.partition(partition_params)
+            partition_request_obj = PartitionRequest(partition_params)
+        resp = client.general.partition(partition_request_obj)
         elements = resp.elements or []
         elements = assign_and_map_hash_ids(elements=elements)
         return elements

--- a/unstructured_ingest/v2/processes/partitioner.py
+++ b/unstructured_ingest/v2/processes/partitioner.py
@@ -13,8 +13,8 @@ from unstructured_ingest.v2.logger import logger
 
 if TYPE_CHECKING:
     from unstructured_client import UnstructuredClient
-    from unstructured_client.models.shared import PartitionParameters
     from unstructured_client.models.operations import PartitionRequest
+    from unstructured_client.models.shared import PartitionParameters
 
 
 class PartitionerConfig(BaseModel):

--- a/unstructured_ingest/v2/processes/partitioner.py
+++ b/unstructured_ingest/v2/processes/partitioner.py
@@ -190,6 +190,7 @@ class Partitioner(BaseProcess, ABC):
         self, filename: Path, metadata: Optional[dict] = None, **kwargs
     ) -> list[dict]:
         from unstructured_client import UnstructuredClient
+        from unstructured_client.models.operations import PartitionRequest
 
         logger.debug(f"partitioning file {filename} with metadata: {metadata}")
         client = UnstructuredClient(

--- a/unstructured_ingest/v2/processes/partitioner.py
+++ b/unstructured_ingest/v2/processes/partitioner.py
@@ -14,6 +14,7 @@ from unstructured_ingest.v2.logger import logger
 if TYPE_CHECKING:
     from unstructured_client import UnstructuredClient
     from unstructured_client.models.shared import PartitionParameters
+    from unstructured_client.models.operations import PartitionRequest
 
 
 class PartitionerConfig(BaseModel):
@@ -153,7 +154,7 @@ class Partitioner(BaseProcess, ABC):
         )
         return self.postprocess(elements=elements_to_dicts(elements))
 
-    async def call_api(self, client: "UnstructuredClient", request: "PartitionParameters"):
+    async def call_api(self, client: "UnstructuredClient", request: "PartitionRequest"):
         # TODO when client supports async, run without using run_in_executor
         # isolate the IO heavy call
         loop = asyncio.get_event_loop()
@@ -196,7 +197,8 @@ class Partitioner(BaseProcess, ABC):
             api_key_auth=self.config.api_key.get_secret_value(),
         )
         partition_params = self.create_partition_parameters(filename=filename)
-        resp = await self.call_api(client=client, request=partition_params)
+        partition_request = PartitionRequest(partition_params)
+        resp = await self.call_api(client=client, request=partition_request)
         elements = resp.elements or []
         # Append the data source metadata the auto partition does for you
         for element in elements:


### PR DESCRIPTION
Calls to the unstructured-client before 0.22.0 looked like this:
```
req = shared.PartitionParameters(
    files=...,
    strategy=...,
)

res = client.general.partition(request=req)
```

Since then, the expected usage has changed with a new object:
```
req = operations.PartitionRequest(
    partition_parameters=shared.PartitionParameters(
        files=...,
        strategy=...,
    ),
)

res = client.general.partition(request=req)
```

The old call that does not use PartitionRequest is no longer supported in the upcoming 0.26.0.

# Testing
I don't have a env set up to run the ingest code so I need someone to verify this for me. All your existing ingest code should still be able to call the API.