### PR TITLE
feat/support parent mutliprocessing fan out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.0.7-dev0
+## 0.0.7-dev1
+
+### Enhancements
+
+* **support sharing parent multiprocessing for uploaders** If an uploader needs to fan out it's process using multiprocessing, support that using the parent pipeline approach rather than handling it explicitly by the connector logic.  
 
 ## 0.0.6
 

--- a/test_e2e/dest/pinecone.sh
+++ b/test_e2e/dest/pinecone.sh
@@ -101,8 +101,7 @@ PYTHONPATH=. ./unstructured_ingest/main.py \
   pinecone \
   --api-key "$PINECONE_API_KEY" \
   --index-name "$PINECONE_INDEX" \
-  --batch-size 80 \
-  --num-processes "$writer_processes"
+  --batch-size 80
 
 # It can take some time for the index to catch up with the content that was written, this check between 10s sleeps
 # to give it that time process the writes. Will timeout after checking for a minute.

--- a/test_e2e/dest/pinecone.sh
+++ b/test_e2e/dest/pinecone.sh
@@ -9,7 +9,6 @@ OUTPUT_FOLDER_NAME=s3-pinecone-dest
 OUTPUT_DIR=$SCRIPT_DIR/structured-output/$OUTPUT_FOLDER_NAME
 WORK_DIR=$SCRIPT_DIR/workdir/$OUTPUT_FOLDER_NAME
 max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
-writer_processes=$(((max_processes - 1) > 1 ? (max_processes - 1) : 2))
 
 if [ -z "$PINECONE_API_KEY" ]; then
   echo "Skipping Pinecone ingest test because PINECONE_API_KEY env var is not set."

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.7-dev0"  # pragma: no cover
+__version__ = "0.0.7-dev1"  # pragma: no cover

--- a/unstructured_ingest/v2/interfaces/uploader.py
+++ b/unstructured_ingest/v2/interfaces/uploader.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeVar
@@ -31,9 +31,14 @@ class Uploader(BaseProcess, BaseConnector, ABC):
     def is_async(self) -> bool:
         return False
 
-    @abstractmethod
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        pass
+    def is_batch(self) -> bool:
+        return False
+
+    def run_batch(self, contents: list[UploadContent], **kwargs: Any) -> None:
+        raise NotImplementedError()
+
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        raise NotImplementedError()
 
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
         return self.run(contents=[UploadContent(path=path, file_data=file_data)], **kwargs)

--- a/unstructured_ingest/v2/pipeline/interfaces.py
+++ b/unstructured_ingest/v2/pipeline/interfaces.py
@@ -12,7 +12,7 @@ from typing import Any, Awaitable, Callable, Optional, TypeVar
 from tqdm import tqdm
 from tqdm.asyncio import tqdm as tqdm_asyncio
 
-from unstructured_ingest.v2.interfaces import BaseProcess, ProcessorConfig
+from unstructured_ingest.v2.interfaces import BaseProcess, ProcessorConfig, Uploader
 from unstructured_ingest.v2.logger import logger, make_default_logger
 
 BaseProcessT = TypeVar("BaseProcessT", bound=BaseProcess)
@@ -131,6 +131,8 @@ class PipelineStep(ABC):
         if self.context.async_supported and self.process.is_async():
             return self.process_async(iterable=iterable)
         if self.context.mp_supported:
+            if isinstance(self.process, Uploader) and self.process.is_batch():
+                return self.run_batch(contents=iterable)
             return self.process_multiprocess(iterable=iterable)
         return self.process_serially(iterable=iterable)
 

--- a/unstructured_ingest/v2/pipeline/interfaces.py
+++ b/unstructured_ingest/v2/pipeline/interfaces.py
@@ -171,11 +171,12 @@ class PipelineStep(ABC):
 
 @dataclass
 class BatchPipelineStep(PipelineStep, ABC):
+    process: Uploader
+
     @timed
     def __call__(self, iterable: Optional[iterable_input] = None) -> Any:
-        if self.context.mp_supported:
-            if isinstance(self.process, Uploader) and self.process.is_batch():
-                return self.run_batch(contents=iterable)
+        if self.context.mp_supported and self.process.is_batch():
+            return self.run_batch(contents=iterable)
         super().__call__(iterable=iterable)
 
     @abstractmethod

