### PR TITLE
fix: Propagate exceptions raised by delta table connector during write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.1-dev3
+## 0.3.1-dev4
 
 ### Enhancements
 
@@ -9,6 +9,7 @@
 ### Fixes
 * **Make AstraDB precheck fail on non-existant collections**
 * **Respect Pinecone's metadata size limits** crop metadata sent to Pinecone's to fit inside its limits, to avoid error responses
+* **Propagate exceptions raised by delta table connector during write**
 
 ## 0.3.0
 

--- a/test/integration/connectors/test_delta_table.py
+++ b/test/integration/connectors/test_delta_table.py
@@ -180,5 +180,5 @@ async def test_delta_table_destination_s3_bad_creds(upload_file: Path, temp_dir:
             await uploader.run_async(path=new_upload_file, file_data=file_data)
         else:
             uploader.run(path=new_upload_file, file_data=file_data)
-    
+
     assert "403 Forbidden" in str(excinfo.value), f"Exception message did not match: {str(excinfo)}"

--- a/test/integration/connectors/test_delta_table.py
+++ b/test/integration/connectors/test_delta_table.py
@@ -136,3 +136,49 @@ async def test_delta_table_destination_s3(upload_file: Path, temp_dir: Path):
             secret=aws_credentials["AWS_SECRET_ACCESS_KEY"],
         )
         s3fs.rm(path=destination_path, recursive=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG)
+@requires_env("S3_INGEST_TEST_ACCESS_KEY", "S3_INGEST_TEST_SECRET_KEY")
+async def test_delta_table_destination_s3_bad_creds(upload_file: Path, temp_dir: Path):
+    aws_credentials = {
+        "AWS_ACCESS_KEY_ID": "bad key",
+        "AWS_SECRET_ACCESS_KEY": "bad secret",
+        "AWS_REGION": "us-east-2",
+    }
+    s3_bucket = "s3://utic-platform-test-destination"
+    destination_path = f"{s3_bucket}/destination/test"
+    connection_config = DeltaTableConnectionConfig(
+        access_config=DeltaTableAccessConfig(
+            aws_access_key_id=aws_credentials["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key=aws_credentials["AWS_SECRET_ACCESS_KEY"],
+        ),
+        aws_region=aws_credentials["AWS_REGION"],
+        table_uri=destination_path,
+    )
+    stager_config = DeltaTableUploadStagerConfig()
+    stager = DeltaTableUploadStager(upload_stager_config=stager_config)
+    new_upload_file = stager.run(
+        elements_filepath=upload_file,
+        output_dir=temp_dir,
+        output_filename=upload_file.name,
+    )
+
+    upload_config = DeltaTableUploaderConfig()
+    uploader = DeltaTableUploader(connection_config=connection_config, upload_config=upload_config)
+    file_data = FileData(
+        source_identifiers=SourceIdentifiers(
+            fullpath=upload_file.name, filename=new_upload_file.name
+        ),
+        connector_type=CONNECTOR_TYPE,
+        identifier="mock file data",
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        if uploader.is_async():
+            await uploader.run_async(path=new_upload_file, file_data=file_data)
+        else:
+            uploader.run(path=new_upload_file, file_data=file_data)
+    
+    assert "403 Forbidden" in str(excinfo.value), f"Exception message did not match: {str(excinfo)}"

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.1-dev3"  # pragma: no cover
+__version__ = "0.3.1-dev4"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/delta_table.py
+++ b/unstructured_ingest/v2/processes/connectors/delta_table.py
@@ -32,8 +32,6 @@ def write_deltalake_with_error_handling(queue, **kwargs):
     from deltalake.writer import write_deltalake
 
     try:
-        from deltalake.writer import write_deltalake
-
         write_deltalake(**kwargs)
     except Exception:
         queue.put(traceback.format_exc())

--- a/unstructured_ingest/v2/processes/connectors/delta_table.py
+++ b/unstructured_ingest/v2/processes/connectors/delta_table.py
@@ -30,11 +30,14 @@ CONNECTOR_TYPE = "delta_table"
 
 def write_deltalake_with_error_handling(queue, **kwargs):
     from deltalake.writer import write_deltalake
+
     try:
         from deltalake.writer import write_deltalake
+
         write_deltalake(**kwargs)
-    except Exception as e:
+    except Exception:
         queue.put(traceback.format_exc())
+
 
 class DeltaTableAccessConfig(AccessConfig):
     aws_access_key_id: Optional[str] = Field(default=None, description="AWS Access Key Id")
@@ -163,7 +166,6 @@ class DeltaTableUploader(Uploader):
             return self.process_parquet(parquet_paths=[path])
         else:
             raise ValueError(f"Unsupported file type, must be parquet, json or csv file: {path}")
-
 
     @requires_dependencies(["deltalake"], extras="delta-table")
     def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:


### PR DESCRIPTION
When the delta table uploader fails, it does so silently. This is because `write_deltalake` executes in a separate process and exceptions that occur within this process do not propagate back to the main process. Here is the motivation for executing the write in a child process:
https://github.com/Unstructured-IO/unstructured-ingest/blob/98bc8cdf8d77fb794b8cd3e36c7b8b61b35e24e2/unstructured_ingest/v2/processes/connectors/delta_table.py#L179-L182

This PR updates the child process to communicate errors to its parent process, using a shared queue. If the child process raised an exception, its parent propagates it.

# Validation
First, I added a test that asserts the uploader raises an exception when it's used with bad credentials. I verified this test fails with the existing implementation.

This test passes with the changes in this PR.

```
(uticinge5t) emilychen@emilys-MacBook-Pro-3 unstructured-ingest % PYTHONPATH=. pytest test/integration/connectors/test_delta_table.py 
/Users/emilychen/code/unstructured-ingest/uticinge5t/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================================================= test session starts ========================================================================================
platform darwin -- Python 3.12.3, pytest-8.3.3, pluggy-1.5.0
tagging: tags=[] , exclude-tags=[]
rootdir: /Users/emilychen/code/unstructured-ingest
configfile: setup.cfg
plugins: asyncio-0.24.0, cov-6.0.0, pytest_tagging-1.6.0, Faker-33.0.0, mock-3.14.0, anyio-4.6.2.post1
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 3 items                                                                                                                                                                                  

test/integration/connectors/test_delta_table.py ...                                                                                                                                          [100%]

========================================================================================= warnings summary =========================================================================================
test/integration/connectors/test_delta_table.py::test_delta_table_destination_s3
test/integration/connectors/test_delta_table.py::test_delta_table_destination_s3
test/integration/connectors/test_delta_table.py::test_delta_table_destination_s3
test/integration/connectors/test_delta_table.py::test_delta_table_destination_s3
  /Users/emilychen/code/unstructured-ingest/uticinge5t/lib/python3.12/site-packages/botocore/auth.py:424: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime_now = datetime.datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 3 passed, 4 warnings in 8.02s ===================================================================================
```