### PR TITLE
feat/validate read/write permissions in fsspec prechecks

### DIFF
--- a/.github/actions/base-cache/action.yml
+++ b/.github/actions/base-cache/action.yml
@@ -29,7 +29,9 @@ runs:
       shell: bash
       run: |
         python${{ inputs.python-version }} -m pip install --upgrade virtualenv
-        python${{ inputs.python-version }} -m venv .venv
+        if [ ! -d ".venv" ]; then
+          python${{ inputs.python-version }} -m venv .venv
+        fi
         source .venv/bin/activate
         if [ "${{ inputs.python-version == '3.12' }}" == "true" ]; then
           python -m ensurepip --upgrade

--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -28,7 +28,7 @@ jobs:
       # actions/checkout MUST come before auth
       - uses: 'actions/checkout@v4'
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Get full Python version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Build artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.18
+
+### Enhancements
+
+* **Better destination precheck for blob storage** Write an empty file to the destination location when running fsspec-based precheck
+
 ## 0.0.17
 
 ### Fixes

--- a/requirements/connectors/kdbai.txt
+++ b/requirements/connectors/kdbai.txt
@@ -10,7 +10,7 @@ charset-normalizer==3.3.2
     # via requests
 idna==3.10
     # via requests
-kdbai-client==1.2.4
+kdbai-client==1.3.0
     # via -r kdbai.in
 numpy==1.26.4
     # via

--- a/test_e2e/dest/s3_no_access.sh
+++ b/test_e2e/dest/s3_no_access.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+DEST_PATH=$(dirname "$(realpath "$0")")
+SCRIPT_DIR=$(dirname "$DEST_PATH")
+cd "$SCRIPT_DIR"/.. || exit 1
+OUTPUT_FOLDER_NAME=s3-dest
+OUTPUT_ROOT=${OUTPUT_ROOT:-$SCRIPT_DIR}
+WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
+max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
+DESTINATION_S3="s3://utic-ingest-test-fixtures/destination/no_access/$(uuidgen)/"
+CI=${CI:-"false"}
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR"/cleanup.sh
+function cleanup() {
+  cleanup_dir "$WORK_DIR"
+}
+trap cleanup EXIT
+
+set +e
+
+RUN_SCRIPT=${RUN_SCRIPT:-./unstructured_ingest/main.py}
+
+# Capture the stderr in a variable to check against
+{ err=$(PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
+  local \
+  --num-processes "$max_processes" \
+  --strategy fast \
+  --verbose \
+  --reprocess \
+  --input-path example-docs/pdf/fake-memo.pdf \
+  --work-dir "$WORK_DIR" \
+  s3 \
+  --remote-url "$DESTINATION_S3" 2>&1 >&3 3>&-); } 3>&1
+
+if [[ "$err" == *"Error: Precheck failed"* ]]; then
+  echo "passed"
+else
+  echo "error didn't occur with expected text: $err"
+  exit 1
+fi

--- a/test_e2e/src/s3_no_access.sh
+++ b/test_e2e/src/s3_no_access.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -e
+
+SRC_PATH=$(dirname "$(realpath "$0")")
+SCRIPT_DIR=$(dirname "$SRC_PATH")
+cd "$SCRIPT_DIR"/.. || exit 1
+OUTPUT_FOLDER_NAME=s3
+OUTPUT_ROOT=${OUTPUT_ROOT:-$SCRIPT_DIR}
+OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
+WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
+DOWNLOAD_DIR=$SCRIPT_DIR/download/$OUTPUT_FOLDER_NAME
+max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR"/cleanup.sh
+# shellcheck disable=SC2317
+function cleanup() {
+  cleanup_dir "$OUTPUT_DIR"
+  cleanup_dir "$WORK_DIR"
+}
+trap cleanup EXIT
+
+set +e
+
+RUN_SCRIPT=${RUN_SCRIPT:-./unstructured_ingest/main.py}
+
+# Capture the stderr in a variable to check against
+{ err=$(PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
+  s3 \
+  --num-processes "$max_processes" \
+  --download-dir "$DOWNLOAD_DIR" \
+  --reprocess \
+  --output-dir "$OUTPUT_DIR" \
+  --verbose \
+  --remote-url s3://utic-ingest-test-fixtures/destination/ \
+  --anonymous \
+  --work-dir "$WORK_DIR" 2>&1 >&3 3>&-); } 3>&1
+
+if [[ "$err" == *"Error: Precheck failed"* ]]; then
+  echo "passed"
+else
+  echo "error didn't occur with expected text: $err"
+  exit 1
+fi

