### PR TITLE
fix: AstraDB precheck suceeds on non-existant collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3-dev0
+
+### Fixes
+* **Make AstraDB precheck fail on non-existant collections**
+
 ## 0.2.2
 
 ### Enhancements

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.2"  # pragma: no cover
+__version__ = "0.2.3-dev0"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/astradb.py
+++ b/unstructured_ingest/v2/processes/connectors/astradb.py
@@ -347,7 +347,7 @@ class AstraDBUploader(Uploader):
                 connection_config=self.connection_config,
                 collection_name=self.upload_config.collection_name,
                 keyspace=self.upload_config.keyspace or self.upload_config.namespace,
-            )
+            ).options()
         except Exception as e:
             logger.error(f"Failed to validate connection {e}", exc_info=True)
             raise DestinationConnectionError(f"failed to validate connection: {e}")

--- a/unstructured_ingest/v2/processes/connectors/astradb.py
+++ b/unstructured_ingest/v2/processes/connectors/astradb.py
@@ -178,7 +178,7 @@ class AstraDBIndexer(Indexer):
 
     def precheck(self) -> None:
         try:
-            self.get_collection()
+            self.get_collection().options()
         except Exception as e:
             logger.error(f"Failed to validate connection {e}", exc_info=True)
             raise SourceConnectionError(f"failed to validate connection: {e}")


### PR DESCRIPTION
### Bug description
Precheck succeeds despite collection passed in parameters not existing

### Solution
Just getting collection with [get_collection()](https://docs.datastax.com/en/astra-api-docs/_attachments/python-client/astrapy/database.html#astrapy.database.AsyncDatabase.get_collection) doesn't validate existance

> an AsyncCollection instance, representing the desired collection (but without any form of validation).

so we run [options()](https://docs.datastax.com/en/astra-api-docs/_attachments/python-client/astrapy/collection.html#astrapy.collection.AsyncCollection.options) after getting a `Collection` which will fails if collection doesn't exist.