### PR TITLE
[DS-307] fix elasticsearch precheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.5-dev0
+
+### Fixes
+
+* **Remove client.ping() from the Elasticsearch precheck.**
+
 ## 0.3.4
 
 ### Enhancements

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.4"  # pragma: no cover
+__version__ = "0.3.5-dev0"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/elasticsearch/elasticsearch.py
+++ b/unstructured_ingest/v2/processes/connectors/elasticsearch/elasticsearch.py
@@ -91,6 +91,7 @@ class ElasticsearchConnectionConfig(ConnectionConfig):
         # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html
         client_input_kwargs: dict[str, Any] = {}
         access_config = self.access_config.get_secret_value()
+        breakpoint()
         if self.hosts:
             client_input_kwargs["hosts"] = self.hosts
         if self.cloud_id:
@@ -142,8 +143,6 @@ class ElasticsearchIndexer(Indexer):
     def precheck(self) -> None:
         try:
             with self.connection_config.get_client() as client:
-                if not client.ping():
-                    raise SourceConnectionError("cluster not detected")
                 indices = client.indices.get_alias(index="*")
                 if self.index_config.index_name not in indices:
                     raise SourceConnectionError(
@@ -393,11 +392,9 @@ class ElasticsearchUploader(Uploader):
     def precheck(self) -> None:
         try:
             with self.connection_config.get_client() as client:
-                if not client.ping():
-                    raise DestinationConnectionError("cluster not detected")
-                indices = client.indices.get_alias(index="*")
+                dices = client.indices.get_alias(index="*")
                 if self.upload_config.index_name not in indices:
-                    raise SourceConnectionError(
+                    raise DestinationConnectionError(
                         "index {} not found: {}".format(
                             self.upload_config.index_name, ", ".join(indices.keys())
                         )

--- a/unstructured_ingest/v2/processes/connectors/elasticsearch/elasticsearch.py
+++ b/unstructured_ingest/v2/processes/connectors/elasticsearch/elasticsearch.py
@@ -91,7 +91,6 @@ class ElasticsearchConnectionConfig(ConnectionConfig):
         # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html
         client_input_kwargs: dict[str, Any] = {}
         access_config = self.access_config.get_secret_value()
-        breakpoint()
         if self.hosts:
             client_input_kwargs["hosts"] = self.hosts
         if self.cloud_id:
@@ -392,7 +391,7 @@ class ElasticsearchUploader(Uploader):
     def precheck(self) -> None:
         try:
             with self.connection_config.get_client() as client:
-                dices = client.indices.get_alias(index="*")
+                indices = client.indices.get_alias(index="*")
                 if self.upload_config.index_name not in indices:
                     raise DestinationConnectionError(
                         "index {} not found: {}".format(


### PR DESCRIPTION
With the default way of creating creds for an elasticsearch index, we get a False returned with client.ping() This is because client.ping() looks for authentication on the cluster and not the index.

If we did want to return True, we would need to add these values to the api key:
```
"cluster": [
      "monitor",
      "manage",
      "all"
    ]
```
This is not worth it and adds extra friction.

I think we are fine testing if the precheck can find the index with the next line of code.