--- a/test_e2e/test-dest.sh
+++ b/test_e2e/test-dest.sh
@@ -33,6 +33,7 @@ all_tests=(
   'pinecone.sh'
   'qdrant.sh'
   's3.sh'
+  's3_no_access.sh'
   'sharepoint-embed-cog-index.sh'
   'sqlite.sh'
   'vectara.sh'

--- a/test_e2e/test-src.sh
+++ b/test_e2e/test-src.sh
@@ -20,6 +20,7 @@ all_tests=(
   's3.sh'
   's3-minio.sh'
   's3-filter.sh'
+  's3_no_access.sh'
   'astradb.sh'
   'azure.sh'
   'biomed-api.sh'

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.17"  # pragma: no cover
+__version__ = "0.0.18"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -103,13 +103,11 @@ class FsspecIndexer(Indexer):
                 **self.connection_config.get_access_config(),
             )
             files = fs.ls(path=self.index_config.path_without_protocol, detail=True)
-            valid_files = [
-                x.get("name") for x in files if x.get("size") > 0 and x.get("type") == "file"
-            ]
+            valid_files = [x.get("name") for x in files if x.get("type") == "file"]
             if not valid_files:
                 return
             file_to_sample = valid_files[0]
-            logger.debug(f"Attempting to make HEAD request for file: {file_to_sample}")
+            logger.debug(f"attempting to make HEAD request for file: {file_to_sample}")
             self.fs.head(path=file_to_sample)
         except Exception as e:
             logger.error(f"failed to validate connection: {e}", exc_info=True)

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -102,7 +102,15 @@ class FsspecIndexer(Indexer):
             fs = get_filesystem_class(self.index_config.protocol)(
                 **self.connection_config.get_access_config(),
             )
-            fs.ls(path=self.index_config.path_without_protocol, detail=False)
+            files = fs.ls(path=self.index_config.path_without_protocol, detail=True)
+            valid_files = [
+                x.get("name") for x in files if x.get("size") > 0 and x.get("type") == "file"
+            ]
+            if not valid_files:
+                return
+            file_to_sample = valid_files[0]
+            logger.debug(f"Attempting to make HEAD request for file: {file_to_sample}")
+            self.fs.head(path=file_to_sample)
         except Exception as e:
             logger.error(f"failed to validate connection: {e}", exc_info=True)
             raise SourceConnectionError(f"failed to validate connection: {e}")

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -299,8 +299,8 @@ class FsspecUploader(Uploader):
             fs = get_filesystem_class(self.upload_config.protocol)(
                 **self.connection_config.get_access_config(),
             )
-            root_dir = self.upload_config.path_without_protocol.split("/")[0]
-            fs.ls(path=root_dir, detail=False)
+            upload_path = Path(self.upload_config.path_without_protocol) / "_empty"
+            fs.write_bytes(path=str(upload_path), value=b"")
         except Exception as e:
             logger.error(f"failed to validate connection: {e}", exc_info=True)
             raise DestinationConnectionError(f"failed to validate connection: {e}")


### PR DESCRIPTION
### Description
Check write access for fsspec destination connectors by writing a small blank file to the desired location. 

This was checked with a properly configured access run and without and got the expected error when access was permitted: 
```
unstructured_ingest.error.DestinationConnectionError: failed to validate connection: Access Denied
```

The indexer was also updated to make a head request on the first file it listed to check read permissions. 