### PR TITLE
bugfix/Add logic to handle file being downloaded as directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.3-dev5
+## 0.2.3-dev6
 
 ### Enhancements
 
@@ -11,6 +11,7 @@
 
 * **Fix Delta Table destination precheck** Validate AWS Region in precheck. 
 * **Add missing batch label to FileData where applicable** 
+* **Handle fsspec download file into directory** When filenames have odd characters, files are downloaded into a directory. Code added to shift it around to match expected behavior.
 
 ## 0.2.2
 

--- a/test/integration/connectors/expected_results/s3-specialchar/directory_structure.json
+++ b/test/integration/connectors/expected_results/s3-specialchar/directory_structure.json
@@ -1,0 +1,5 @@
+{
+    "directory_structure": [
+      "Why_is_the_sky_blue?.txt"
+    ]
+  }

--- a/test/integration/connectors/expected_results/s3-specialchar/file_data/869bf15f-e840-51dc-a818-8d0b817817c9.json
+++ b/test/integration/connectors/expected_results/s3-specialchar/file_data/869bf15f-e840-51dc-a818-8d0b817817c9.json
@@ -1,0 +1,37 @@
+{
+    "identifier": "869bf15f-e840-51dc-a818-8d0b817817c9",
+    "connector_type": "s3",
+    "source_identifiers": {
+      "filename": "Why_is_the_sky_blue?.txt",
+      "fullpath": "utic-dev-tech-fixtures/special-characters/Why_is_the_sky_blue?.txt",
+      "rel_path": "Why_is_the_sky_blue?.txt"
+    },
+    "doc_type": "file",
+    "metadata": {
+      "url": "s3://utic-dev-tech-fixtures/special-characters/Why_is_the_sky_blue?.txt",
+      "version": "15344f385570b834e468ca05bc1cebd0",
+      "record_locator": {
+        "protocol": "s3",
+        "remote_file_path": "s3://utic-dev-tech-fixtures/special-characters/"
+      },
+      "date_created": "1731627148.0",
+      "date_modified": "1731627148.0",
+      "date_processed": "1730944104.616075",
+      "permissions_data": null,
+      "filesize_bytes": 14
+    },
+    "additional_metadata": {
+      "Key": "utic-dev-tech-fixtures/special-characters/Why_is_the_sky_blue?.txt",
+      "LastModified": "2024-11-14T23:32:28+00:00",
+      "ETag": "\"15344f385570b834e468ca05bc1cebd0\"",
+      "Size": 14,
+      "StorageClass": "STANDARD",
+      "type": "file",
+      "size": 14,
+      "name": "utic-dev-tech-fixtures/special-characters/Why_is_the_sky_blue?.txt",
+      "original_file_path": "utic-dev-tech-fixtures/special-characters/Why_is_the_sky_blue?.txt"
+    },
+    "reprocess": false,
+    "local_download_path": "/private/var/folders/n8/rps3wl195pj4p_0vyxqj5jrw0000gn/T/tmpa5ftry9m/recalibrating-risk-report.pdf",
+    "display_name": "utic-dev-tech-fixtures/special-characters/Why_is_the_sky_blue?.txt"
+  }

--- a/test/integration/connectors/test_s3.py
+++ b/test/integration/connectors/test_s3.py
@@ -73,6 +73,29 @@ async def test_s3_source(anon_connection_config: S3ConnectionConfig):
 
 @pytest.mark.asyncio
 @pytest.mark.tags(CONNECTOR_TYPE, SOURCE_TAG)
