### PR TITLE
fix: Invalid `replace()` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.12
+
+### Enhancements
+
+### Fixes
+
+* **Fix invalid `replace()` calls in uncompress** - `replace()` calls meant to be on `str` versions of the path were instead called on `Path` causing errors with parameters.
+
 ## 0.0.11
 
 ### Enhancements

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.11"  # pragma: no cover
+__version__ = "0.0.12"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/uncompress.py
+++ b/unstructured_ingest/v2/processes/uncompress.py
@@ -43,11 +43,11 @@ class Uncompressor(BaseProcess, ABC):
             new_rel_download_path = str(f).replace(str(Path(local_filepath.parent)), "")[1:]
             new_file_data.source_identifiers = SourceIdentifiers(
                 filename=f.name,
-                fullpath=file_data.source_identifiers.fullpath.replace(
+                fullpath=str(file_data.source_identifiers.fullpath).replace(
                     file_data.source_identifiers.filename, new_rel_download_path
                 ),
                 rel_path=(
-                    file_data.source_identifiers.rel_path.replace(
+                    str(file_data.source_identifiers.rel_path).replace(
                         file_data.source_identifiers.filename, new_rel_download_path
                     )
                     if file_data.source_identifiers.rel_path


### PR DESCRIPTION
In `Uncompressor` when creating new instances of `FileData` calls to `replace()` are called as if were operating on `str` but are operating on `Path` instead which causes error.

This PR fixes the type `replace` is called on.