### PR TITLE
fix: pinecone metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 0.3.5-dev1
+## 0.3.5-dev2
 
 ### Fixes
 
 * **Remove client.ping() from the Elasticsearch precheck.**
 * **Persist record id in dedicated LanceDB column, use it to delete previous content to prevent duplicates.**
+* **Pinecone metadata fixes** - Fix CLI's --metadata-fields default. Always preserve record ID tracking metadata.
 
 ## 0.3.4
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.5-dev1"  # pragma: no cover
+__version__ = "0.3.5-dev2"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/pinecone.py
+++ b/unstructured_ingest/v2/processes/connectors/pinecone.py
@@ -84,7 +84,7 @@ ALLOWED_FIELDS = (
 
 class PineconeUploadStagerConfig(UploadStagerConfig):
     metadata_fields: list[str] = Field(
-        default=str(ALLOWED_FIELDS),
+        default=list(ALLOWED_FIELDS),
         description=(
             "which metadata from the source element to map to the payload metadata being sent to "
             "Pinecone."

--- a/unstructured_ingest/v2/processes/connectors/pinecone.py
+++ b/unstructured_ingest/v2/processes/connectors/pinecone.py
@@ -146,6 +146,7 @@ class PineconeUploadStager(UploadStager):
             )
             metadata = {}
 
+        metadata[RECORD_ID_LABEL] = file_data.identifier
         return {
             "id": str(uuid.uuid4()),
             "values": embeddings,

--- a/unstructured_ingest/v2/processes/connectors/pinecone.py
+++ b/unstructured_ingest/v2/processes/connectors/pinecone.py
@@ -137,7 +137,6 @@ class PineconeUploadStager(UploadStager):
             flatten_lists=True,
             remove_none=True,
         )
-        metadata[RECORD_ID_LABEL] = file_data.identifier
         metadata_size_bytes = len(json.dumps(metadata).encode())
         if metadata_size_bytes > MAX_METADATA_BYTES:
             logger.info(
@@ -147,6 +146,7 @@ class PineconeUploadStager(UploadStager):
             metadata = {}
 
         metadata[RECORD_ID_LABEL] = file_data.identifier
+
         return {
             "id": str(uuid.uuid4()),
             "values": embeddings,


### PR DESCRIPTION
1. Fix default value of `metadata_fields` to be a list, it being a `string` made the default not work properly in CLI.
2. Always preserve record ID tracking metadata, when dropping too large metadata we should still have the record ID as it is necessary for overwriting