+async def test_s3_source_special_char(anon_connection_config: S3ConnectionConfig):
+    indexer_config = S3IndexerConfig(remote_url="s3://utic-dev-tech-fixtures/special-characters/")
+    with tempfile.TemporaryDirectory() as tempdir:
+        tempdir_path = Path(tempdir)
+        download_config = S3DownloaderConfig(download_dir=tempdir_path)
+        indexer = S3Indexer(connection_config=anon_connection_config, index_config=indexer_config)
+        downloader = S3Downloader(
+            connection_config=anon_connection_config, download_config=download_config
+        )
+        await source_connector_validation(
+            indexer=indexer,
+            downloader=downloader,
+            configs=ValidationConfigs(
+                test_id="s3-specialchar",
+                predownload_file_data_check=validate_predownload_file_data,
+                postdownload_file_data_check=validate_postdownload_file_data,
+                expected_num_files=1,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, SOURCE_TAG)
 async def test_s3_source_no_access(anon_connection_config: S3ConnectionConfig):
     indexer_config = S3IndexerConfig(remote_url="s3://utic-ingest-test-fixtures/destination/")
     indexer = S3Indexer(connection_config=anon_connection_config, index_config=indexer_config)

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.3-dev5"  # pragma: no cover
+__version__ = "0.2.3-dev6"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -212,7 +212,8 @@ class FsspecDownloader(Downloader):
 
     def handle_directory_download(self, lpath: Path) -> None:
         # When the extension has odd characters in it (i.e. ???,gz), it
-        # gets downloaded in a new directory rather than as a file. This reconciles that with what is expected.
+        # gets downloaded in a new directory rather than as a file. This reconciles
+        # that with what is expected.
         if not lpath.is_dir():
             return
         desired_name = lpath.name

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os.path
 import random
+import shutil
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Optional, TypeVar
@@ -207,12 +210,33 @@ class FsspecDownloader(Downloader):
             **self.connection_config.get_access_config(),
         )
 
+    def handle_directory_download(self, lpath: Path) -> None:
+        # When the extension has odd characters in it (i.e. ???,gz), it
+        # gets downloaded in a new directory rather than as a file. This reconciles that with what is expected.
+        if not lpath.is_dir():
+            return
+        desired_name = lpath.name
+        files_in_dir = [file for file in lpath.iterdir() if file.is_file()]
+        if not files_in_dir:
+            raise ValueError(f"no files in {lpath}")
+        if len(files_in_dir) > 1:
+            raise ValueError(
+                "Multiple files in {}: {}".format(lpath, ", ".join([str(f) for f in files_in_dir]))
+            )
+        file = files_in_dir[0]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_location = os.path.join(temp_dir, desired_name)
+            shutil.copyfile(src=file, dst=temp_location)
+            shutil.rmtree(lpath)
+            shutil.move(src=temp_location, dst=lpath)
+
     def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
         download_path = self.get_download_path(file_data=file_data)
         download_path.parent.mkdir(parents=True, exist_ok=True)
         try:
             rpath = file_data.additional_metadata["original_file_path"]
             self.fs.get(rpath=rpath, lpath=download_path.as_posix())
+            self.handle_directory_download(lpath=download_path)
         except Exception as e:
             logger.error(f"failed to download file {file_data.identifier}: {e}", exc_info=True)
             raise SourceConnectionNetworkError(f"failed to download file {file_data.identifier}")
@@ -224,6 +248,7 @@ class FsspecDownloader(Downloader):
         try:
             rpath = file_data.additional_metadata["original_file_path"]
             await self.fs.get(rpath=rpath, lpath=download_path.as_posix())
+            self.handle_directory_download(lpath=download_path)
         except Exception as e:
             logger.error(f"failed to download file {file_data.identifier}: {e}", exc_info=True)
             raise SourceConnectionNetworkError(f"failed to download file {file_data.identifier}")

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os.path
+import os
 import random
 import shutil
 import tempfile
@@ -211,9 +211,10 @@ class FsspecDownloader(Downloader):
         )
 
     def handle_directory_download(self, lpath: Path) -> None:
-        # When the extension has odd characters in it (i.e. ???,gz), it
-        # gets downloaded in a new directory rather than as a file. This reconciles
-        # that with what is expected.
+        # If the object's name contains certain characters (i.e. '?'), it
+        # gets downloaded into a new directory of the same name. This
+        # reconciles that with what is expected, which is to download it 
+        # as a file that is not within a directory.
         if not lpath.is_dir():
             return
         desired_name = lpath.name

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -213,7 +213,7 @@ class FsspecDownloader(Downloader):
     def handle_directory_download(self, lpath: Path) -> None:
         # If the object's name contains certain characters (i.e. '?'), it
         # gets downloaded into a new directory of the same name. This
-        # reconciles that with what is expected, which is to download it 
+        # reconciles that with what is expected, which is to download it
         # as a file that is not within a directory.
         if not lpath.is_dir():
             return


### PR DESCRIPTION
### Description
When extensions have odd characters, files are downloaded into a directory. Code added to shift it around to match expected behavior. 