### PR TITLE
bugfix/prevent pinecone being called too often when deleting content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.8-dev0
+
+### Fixes
+
+* **Prevent pinecone delete from hammering database when deleting**
 
 ## 0.3.7
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.7"  # pragma: no cover
+__version__ = "0.3.8-dev0"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/pinecone.py
+++ b/unstructured_ingest/v2/processes/connectors/pinecone.py
@@ -216,19 +216,6 @@ class PineconeUploader(Uploader):
             f"from pinecone index: {resp}"
         )
 
-    def delete_by_query(self, index: "PineconeIndex", query_params: dict) -> None:
-        while True:
-            query_results = index.query(**query_params)
-            matches = query_results.get("matches", [])
-            if not matches:
-                break
-            ids = [match["id"] for match in matches]
-            delete_params = {"ids": ids}
-            if namespace := self.upload_config.namespace:
-                delete_params["namespace"] = namespace
-            index.delete(**delete_params)
-            time.sleep(1)
-
     def serverless_delete_by_record_id(self, file_data: FileData) -> None:
         logger.debug(
             f"deleting any content with metadata "

--- a/unstructured_ingest/v2/processes/connectors/pinecone.py
+++ b/unstructured_ingest/v2/processes/connectors/pinecone.py
@@ -1,5 +1,4 @@
 import json
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -7,7 +6,10 @@ from typing import TYPE_CHECKING, Any, Optional
 from pydantic import Field, Secret
 
 from unstructured_ingest.error import DestinationConnectionError
-from unstructured_ingest.utils.data_prep import flatten_dict, generator_batching_wbytes
+from unstructured_ingest.utils.data_prep import (
+    flatten_dict,
+    generator_batching_wbytes,
+)
 from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.v2.constants import RECORD_ID_LABEL
 from unstructured_ingest.v2.interfaces import (
@@ -149,8 +151,10 @@ class PineconeUploadStager(UploadStager):
 
         metadata[RECORD_ID_LABEL] = file_data.identifier
 
+        # To support more optimal deletes, a prefix is suggested for each record:
+        # https://docs.pinecone.io/guides/data/manage-rag-documents#delete-all-records-for-a-parent-document
         return {
-            "id": get_enhanced_element_id(element_dict=element_dict, file_data=file_data),
+            "id": f"{file_data.identifier}#{get_enhanced_element_id(element_dict=element_dict, file_data=file_data)}",  # noqa:E501
             "values": embeddings,
             "metadata": metadata,
         }
@@ -223,40 +227,23 @@ class PineconeUploader(Uploader):
             f"from pinecone serverless index"
         )
         index = self.connection_config.get_index(pool_threads=MAX_POOL_THREADS)
-        filter_dict = {self.upload_config.record_id_key: {"$eq": file_data.identifier}}
-        index_stats = index.describe_index_stats()
-        dimension = index_stats["dimension"]
-        total_vectors = index_stats["total_vector_count"]
-        if total_vectors == 0:
-            return
-        top_k = min(total_vectors, MAX_QUERY_RESULTS)
-        query_params = {
-            "filter": filter_dict,
-            "vector": [0] * dimension,
-            "top_k": top_k,
-        }
+        list_kwargs = {"prefix": f"{file_data.identifier}#"}
+        deleted_ids = 0
         if namespace := self.upload_config.namespace:
-            query_params["namespace"] = namespace
-        read_units_used = 0
-        while True:
-            query_results = index.query(**query_params)
-            read_units_used += query_results.get("usage").get("read_units", 0)
-            matches = query_results.get("matches", [])
-            if not matches:
-                break
-            ids = [match["id"] for match in matches]
-            delete_params = {"ids": ids}
+            list_kwargs["namespace"] = namespace
+        for ids in index.list(**list_kwargs):
+            deleted_ids += len(ids)
+            delete_kwargs = {"ids": ids}
             if namespace := self.upload_config.namespace:
-                delete_params["namespace"] = namespace
-            # delete operation doesn't return any usage data
-            index.delete(**delete_params)
-            # Give the index a second to process before making another request
-            time.sleep(1)
-
+                delete_resp = delete_kwargs["namespace"] = namespace
+                # delete_resp should be an empty dict if there were no errors
+                if delete_resp:
+                    logger.error(f"failed to delete batch of ids: {delete_resp}")
+            index.delete(**delete_kwargs)
         logger.info(
-            f"deleted records with metadata "
+            f"deleted {deleted_ids} records with metadata "
             f"{self.upload_config.record_id_key}={file_data.identifier} "
-            f"from pinecone index, read units used: {read_units_used}"
+            f"from pinecone index"
         )
 
     @requires_dependencies(["pinecone"], extras="pinecone")


### PR DESCRIPTION
### Description
A while loop was running as often as possible when checking if content was deleting, causing a ton of read units to be used while the database caught up to the delete request. A wait was added to give the database time to catch up before making the next call. 