--- a/unstructured_ingest/v2/pipeline/pipeline.py
+++ b/unstructured_ingest/v2/pipeline/pipeline.py
@@ -4,7 +4,7 @@ from dataclasses import InitVar, dataclass, field
 from time import time
 from typing import Any, Optional, Union
 
-from unstructured_ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.interfaces import ProcessorConfig, Uploader
 from unstructured_ingest.v2.logger import logger, make_default_logger
 from unstructured_ingest.v2.pipeline.steps.chunk import Chunker, ChunkStep
 from unstructured_ingest.v2.pipeline.steps.download import DownloaderT, DownloadStep
@@ -14,7 +14,7 @@ from unstructured_ingest.v2.pipeline.steps.index import IndexerT, IndexStep
 from unstructured_ingest.v2.pipeline.steps.partition import Partitioner, PartitionStep
 from unstructured_ingest.v2.pipeline.steps.stage import UploadStager, UploadStageStep
 from unstructured_ingest.v2.pipeline.steps.uncompress import Uncompressor, UncompressStep
-from unstructured_ingest.v2.pipeline.steps.upload import Uploader, UploadStep
+from unstructured_ingest.v2.pipeline.steps.upload import UploadStep
 from unstructured_ingest.v2.processes.chunker import ChunkerConfig
 from unstructured_ingest.v2.processes.connector_registry import (
     ConnectionConfig,

--- a/unstructured_ingest/v2/pipeline/steps/upload.py
+++ b/unstructured_ingest/v2/pipeline/steps/upload.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Callable, Optional, TypedDict
 
 from unstructured_ingest.v2.interfaces import FileData
-from unstructured_ingest.v2.interfaces.uploader import UploadContent, Uploader
+from unstructured_ingest.v2.interfaces.uploader import UploadContent
 from unstructured_ingest.v2.logger import logger
 from unstructured_ingest.v2.pipeline.interfaces import BatchPipelineStep
 
@@ -18,7 +18,6 @@ class UploadStepContent(TypedDict):
 
 @dataclass
 class UploadStep(BatchPipelineStep):
-    process: Uploader
     identifier: str = STEP_ID
 
     def __str__(self):

--- a/unstructured_ingest/v2/pipeline/steps/upload.py
+++ b/unstructured_ingest/v2/pipeline/steps/upload.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, TypedDict
 from unstructured_ingest.v2.interfaces import FileData
 from unstructured_ingest.v2.interfaces.uploader import UploadContent, Uploader
 from unstructured_ingest.v2.logger import logger
-from unstructured_ingest.v2.pipeline.interfaces import PipelineStep, iterable_input, timed
+from unstructured_ingest.v2.pipeline.interfaces import PipelineStep
 
 STEP_ID = "upload"
 
@@ -34,25 +34,12 @@ class UploadStep(PipelineStep):
             f"connection configs: {connection_config}"
         )
 
-    def process_whole(self, iterable: iterable_input):
-        self.run(contents=iterable)
-
-    @timed
-    def __call__(self, iterable: iterable_input):
-        logger.info(
-            f"Calling {self.__class__.__name__} " f"with {len(iterable)} docs",  # type: ignore
-        )
-        if self.process.is_async():
-            self.process_async(iterable=iterable)
-        else:
-            self.process_whole(iterable=iterable)
-
-    def _run(self, fn: Callable, contents: list[UploadStepContent]):
+    def _run_batch(self, contents: list[UploadStepContent]) -> None:
         upload_contents = [
             UploadContent(path=Path(c["path"]), file_data=FileData.from_file(c["file_data_path"]))
             for c in contents
         ]
-        fn(contents=upload_contents)
+        self.process.run_batch(contents=upload_contents)
 
     async def _run_async(self, path: str, file_data_path: str, fn: Optional[Callable] = None):
         fn = fn or self.process.run_async

--- a/unstructured_ingest/v2/pipeline/steps/upload.py
+++ b/unstructured_ingest/v2/pipeline/steps/upload.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, TypedDict
 from unstructured_ingest.v2.interfaces import FileData
 from unstructured_ingest.v2.interfaces.uploader import UploadContent, Uploader
 from unstructured_ingest.v2.logger import logger
