### PR TITLE
feat/support annotation and string values for dict when mapping pydantic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.9-dev0
+
+### Enhancements
+
+**Support string inputs for dict type model fields** Use the `BeforeValidator` support from pydantic to map a string value to a dict if that's provided. 
+
 ## 0.0.8
 
 ### Enhancements

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.8"  # pragma: no cover
+__version__ = "0.0.9-dev0"  # pragma: no cover

--- a/unstructured_ingest/v2/cli/utils/model_conversion.py
+++ b/unstructured_ingest/v2/cli/utils/model_conversion.py
@@ -3,7 +3,18 @@ import datetime
 from collections import Counter
 from enum import EnumMeta
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, Type, TypedDict, Union, get_args, get_origin
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Literal,
+    Optional,
+    Type,
+    TypedDict,
+    Union,
+    get_args,
+    get_origin,
+)
 from uuid import UUID
 
 import click
@@ -102,6 +113,11 @@ def get_type_from_annotation(field_type: Any) -> click.ParamType:
     if field_origin is Union and len(field_args) == 2 and NoneType in field_args:
         field_type = next(field_arg for field_arg in field_args if field_arg is not None)
         return get_type_from_annotation(field_type=field_type)
+    if field_origin is Annotated:
+        field_origin = field_args[0]
+        field_metadata = field_args[1]
+        if isinstance(field_metadata, click.ParamType):
+            return field_metadata
     if field_origin is Secret and len(field_args) == 1:
         field_type = next(field_arg for field_arg in field_args if field_arg is not None)
         return get_type_from_annotation(field_type=field_type)


### PR DESCRIPTION
### Description
2 enhancements:
* Support annotated fields to allow the second value to be an explicit click `ParamType` mapping. 
* Support string values to be passed in when serializing a pydantic model by using `BeforeValidator` to convert it to a dict before populating. 