### PR TITLE
fix/Azure AI - reuse client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.7-dev0
+
+### Fixes
+
+* **Fix Azure AI Search session handling**
+
 ## 0.3.6
 
 ### Fixes

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.6"  # pragma: no cover
+__version__ = "0.3.7-dev0"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/azure_ai_search.py
+++ b/unstructured_ingest/v2/processes/connectors/azure_ai_search.py
@@ -174,7 +174,9 @@ class AzureAISearchUploader(Uploader):
 
     def query_docs(self, record_id: str, index_key: str) -> list[str]:
         with self.connection_config.get_search_client() as search_client:
-            results = list(search_client.search(filter=f"record_id eq '{record_id}'", select=[index_key]))
+            results = list(
+                search_client.search(filter=f"record_id eq '{record_id}'", select=[index_key])
+            )
         return [result[index_key] for result in results]
 
     def delete_by_record_id(self, file_data: FileData, index_key: str) -> None:


### PR DESCRIPTION
This fix should improve the behaviour of this connector when handling big files. It reuses the client, and closes the session.

I couldn't exactly pinpoint in MS documentation that the session should be reused and closed for this class, altough:
- related bug: https://github.com/Azure/azure-sdk-for-python/issues/13242  (we've seen similar logs in Platform)
- in other doc they recommend keeping single client https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/best-practice-python  "Use a single instance of CosmosClient for the lifetime of your application for better performance."
- it makes sense