### PR TITLE
fix: Generalize tar decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Fixes
 
-**Fix uncompress logic** Use of the uncompress process wasn't being leveraged in the pipeline correctly. Updated to use the new loca download path for where the partitioned looks for the new file.  
 
 ## 0.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.10
+
+### Enhancements
+
+* "Fix tar extraction" - tar extraction function assumed archive was gzip compressed which isn't true for supported `.tar` archives. Updated to work for both compressed and uncompressed tar archives.
+
+### Fixes
+
+**Fix uncompress logic** Use of the uncompress process wasn't being leveraged in the pipeline correctly. Updated to use the new loca download path for where the partitioned looks for the new file.  
+
 ## 0.0.9
 
 ### Enhancements
@@ -10,7 +20,7 @@
 ### Fixes
 
 **Fix uncompress logic** Use of the uncompress process wasn't being leveraged in the pipeline correctly. Updated to use the new loca download path for where the partitioned looks for the new file.  
->>>>>>> d7a2cab (Add entry to changelog)
+
 
 ## 0.0.8
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.9"  # pragma: no cover
+__version__ = "0.0.10"  # pragma: no cover

--- a/unstructured_ingest/utils/compression.py
+++ b/unstructured_ingest/utils/compression.py
@@ -63,6 +63,7 @@ def uncompress_tar_file(tar_filename: str, path: Optional[str] = None) -> str:
 
     path = path if path else os.path.join(head, f"{tail}-tar-uncompressed")
     logger.info(f"extracting tar {tar_filename} -> {path}")
+    # NOTE: "r:*" mode opens both compressed (e.g ".tar.gz") and uncompressed ".tar" archives
     with tarfile.open(tar_filename, "r:*") as tfile:
         # NOTE(robinson: Mitigate against malicious content being extracted from the tar file.
         # This was added in Python 3.12

--- a/unstructured_ingest/utils/compression.py
+++ b/unstructured_ingest/utils/compression.py
@@ -63,7 +63,7 @@ def uncompress_tar_file(tar_filename: str, path: Optional[str] = None) -> str:
 
     path = path if path else os.path.join(head, f"{tail}-tar-uncompressed")
     logger.info(f"extracting tar {tar_filename} -> {path}")
-    with tarfile.open(tar_filename, "r:gz") as tfile:
+    with tarfile.open(tar_filename, "r:*") as tfile:
         # NOTE(robinson: Mitigate against malicious content being extracted from the tar file.
         # This was added in Python 3.12
         # Ref: https://docs.python.org/3/library/tarfile.html#extraction-filters


### PR DESCRIPTION
Function for extracting tar archives used `"r:gz"` mode to open them, assuming their gzip compressed which is not true for `.tar` files which are supposed to be supported.

This PR modifies the mode to more general `"r:*"` which will open both compressed and uncompressed tar files.

![image](https://github.com/user-attachments/assets/aac3cc0b-a6b3-49b8-b435-b7874e330534)
 