### PR TITLE
feat/refactor pinecone to upload async batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.14-dev0
+
+### Enhancements
+
+* **Support async batch uploads for pinecone connector**
+
 ## 0.0.13
 
 ### Fixes

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.13"  # pragma: no cover
+__version__ = "0.0.14-dev0"  # pragma: no cover


### PR DESCRIPTION
### Description
To leverage the [parallel support](https://docs.pinecone.io/guides/data/upsert-data#sending-upserts-in-parallel) of the pinecone SDK, the destination connector was slightly refactored to use this approach from their docs. 