### PR TITLE
prep release 0.3.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.3-dev2
+## 0.3.3
 
 ### Enhancements
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.3-dev2"  # pragma: no cover
+__version__ = "0.3.3"  # pragma: no cover


### PR DESCRIPTION
needed for breaking Weaviate fix

authentication in weaviate cloud was not allowing us to choose the right method