### PR TITLE
fix: recursively compare expected files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.2-dev0
+
+### Fixes
+
+* **Fix file comparison in E2E test** Compare all files recursively instead of only files in the root directory.
+
 ## 0.2.1
 
 ### Enhancements

--- a/test_e2e/check-diff-expected-output.py
+++ b/test_e2e/check-diff-expected-output.py
@@ -17,9 +17,7 @@ class CheckError(Exception):
 
 
 def get_files(dir_path: Path) -> list[str]:
-    return [
-        str(f).replace(str(dir_path), "").lstrip("/") for f in dir_path.iterdir() if f.is_file()
-    ]
+    return [str(f.relative_to(dir_path)) for f in dir_path.rglob("*") if f.is_file()]
 
 
 def check_files(expected_output_dir: Path, current_output_dir: Path):

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.1"  # pragma: no cover
+__version__ = "0.2.2-dev0"  # pragma: no cover


### PR DESCRIPTION
The comparison of directories of structured files produced by e2e test to the expected ones wasn't done recursively, resulting in some of the files not being compared at all.

This PR changes that behavior to recursively grab all of the files in expected/produced directories.