### PR TITLE
fix: deregister abstract weaviate destination entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 0.3.5-dev1
+## 0.3.5-dev2
 
 ### Fixes
 
 * **Remove client.ping() from the Elasticsearch precheck.**
 * **Persist record id in dedicated LanceDB column, use it to delete previous content to prevent duplicates.**
+* **Unregister Weaviate base classes** - Weaviate base classes shouldn't be registered as they are abstract and cannot be instantiated as a configuration
 
 ## 0.3.4
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.5-dev1"  # pragma: no cover
+__version__ = "0.3.5-dev2"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/weaviate/__init__.py
+++ b/unstructured_ingest/v2/processes/connectors/weaviate/__init__.py
@@ -10,8 +10,6 @@ from .embedded import CONNECTOR_TYPE as EMBEDDED_WEAVIATE_CONNECTOR_TYPE
 from .embedded import weaviate_embedded_destination_entry
 from .local import CONNECTOR_TYPE as LOCAL_WEAVIATE_CONNECTOR_TYPE
 from .local import weaviate_local_destination_entry
-from .weaviate import CONNECTOR_TYPE as WEAVIATE_CONNECTOR_TYPE
-from .weaviate import weaviate_destination_entry
 
 add_destination_entry(
     destination_type=LOCAL_WEAVIATE_CONNECTOR_TYPE, entry=weaviate_local_destination_entry
@@ -22,4 +20,3 @@ add_destination_entry(
 add_destination_entry(
     destination_type=EMBEDDED_WEAVIATE_CONNECTOR_TYPE, entry=weaviate_embedded_destination_entry
 )
-add_destination_entry(destination_type=WEAVIATE_CONNECTOR_TYPE, entry=weaviate_destination_entry)

--- a/unstructured_ingest/v2/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/v2/processes/connectors/weaviate/weaviate.py
@@ -22,7 +22,6 @@ from unstructured_ingest.v2.interfaces import (
     UploadStagerConfig,
 )
 from unstructured_ingest.v2.logger import logger
-from unstructured_ingest.v2.processes.connector_registry import DestinationRegistryEntry
 
 if TYPE_CHECKING:
     from weaviate.classes.init import Timeout
@@ -288,12 +287,3 @@ class WeaviateUploader(Uploader, ABC):
                         vector=vector,
                     )
             self.check_for_errors(client=weaviate_client)
-
-
-weaviate_destination_entry = DestinationRegistryEntry(
-    connection_config=WeaviateConnectionConfig,
-    uploader=WeaviateUploader,
-    uploader_config=WeaviateUploaderConfig,
-    upload_stager=WeaviateUploadStager,
-    upload_stager_config=WeaviateUploadStagerConfig,
-)


### PR DESCRIPTION
### Description

Pipeline with Weaviate cannot be created because a concrete implementation of the [abstract config](https://github.com/Unstructured-IO/unstructured-ingest/blob/87a90a0f009f470168c4af9d6a8ef4929e57623a/unstructured_ingest/v2/processes/connectors/weaviate/weaviate.py#L39) is counted as two configurations due to the fact that both abstract classes and concrete classes are registered as valid destination entries. The double registration occurs [here](https://github.com/Unstructured-IO/unstructured-ingest/blob/87a90a0f009f470168c4af9d6a8ef4929e57623a/unstructured_ingest/v2/pipeline/pipeline.py#L345) on `isinstance...`.

### Fix
The base classes shouldn't be registered as they cannot be instantiated as a configuration, this PR reverts registering them as a valid destination entry.

### How to reproduce
Run the following python code on main branch

```py
from unstructured_ingest.pipeline import Pipeline
from unstructured_ingest.processor import ProcessorConfig
from unstructured_ingest.v2.interfaces import ProcessorConfig
from unstructured_ingest.v2.pipeline.pipeline import Pipeline
from unstructured_ingest.v2.processes.chunker import ChunkerConfig
from unstructured_ingest.v2.processes.connectors.local import (
    LocalConnectionConfig,
    LocalDownloaderConfig,
    LocalIndexerConfig,
)
from unstructured_ingest.v2.processes.connectors.weaviate.cloud import (
    CloudWeaviateAccessConfig,
    CloudWeaviateConnectionConfig,
    CloudWeaviateUploaderConfig,
    CloudWeaviateUploadStagerConfig,
)
from unstructured_ingest.v2.processes.embedder import EmbedderConfig
from unstructured_ingest.v2.processes.partitioner import PartitionerConfig

Pipeline.from_configs(
    context=ProcessorConfig(),
    indexer_config=LocalIndexerConfig(input_path="."),
    downloader_config=LocalDownloaderConfig(),
    source_connection_config=LocalConnectionConfig(),
    partitioner_config=PartitionerConfig(),
    chunker_config=ChunkerConfig(chunking_strategy="by_title"),
    embedder_config=EmbedderConfig(embedding_provider="openai", embedding_api_key=""),
    destination_connection_config=CloudWeaviateConnectionConfig(
        access_config=CloudWeaviateAccessConfig(api_key=""),
        cluster_url="http://localhost:4444",
    ),
    stager_config=CloudWeaviateUploadStagerConfig(),
    uploader_config=CloudWeaviateUploaderConfig(collection=""),
).run()
```

The following error should occur
```
ValueError: multiple entries found matching provided uploader, stager and connection configs: ...
```


