### PR TITLE
bugfix/fix sharepoint permission config requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.0.15-dev0
+## 0.0.15-dev1
 
 ### Fixes
 
 * **Model serialization with nested models** Logic updated to properly handle serializing pydantic models that have nested configs with secret values.
+* **Sharepoint permission config requirement** The sharepoint connector was expecting the permission config, even though it should have been optional.
+
 ## 0.0.14
 
 ### Enhancements

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.15-dev0"  # pragma: no cover
+__version__ = "0.0.15-dev1"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/v2/processes/connectors/sharepoint.py
@@ -335,7 +335,8 @@ class SharepointIndexer(Indexer):
     @property
     def process_permissions(self) -> bool:
         return (
-            self.connection_config.permissions_config.permissions_tenant
+            self.connection_config.permissions_config is not None
+            and self.connection_config.permissions_config.permissions_tenant
             and self.connection_config.permissions_config.permissions_client_cred.get_secret_value()
             and self.connection_config.permissions_config.permissions_application_id
         )


### PR DESCRIPTION
### Description
The logic in `process_permissions` wasn't first checking if the permission config even exists before looking for the fields in it. This add a null check first. 