### PR TITLE
fix/Kafka cloud source couldn't connect, add test

### DIFF
--- a/unstructured_ingest/v2/processes/connectors/kafka/cloud.py
+++ b/unstructured_ingest/v2/processes/connectors/kafka/cloud.py
@@ -27,7 +27,7 @@ CONNECTOR_TYPE = "kafka-cloud"
 
 class CloudKafkaAccessConfig(KafkaAccessConfig):
     api_key: Optional[SecretStr] = Field(
-        description="Kafka API key to connect at the server", alias="kafka_api_key", default=None
+        description="Kafka API key to connect at the server", default=None
     )
     secret: Optional[SecretStr] = Field(description="", default=None)
 
@@ -46,8 +46,8 @@ class CloudKafkaConnectionConfig(KafkaConnectionConfig):
             "group.id": "default_group_id",
             "enable.auto.commit": "false",
             "auto.offset.reset": "earliest",
-            "sasl.username": access_config.api_key,
-            "sasl.password": access_config.secret,
+            "sasl.username": access_config.api_key.get_secret_value(),
+            "sasl.password": access_config.secret.get_secret_value(),
             "sasl.mechanism": "PLAIN",
             "security.protocol": "SASL_SSL",
         }

--- a/unstructured_ingest/v2/processes/connectors/kafka/kafka.py
+++ b/unstructured_ingest/v2/processes/connectors/kafka/kafka.py
@@ -157,7 +157,9 @@ class KafkaIndexer(Indexer, ABC):
     def precheck(self):
         try:
             with self.get_consumer() as consumer:
-                cluster_meta = consumer.list_topics(timeout=self.index_config.timeout)
+                # timeout needs at least 3 secs,
+                # more info: https://forum.confluent.io/t/kafkacat-connect-failure-to-confcloud-ssl/2513
+                cluster_meta = consumer.list_topics(timeout=5)
                 current_topics = [
                     topic for topic in cluster_meta.topics if topic != "__consumer_offsets"
                 ]


### PR DESCRIPTION
There were 2 config errors in the Kafka Cloud source connector.

Also adding test for it. To have it work, admin will have to set secrets KAFKA_API_KEY , KAFKA_SECRET and KAFKA_BOOTSTRAP_SERVER in repo.