### PR TITLE
feat/support personal access token for confluence auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,14 @@
-## 0.3.7-dev2
-
-### Fixes
-
-* **Fix Azure AI Search session handling**
-
-## 0.3.7-dev1
+## 0.3.7-dev3
 
 ### Fixes
 
 * **Fix Kafka source connection problems**
+* **Fix Azure AI Search session handling**
 
 ### Enhancements
 
 * **Kafka source connector has new field: group_id**
+* * **Support personal access token for confluence auth**
 
 ## 0.3.6
 

--- a/test/unit/v2/connectors/test_confluence.py
+++ b/test/unit/v2/connectors/test_confluence.py
@@ -1,0 +1,39 @@
+import pytest
+from pydantic import ValidationError
+
+from unstructured_ingest.v2.processes.connectors.confluence import (
+    ConfluenceAccessConfig,
+    ConfluenceConnectionConfig,
+)
+
+
+def test_connection_config_multiple_auth():
+    with pytest.raises(ValidationError):
+        ConfluenceConnectionConfig(
+            access_config=ConfluenceAccessConfig(
+                api_token="api_token",
+                access_token="access_token",
+            ),
+            user_email="user_email",
+            url="url",
+        )
+
+
+def test_connection_config_no_auth():
+    with pytest.raises(ValidationError):
+        ConfluenceConnectionConfig(access_config=ConfluenceAccessConfig(), url="url")
+
+
+def test_connection_config_basic_auth():
+    ConfluenceConnectionConfig(
+        access_config=ConfluenceAccessConfig(api_token="api_token"),
+        url="url",
+        user_email="user_email",
+    )
+
+
+def test_connection_config_pat_auth():
+    ConfluenceConnectionConfig(
+        access_config=ConfluenceAccessConfig(access_token="access_token"),
+        url="url",
+    )

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.7-dev2"  # pragma: no cover
+__version__ = "0.3.7-dev3"  # pragma: no cover


### PR DESCRIPTION
### Description
To support a user connecting to a cluster that might be in a data center and not cloud, confluence auth was updated to support personal access tokens: [Confluence Docs](https://atlassian-python-api.readthedocs.io/)