### PR TITLE
feat/add validation that access config always wrapped in secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.0.26-dev2
+## 0.0.26-dev3
 
 ### Enhancements
 
 * **Move default API URL parameter value to serverless API**
+* **Add check that access config always wrapped in Secret**
 
 ## 0.0.25
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.26-dev2"  # pragma: no cover
+__version__ = "0.0.26-dev3"  # pragma: no cover

--- a/unstructured_ingest/v2/interfaces/connector.py
+++ b/unstructured_ingest/v2/interfaces/connector.py
@@ -2,7 +2,8 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
-from pydantic import BaseModel, Secret
+from pydantic import BaseModel, Secret, model_validator
+from pydantic.types import _SecretBase
 
 
 class AccessConfig(BaseModel):
@@ -20,6 +21,13 @@ class ConnectionConfig(BaseModel):
         if not self.access_config:
             return {}
         return self.access_config.get_secret_value().model_dump()
+
+    @model_validator(mode="after")
+    def check_access_config(self):
+        access_config = self.access_config
+        if not isinstance(access_config, _SecretBase):
+            raise ValueError("access_config must be an instance of SecretBase")
+        return self
 
 
 ConnectionConfigT = TypeVar("ConnectionConfigT", bound=ConnectionConfig)


### PR DESCRIPTION
### Description
Given that the comon approach to creating new connectors is implementing concrete classes for the access config and connection config, a check was added to make sure that the type on the access config is always wrapped by a pydantic `Secret`. 