### PR TITLE
bugfix/support optional access configs on connection configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.26-dev6
+## 0.0.26-dev7
 
 ### Enhancements
 
@@ -7,6 +7,7 @@
 * **Add togetherai embedder support**
 * **Refactor sqlite and postgres to be distinct connectors to support better input validation**
 * **Added MongoDB source V2 connector**
+* **Support optional access configs on connection configs**
 
 ### Fixes
 

--- a/test/unit/cli/test_utils_v2.py
+++ b/test/unit/cli/test_utils_v2.py
@@ -1,0 +1,58 @@
+import json
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel, Secret, ValidationError
+
+from unstructured_ingest.v2.cli.utils.click import extract_config
+
+
+def test_extract_config_optional_access_config():
+    class MyAccessConfig(BaseModel):
+        host: str
+
+    class MyModel(BaseModel):
+        v: int
+        access_config: Optional[Secret[MyAccessConfig]]
+
+    data = {
+        "v": 4,
+        "host": "localhost",
+    }
+    extracted_config = extract_config(data, MyModel)
+    assert json.loads(extracted_config.model_dump_json()) == {"v": 4, "access_config": "**********"}
+
+    data = {"v": 4}
+    extracted_config = extract_config(data, MyModel)
+    assert json.loads(extracted_config.model_dump_json()) == {"v": 4, "access_config": None}
+
+
+def test_extract_config():
+    class MyAccessConfig(BaseModel):
+        host: str
+
+    class MyModel(BaseModel):
+        v: int
+        access_config: Secret[MyAccessConfig]
+
+    data = {
+        "v": 4,
+        "host": "localhost",
+    }
+    extracted_config = extract_config(data, MyModel)
+    assert json.loads(extracted_config.model_dump_json()) == {"v": 4, "access_config": "**********"}
+
+
+def test_extract_config_missing_data():
+    class MyAccessConfig(BaseModel):
+        host: str
+
+    class MyModel(BaseModel):
+        v: int
+        access_config: Secret[MyAccessConfig]
+
+    data = {
+        "v": 4,
+    }
+    with pytest.raises(ValidationError):
+        extract_config(data, MyModel)

--- a/test/unit/cli/test_utils_v2.py
+++ b/test/unit/cli/test_utils_v2.py
@@ -2,16 +2,17 @@ import json
 from typing import Optional
 
 import pytest
-from pydantic import BaseModel, Secret, ValidationError
+from pydantic import Secret, ValidationError
 
 from unstructured_ingest.v2.cli.utils.click import extract_config
+from unstructured_ingest.v2.interfaces import AccessConfig, ConnectionConfig
 
 
 def test_extract_config_optional_access_config():
-    class MyAccessConfig(BaseModel):
+    class MyAccessConfig(AccessConfig):
         host: str
 
-    class MyModel(BaseModel):
+    class MyModel(ConnectionConfig):
         v: int
         access_config: Optional[Secret[MyAccessConfig]]
 
@@ -28,10 +29,10 @@ def test_extract_config_optional_access_config():
 
 
 def test_extract_config():
-    class MyAccessConfig(BaseModel):
+    class MyAccessConfig(AccessConfig):
         host: str
 
-    class MyModel(BaseModel):
+    class MyModel(ConnectionConfig):
         v: int
         access_config: Secret[MyAccessConfig]
 
@@ -44,10 +45,10 @@ def test_extract_config():
 
 
 def test_extract_config_missing_data():
-    class MyAccessConfig(BaseModel):
+    class MyAccessConfig(AccessConfig):
         host: str
 
-    class MyModel(BaseModel):
+    class MyModel(ConnectionConfig):
         v: int
         access_config: Secret[MyAccessConfig]
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.26-dev6"  # pragma: no cover
+__version__ = "0.0.26-dev7"  # pragma: no cover

--- a/unstructured_ingest/v2/interfaces/connector.py
+++ b/unstructured_ingest/v2/interfaces/connector.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Union
 
 from pydantic import BaseModel, Secret, model_validator
 from pydantic.types import _SecretBase
@@ -25,9 +25,21 @@ class ConnectionConfig(BaseModel):
     @model_validator(mode="after")
     def check_access_config(self):
         access_config = self.access_config
+        if self._is_access_config_optional() and access_config is None:
+            return self
         if not isinstance(access_config, _SecretBase):
             raise ValueError("access_config must be an instance of SecretBase")
         return self
+
+    def _is_access_config_optional(self) -> bool:
+        access_config_type = self.model_fields["access_config"].annotation
+        return (
+            hasattr(access_config_type, "__origin__")
+            and hasattr(access_config_type, "__args__")
+            and access_config_type.__origin__ is Union
+            and len(access_config_type.__args__) == 2
+            and type(None) in access_config_type.__args__
+        )
 
 
 ConnectionConfigT = TypeVar("ConnectionConfigT", bound=ConnectionConfig)


### PR DESCRIPTION
### Description
Having a connection config implemented with the access config typing set to `Optional` breaks the mapping from flat data. This updates that code to handle it. 