-from unstructured_ingest.v2.pipeline.interfaces import PipelineStep
+from unstructured_ingest.v2.pipeline.interfaces import BatchPipelineStep
 
 STEP_ID = "upload"
 
@@ -17,7 +17,7 @@ class UploadStepContent(TypedDict):
 
 
 @dataclass
-class UploadStep(PipelineStep):
+class UploadStep(BatchPipelineStep):
     process: Uploader
     identifier: str = STEP_ID
 

--- a/unstructured_ingest/v2/processes/connectors/astradb.py
+++ b/unstructured_ingest/v2/processes/connectors/astradb.py
@@ -14,7 +14,6 @@ from unstructured_ingest.v2.interfaces import (
     AccessConfig,
     ConnectionConfig,
     FileData,
-    UploadContent,
     Uploader,
     UploaderConfig,
     UploadStager,
@@ -139,13 +138,9 @@ class AstraDBUploader(Uploader):
         )
         return astra_db_collection
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        elements_dict = []
-        for content in contents:
-            with open(content.path) as elements_file:
-                elements = json.load(elements_file)
-                elements_dict.extend(elements)
-
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        with path.open("r") as file:
+            elements_dict = json.load(file)
         logger.info(
             f"writing {len(elements_dict)} objects to destination "
             f"collection {self.upload_config.collection_name}"

--- a/unstructured_ingest/v2/processes/connectors/azure_cognitive_search.py
+++ b/unstructured_ingest/v2/processes/connectors/azure_cognitive_search.py
@@ -12,7 +12,7 @@ from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.v2.interfaces import (
     AccessConfig,
     ConnectionConfig,
-    UploadContent,
+    FileData,
     Uploader,
     UploaderConfig,
     UploadStager,
@@ -192,14 +192,9 @@ class AzureCognitiveSearchUploader(Uploader):
     def write_dict_wrapper(self, elements_dict):
         return self.write_dict(elements_dict=elements_dict)
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-
-        elements_dict = []
-        for content in contents:
-            with open(content.path) as elements_file:
-                elements = json.load(elements_file)
-                elements_dict.extend(elements)
-
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        with path.open("r") as file:
+            elements_dict = json.load(file)
         logger.info(
             f"writing document batches to destination"
             f" endpoint at {str(self.connection_config.endpoint)}"

--- a/unstructured_ingest/v2/processes/connectors/chroma.py
+++ b/unstructured_ingest/v2/processes/connectors/chroma.py
@@ -15,7 +15,6 @@ from unstructured_ingest.v2.interfaces import (
     AccessConfig,
     ConnectionConfig,
     FileData,
-    UploadContent,
     Uploader,
     UploaderConfig,
     UploadStager,
@@ -186,13 +185,9 @@ class ChromaUploader(Uploader):
         )
         return chroma_dict
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-
-        elements_dict = []
-        for content in contents:
-            with open(content.path) as elements_file:
-                elements = json.load(elements_file)
-                elements_dict.extend(elements)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        with path.open("r") as file:
+            elements_dict = json.load(file)
 
         logger.info(
             f"writing {len(elements_dict)} objects to destination "

--- a/unstructured_ingest/v2/processes/connectors/databricks_volumes.py
+++ b/unstructured_ingest/v2/processes/connectors/databricks_volumes.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field, Secret
@@ -9,7 +10,7 @@ from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.v2.interfaces import (
     AccessConfig,
     ConnectionConfig,
-    UploadContent,
+    FileData,
     Uploader,
     UploaderConfig,
 )
@@ -142,15 +143,13 @@ class DatabricksVolumesUploader(Uploader):
             logger.error(f"failed to validate connection: {e}", exc_info=True)
             raise DestinationConnectionError(f"failed to validate connection: {e}")
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        for content in contents:
-            with open(content.path, "rb") as elements_file:
-                output_path = os.path.join(self.upload_config.path, content.path.name)
-                self.get_client().files.upload(
-                    file_path=output_path,
-                    contents=elements_file,
-                    overwrite=self.upload_config.overwrite,
-                )
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        output_path = os.path.join(self.upload_config.path, path.name)
+        self.get_client().files.upload(
+            file_path=output_path,
+            contents=path,
+            overwrite=self.upload_config.overwrite,
+        )
 
 
 databricks_volumes_destination_entry = DestinationRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/elasticsearch.py
+++ b/unstructured_ingest/v2/processes/connectors/elasticsearch.py
@@ -26,7 +26,6 @@ from unstructured_ingest.v2.interfaces import (
     FileDataSourceMetadata,
     Indexer,
     IndexerConfig,
-    UploadContent,
     Uploader,
     UploaderConfig,
     UploadStager,
@@ -384,14 +383,12 @@ class ElasticsearchUploader(Uploader):
 
         return parallel_bulk
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
         parallel_bulk = self.load_parallel_bulk()
-        elements_dict = []
-        for content in contents:
-            with open(content.path) as elements_file:
-                elements = json.load(elements_file)
-                elements_dict.extend(elements)
+        with path.open("r") as file:
+            elements_dict = json.load(file)
         upload_destination = self.connection_config.hosts or self.connection_config.cloud_id
+
         logger.info(
             f"writing {len(elements_dict)} elements via document batches to destination "
             f"index named {self.upload_config.index_name} at {upload_destination} with "

--- a/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
@@ -7,7 +7,7 @@ from typing import Any, Generator, Optional
 from pydantic import Field, Secret
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
-from unstructured_ingest.v2.interfaces import DownloadResponse, FileData, UploadContent
+from unstructured_ingest.v2.interfaces import DownloadResponse, FileData
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -152,8 +152,8 @@ class AzureUploader(FsspecUploader):
         super().precheck()
 
     @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        return super().run(contents=contents, **kwargs)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        return super().run(path=path, file_data=file_data, **kwargs)
 
     @requires_dependencies(["adlfs", "fsspec"], extras="azure")
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/box.py
@@ -7,7 +7,7 @@ from typing import Any, Generator, Optional
 from pydantic import Field, Secret
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
-from unstructured_ingest.v2.interfaces import DownloadResponse, FileData, UploadContent
+from unstructured_ingest.v2.interfaces import DownloadResponse, FileData
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -118,8 +118,8 @@ class BoxUploader(FsspecUploader):
         super().precheck()
 
     @requires_dependencies(["boxfs"], extras="box")
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        return super().run(contents=contents, **kwargs)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        return super().run(path=path, file_data=file_data, **kwargs)
 
     @requires_dependencies(["boxfs"], extras="box")
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/dropbox.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/dropbox.py
@@ -7,7 +7,7 @@ from typing import Any, Generator, Optional
 from pydantic import Field, Secret
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
-from unstructured_ingest.v2.interfaces import DownloadResponse, FileData, UploadContent
+from unstructured_ingest.v2.interfaces import DownloadResponse, FileData
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -114,8 +114,8 @@ class DropboxUploader(FsspecUploader):
         super().precheck()
 
     @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        return super().run(contents=contents, **kwargs)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        return super().run(path=path, file_data=file_data, **kwargs)
 
     @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -26,7 +26,6 @@ from unstructured_ingest.v2.interfaces import (
     Indexer,
     IndexerConfig,
     SourceIdentifiers,
-    UploadContent,
     Uploader,
     UploaderConfig,
 )
@@ -311,11 +310,7 @@ class FsspecUploader(Uploader):
         updated_upload_path = upload_path.parent / f"{upload_path.name}.json"
         return updated_upload_path
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        for content in contents:
-            self._run(path=content.path, file_data=content.file_data)
-
-    def _run(self, path: Path, file_data: FileData) -> None:
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
         path_str = str(path.resolve())
         upload_path = self.get_upload_path(file_data=file_data)
         if self.fs.exists(path=str(upload_path)) and not self.upload_config.overwrite:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -272,6 +272,9 @@ class FsspecUploader(Uploader):
     connector_type: str = CONNECTOR_TYPE
     upload_config: FsspecUploaderConfigT = field(default=None)
 
+    def is_async(self) -> bool:
+        return self.fs.async_impl
+
     @property
     def fs(self) -> "AbstractFileSystem":
         from fsspec import get_filesystem_class

--- a/unstructured_ingest/v2/processes/connectors/fsspec/gcs.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/gcs.py
@@ -8,7 +8,7 @@ from pydantic import Field, Secret
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.utils.string_and_date_utils import json_to_dict
-from unstructured_ingest.v2.interfaces import DownloadResponse, FileData, UploadContent
+from unstructured_ingest.v2.interfaces import DownloadResponse, FileData
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -151,8 +151,8 @@ class GcsUploader(FsspecUploader):
         super().precheck()
 
     @requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        return super().run(contents=contents, **kwargs)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        return super().run(path=path, file_data=file_data, **kwargs)
 
     @requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
@@ -12,7 +12,6 @@ from unstructured_ingest.v2.interfaces import (
     DownloadResponse,
     FileData,
     FileDataSourceMetadata,
-    UploadContent,
 )
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
@@ -171,8 +170,8 @@ class S3Uploader(FsspecUploader):
         super().__post_init__()
 
     @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        return super().run(contents=contents, **kwargs)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        return super().run(path=path, file_data=file_data, **kwargs)
 
     @requires_dependencies(["s3fs", "fsspec"], extras="s3")
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from pydantic import Field, Secret
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
-from unstructured_ingest.v2.interfaces import DownloadResponse, FileData, UploadContent
+from unstructured_ingest.v2.interfaces import DownloadResponse, FileData
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -142,8 +142,8 @@ class SftpUploader(FsspecUploader):
         super().precheck()
 
     @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        return super().run(contents=contents, **kwargs)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        return super().run(path=path, file_data=file_data, **kwargs)
 
     @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:

--- a/unstructured_ingest/v2/processes/connectors/kdbai.py
+++ b/unstructured_ingest/v2/processes/connectors/kdbai.py
@@ -15,7 +15,6 @@ from unstructured_ingest.v2.interfaces import (
     AccessConfig,
     ConnectionConfig,
     FileData,
-    UploadContent,
     Uploader,
     UploaderConfig,
     UploadStager,
@@ -152,13 +151,13 @@ class KdbaiUploader(Uploader):
         df = pd.DataFrame(data=all_records)
         self.process_dataframe(df=df)
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        csv_paths = [c.path for c in contents if c.path.suffix == ".csv"]
-        if csv_paths:
-            self.process_csv(csv_paths=csv_paths)
-        json_paths = [c.path for c in contents if c.path.suffix == ".json"]
-        if json_paths:
-            self.process_json(json_paths=json_paths)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        if path.suffix == ".csv":
+            self.process_csv(csv_paths=[path])
+        elif path.suffix == ".json":
+            self.process_json(json_paths=[path])
+        else:
+            raise ValueError(f"Unsupported file type, must be json or csv file: {path}")
 
 
 kdbai_destination_entry = DestinationRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/milvus.py
+++ b/unstructured_ingest/v2/processes/connectors/milvus.py
@@ -1,5 +1,4 @@
 import json
-import multiprocessing as mp
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
@@ -135,9 +134,6 @@ class MilvusUploadStager(UploadStager):
 
 class MilvusUploaderConfig(UploaderConfig):
     collection_name: str = Field(description="Milvus collections to write to")
-    num_processes: int = Field(
-        default=4, description="number of processes to use when writing to support parallel writes"
-    )
 
 
 @dataclass
@@ -183,16 +179,8 @@ class MilvusUploader(Uploader):
             data: list[dict] = json.load(file)
         self.insert_results(data=data)
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        if self.upload_config.num_processes == 1:
-            for content in contents:
-                self.upload(content=content)
-
-        else:
-            with mp.Pool(
-                processes=self.upload_config.num_processes,
-            ) as pool:
-                pool.map(self.upload, contents)
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        self.upload(content=UploadContent(path=path, file_data=file_data))
 
 
 milvus_destination_entry = DestinationRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/mongodb.py
+++ b/unstructured_ingest/v2/processes/connectors/mongodb.py
@@ -13,7 +13,6 @@ from unstructured_ingest.v2.interfaces import (
     AccessConfig,
     ConnectionConfig,
     FileData,
-    UploadContent,
     Uploader,
     UploaderConfig,
     UploadStager,
@@ -119,13 +118,9 @@ class MongoDBUploader(Uploader):
                 server_api=ServerApi(version=SERVER_API_VERSION),
             )
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        elements_dict = []
-        for content in contents:
-            with open(content.path) as elements_file:
-                elements = json.load(elements_file)
-                elements_dict.extend(elements)
-
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        with path.open("r") as file:
+            elements_dict = json.load(file)
         logger.info(
             f"writing {len(elements_dict)} objects to destination "
             f"db, {self.connection_config.database}, "

--- a/unstructured_ingest/v2/processes/connectors/pinecone.py
+++ b/unstructured_ingest/v2/processes/connectors/pinecone.py
@@ -67,7 +67,6 @@ class PineconeUploadStagerConfig(UploadStagerConfig):
 
 class PineconeUploaderConfig(UploaderConfig):
     batch_size: int = Field(default=100, description="Number of records per batch")
-    num_processes: int = Field(default=4, description="Number of processes to use for uploading")
 
 
 @dataclass
@@ -149,7 +148,6 @@ class PineconeUploader(Uploader):
             f"writing document batches to destination"
             f" index named {self.connection_config.index_name}"
             f" with batch size {self.upload_config.batch_size}"
-            f" with {self.upload_config.num_processes} (number of) processes"
         )
 
         pinecone_batch_size = self.upload_config.batch_size

--- a/unstructured_ingest/v2/processes/connectors/pinecone.py
+++ b/unstructured_ingest/v2/processes/connectors/pinecone.py
@@ -1,5 +1,4 @@
 import json
-import multiprocessing as mp
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,7 +12,7 @@ from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.v2.interfaces import (
     AccessConfig,
     ConnectionConfig,
-    UploadContent,
+    FileData,
     Uploader,
     UploaderConfig,
     UploadStager,
@@ -143,14 +142,9 @@ class PineconeUploader(Uploader):
             raise DestinationConnectionError(f"http error: {api_error}") from api_error
         logger.debug(f"results: {response}")
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-
-        elements_dict = []
-        for content in contents:
-            with open(content.path) as elements_file:
-                elements = json.load(elements_file)
-                elements_dict.extend(elements)
-
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        with path.open("r") as file:
+            elements_dict = json.load(file)
         logger.info(
             f"writing document batches to destination"
             f" index named {self.connection_config.index_name}"
@@ -159,18 +153,8 @@ class PineconeUploader(Uploader):
         )
 
         pinecone_batch_size = self.upload_config.batch_size
-
-        if self.upload_config.num_processes == 1:
-            for batch in batch_generator(elements_dict, pinecone_batch_size):
-                self.upsert_batch(batch)  # noqa: E203
-
-        else:
-            with mp.Pool(
-                processes=self.upload_config.num_processes,
-            ) as pool:
-                pool.map(
-                    self.upsert_batch, list(batch_generator(elements_dict, pinecone_batch_size))
-                )
+        for pinecone_batch in batch_generator(elements_dict, pinecone_batch_size):
+            self.upsert_batch(batch=pinecone_batch)
 
 
 pinecone_destination_entry = DestinationRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/weaviate.py
+++ b/unstructured_ingest/v2/processes/connectors/weaviate.py
@@ -13,7 +13,6 @@ from unstructured_ingest.v2.interfaces import (
     AccessConfig,
     ConnectionConfig,
     FileData,
-    UploadContent,
     Uploader,
     UploaderConfig,
     UploadStager,
@@ -216,15 +215,9 @@ class WeaviateUploader(Uploader):
             )
         return None
 
-    def run(self, contents: list[UploadContent], **kwargs: Any) -> None:
-        # TODO update to use async support in weaviate client
-        #  once the version can be bumped to include it
-        elements_dict = []
-        for content in contents:
-            with open(content.path) as elements_file:
-                elements = json.load(elements_file)
-                elements_dict.extend(elements)
-
+    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
+        with path.open("r") as file:
+            elements_dict = json.load(file)
         logger.info(
             f"writing {len(elements_dict)} objects to destination "
             f"class {self.connection_config.class_name} "


### PR DESCRIPTION
### Description
Many uploaders at the moment still use a basic iterator or have to manually manipulate multiprocessing fan outs. This adds a new option to the uploader to run in batch or per file which allows the parent process to handle the multiprocessing fan out. 