### PR TITLE
bugfix/close SSHClient in sftp connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 0.3.10-dev0
+## 0.3.10-dev1
 
 ### Enhancements
 
 * **Support more concrete FileData content for batch support**
+
+### Fixes
+
+* **Fix closing SSHClient in sftp connector**
 
 ## 0.3.9
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.10-dev0"  # pragma: no cover
+__version__ = "0.3.10-dev1"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
 from time import time
-from typing import Any, Generator, Optional
+from typing import TYPE_CHECKING, Any, Generator, Optional
 
 from pydantic import Field, Secret
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
-from unstructured_ingest.v2.interfaces import DownloadResponse, FileData, FileDataSourceMetadata
+from unstructured_ingest.v2.interfaces import FileDataSourceMetadata
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -25,6 +24,8 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
 )
 from unstructured_ingest.v2.processes.connectors.fsspec.utils import json_serial, sterilize_dict
 
+if TYPE_CHECKING:
+    from adlfs import AzureBlobFileSystem
 CONNECTOR_TYPE = "azure"
 
 
@@ -89,6 +90,10 @@ class AzureConnectionConfig(FsspecConnectionConfig):
         }
         return access_configs
 
+    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
+    def get_client(self, protocol: str) -> Generator["AzureBlobFileSystem", None, None]:
+        yield super().get_client(protocol=protocol)
+
 
 @dataclass
 class AzureIndexer(FsspecIndexer):
@@ -96,16 +101,8 @@ class AzureIndexer(FsspecIndexer):
     index_config: AzureIndexerConfig
     connector_type: str = CONNECTOR_TYPE
 
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    def precheck(self) -> None:
-        super().precheck()
-
     def sterilize_info(self, file_data: dict) -> dict:
         return sterilize_dict(data=file_data, default=azure_json_serial)
-
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
-        return super().run(**kwargs)
 
     def get_metadata(self, file_data: dict) -> FileDataSourceMetadata:
         path = file_data["name"]
@@ -149,14 +146,6 @@ class AzureDownloader(FsspecDownloader):
     connector_type: str = CONNECTOR_TYPE
     download_config: Optional[AzureDownloaderConfig] = field(default_factory=AzureDownloaderConfig)
 
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        return super().run(file_data=file_data, **kwargs)
-
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    async def run_async(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        return await super().run_async(file_data=file_data, **kwargs)
-
 
 class AzureUploaderConfig(FsspecUploaderConfig):
     pass
@@ -167,22 +156,6 @@ class AzureUploader(FsspecUploader):
     connector_type: str = CONNECTOR_TYPE
     connection_config: AzureConnectionConfig
     upload_config: AzureUploaderConfig = field(default=None)
-
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    def __post_init__(self):
-        super().__post_init__()
-
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    def precheck(self) -> None:
-        super().precheck()
-
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return super().run(path=path, file_data=file_data, **kwargs)
-
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
-    async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
 azure_source_entry = SourceRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from time import time
 from typing import TYPE_CHECKING, Any, Generator, Optional
@@ -26,6 +27,7 @@ from unstructured_ingest.v2.processes.connectors.fsspec.utils import json_serial
 
 if TYPE_CHECKING:
     from adlfs import AzureBlobFileSystem
+
 CONNECTOR_TYPE = "azure"
 
 
@@ -91,8 +93,10 @@ class AzureConnectionConfig(FsspecConnectionConfig):
         return access_configs
 
     @requires_dependencies(["adlfs", "fsspec"], extras="azure")
+    @contextmanager
     def get_client(self, protocol: str) -> Generator["AzureBlobFileSystem", None, None]:
-        yield super().get_client(protocol=protocol)
+        with super().get_client(protocol=protocol) as client:
+            yield client
 
 
 @dataclass

--- a/unstructured_ingest/v2/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/box.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
 from time import time
-from typing import Annotated, Any, Generator, Optional
+from typing import TYPE_CHECKING, Annotated, Any, Generator, Optional
 
 from dateutil import parser
 from pydantic import Field, Secret
 from pydantic.functional_validators import BeforeValidator
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
-from unstructured_ingest.v2.interfaces import DownloadResponse, FileData, FileDataSourceMetadata
+from unstructured_ingest.v2.interfaces import FileDataSourceMetadata
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -27,6 +26,9 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
     SourceConnectionError,
 )
 from unstructured_ingest.v2.processes.connectors.utils import conform_string_to_dict
+
+if TYPE_CHECKING:
+    from boxfs import BoxFileSystem
 
 CONNECTOR_TYPE = "box"
 
@@ -72,20 +74,16 @@ class BoxConnectionConfig(FsspecConnectionConfig):
 
         return access_kwargs_with_oauth
 
+    @requires_dependencies(["boxfs"], extras="box")
+    def get_client(self, protocol: str) -> Generator["BoxFileSystem", None, None]:
+        yield super().get_client(protocol=protocol)
+
 
 @dataclass
 class BoxIndexer(FsspecIndexer):
     connection_config: BoxConnectionConfig
     index_config: BoxIndexerConfig
     connector_type: str = CONNECTOR_TYPE
-
-    @requires_dependencies(["boxfs"], extras="box")
-    def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
-        return super().run(**kwargs)
-
-    @requires_dependencies(["boxfs"], extras="box")
-    def precheck(self) -> None:
-        super().precheck()
 
     def get_metadata(self, file_data: dict) -> FileDataSourceMetadata:
         path = file_data["name"]
@@ -126,14 +124,6 @@ class BoxDownloader(FsspecDownloader):
     connector_type: str = CONNECTOR_TYPE
     download_config: Optional[BoxDownloaderConfig] = field(default_factory=BoxDownloaderConfig)
 
-    @requires_dependencies(["boxfs"], extras="box")
-    def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        return super().run(file_data=file_data, **kwargs)
-
-    @requires_dependencies(["boxfs"], extras="box")
-    async def run_async(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        return await super().run_async(file_data=file_data, **kwargs)
-
 
 class BoxUploaderConfig(FsspecUploaderConfig):
     pass
@@ -144,22 +134,6 @@ class BoxUploader(FsspecUploader):
     connector_type: str = CONNECTOR_TYPE
     connection_config: BoxConnectionConfig
     upload_config: BoxUploaderConfig = field(default=None)
-
-    @requires_dependencies(["boxfs"], extras="box")
-    def __post_init__(self):
-        super().__post_init__()
-
-    @requires_dependencies(["boxfs"], extras="box")
-    def precheck(self) -> None:
-        super().precheck()
-
-    @requires_dependencies(["boxfs"], extras="box")
-    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return super().run(path=path, file_data=file_data, **kwargs)
-
-    @requires_dependencies(["boxfs"], extras="box")
-    async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
 box_source_entry = SourceRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/box.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from time import time
 from typing import TYPE_CHECKING, Annotated, Any, Generator, Optional
@@ -75,8 +76,10 @@ class BoxConnectionConfig(FsspecConnectionConfig):
         return access_kwargs_with_oauth
 
     @requires_dependencies(["boxfs"], extras="box")
+    @contextmanager
     def get_client(self, protocol: str) -> Generator["BoxFileSystem", None, None]:
-        yield super().get_client(protocol=protocol)
+        with super().get_client(protocol=protocol) as client:
+            yield client
 
 
 @dataclass

--- a/unstructured_ingest/v2/processes/connectors/fsspec/dropbox.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/dropbox.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from time import time
 from typing import TYPE_CHECKING, Generator, Optional
@@ -47,8 +48,10 @@ class DropboxConnectionConfig(FsspecConnectionConfig):
     connector_type: str = Field(default=CONNECTOR_TYPE, init=False)
 
     @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
+    @contextmanager
     def get_client(self, protocol: str) -> Generator["DropboxDriveFileSystem", None, None]:
-        yield super().get_client(protocol=protocol)
+        with super().get_client(protocol=protocol) as client:
+            yield client
 
 
 @dataclass

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -325,4 +325,4 @@ class FsspecUploader(Uploader):
         # Odd that fsspec doesn't run exists() as async even when client support async
         logger.debug(f"writing local file {path_str} to {upload_path}")
         with self.connection_config.get_client(protocol=self.upload_config.protocol) as client:
-            await client.upload(lpath=path_str, rpath=upload_path.as_posix())
+            client.upload(lpath=path_str, rpath=upload_path.as_posix())

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -324,4 +324,5 @@ class FsspecUploader(Uploader):
         path_str = str(path.resolve())
         # Odd that fsspec doesn't run exists() as async even when client support async
         logger.debug(f"writing local file {path_str} to {upload_path}")
-        self.fs.upload(lpath=path_str, rpath=upload_path.as_posix())
+        with self.connection_config.get_client(protocol=self.upload_config.protocol) as client:
+            await client.upload(lpath=path_str, rpath=upload_path.as_posix())

--- a/unstructured_ingest/v2/processes/connectors/fsspec/gcs.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/gcs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from time import time
@@ -97,8 +98,10 @@ class GcsConnectionConfig(FsspecConnectionConfig):
     connector_type: str = Field(default=CONNECTOR_TYPE, init=False)
 
     @requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
+    @contextmanager
     def get_client(self, protocol: str) -> Generator["GCSFileSystem", None, None]:
-        yield super().get_client(protocol=protocol)
+        with super().get_client(protocol=protocol) as client:
+            yield client
 
 
 @dataclass

--- a/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
@@ -97,7 +97,8 @@ class S3Indexer(FsspecIndexer):
         version = file_data.get("ETag").rstrip('"').lstrip('"') if "ETag" in file_data else None
         metadata: dict[str, str] = {}
         with contextlib.suppress(AttributeError):
-            metadata = self.fs.metadata(path=path)
+            with self.connection_config.get_client(protocol=self.index_config.protocol) as client:
+                metadata = client.metadata(path=path)
         record_locator = {
             "protocol": self.index_config.protocol,
             "remote_file_path": self.index_config.remote_url,

--- a/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
@@ -1,4 +1,5 @@
 import contextlib
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from time import time
 from typing import TYPE_CHECKING, Any, Generator, Optional
@@ -73,8 +74,10 @@ class S3ConnectionConfig(FsspecConnectionConfig):
         return access_configs
 
     @requires_dependencies(["s3fs", "fsspec"], extras="s3")
+    @contextmanager
     def get_client(self, protocol: str) -> Generator["S3FileSystem", None, None]:
-        yield super().get_client(protocol=protocol)
+        with super().get_client(protocol=protocol) as client:
+            yield client
 
 
 @dataclass

--- a/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
@@ -1,15 +1,12 @@
 import contextlib
 from dataclasses import dataclass, field
-from pathlib import Path
 from time import time
-from typing import Any, Generator, Optional
+from typing import TYPE_CHECKING, Any, Generator, Optional
 
 from pydantic import Field, Secret
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.v2.interfaces import (
-    DownloadResponse,
-    FileData,
     FileDataSourceMetadata,
 )
 from unstructured_ingest.v2.processes.connector_registry import (
@@ -28,6 +25,9 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
 )
 
 CONNECTOR_TYPE = "s3"
+
+if TYPE_CHECKING:
+    from s3fs import S3FileSystem
 
 
 class S3IndexerConfig(FsspecIndexerConfig):
@@ -72,6 +72,10 @@ class S3ConnectionConfig(FsspecConnectionConfig):
         )
         return access_configs
 
+    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
+    def get_client(self, protocol: str) -> Generator["S3FileSystem", None, None]:
+        yield super().get_client(protocol=protocol)
+
 
 @dataclass
 class S3Indexer(FsspecIndexer):
@@ -115,14 +119,6 @@ class S3Indexer(FsspecIndexer):
             filesize_bytes=file_size,
         )
 
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
-        return super().run(**kwargs)
-
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    def precheck(self) -> None:
-        super().precheck()
-
 
 class S3DownloaderConfig(FsspecDownloaderConfig):
     pass
@@ -135,14 +131,6 @@ class S3Downloader(FsspecDownloader):
     connector_type: str = CONNECTOR_TYPE
     download_config: Optional[S3DownloaderConfig] = field(default_factory=S3DownloaderConfig)
 
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        return super().run(file_data=file_data, **kwargs)
-
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    async def run_async(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        return await super().run_async(file_data=file_data, **kwargs)
-
 
 class S3UploaderConfig(FsspecUploaderConfig):
     pass
@@ -153,22 +141,6 @@ class S3Uploader(FsspecUploader):
     connector_type: str = CONNECTOR_TYPE
     connection_config: S3ConnectionConfig
     upload_config: S3UploaderConfig = field(default=None)
-
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    def precheck(self) -> None:
-        super().precheck()
-
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    def __post_init__(self):
-        super().__post_init__()
-
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return super().run(path=path, file_data=file_data, **kwargs)
-
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
-    async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
 s3_source_entry = SourceRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from pydantic import Field, Secret
 
 from unstructured_ingest.utils.dep_check import requires_dependencies
-from unstructured_ingest.v2.interfaces import DownloadResponse, FileData, FileDataSourceMetadata
+from unstructured_ingest.v2.interfaces import FileData, FileDataSourceMetadata
 from unstructured_ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -29,6 +29,7 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
 
 if TYPE_CHECKING:
     from fsspec.implementations.sftp import SFTPFileSystem
+
 CONNECTOR_TYPE = "sftp"
 
 
@@ -71,6 +72,7 @@ class SftpConnectionConfig(FsspecConnectionConfig):
         return access_config
 
     @contextmanager
+    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
     def get_client(self, protocol: str) -> Generator["SFTPFileSystem", None, None]:
         # The paramiko.SSHClient() client that's opened by the SFTPFileSystem
         # never gets closed so explicitly adding that as part of this context manager
@@ -89,13 +91,11 @@ class SftpIndexer(FsspecIndexer):
     index_config: SftpIndexerConfig
     connector_type: str = CONNECTOR_TYPE
 
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
     def __post_init__(self):
         parsed_url = urlparse(self.index_config.remote_url)
         self.connection_config.host = parsed_url.hostname or self.connection_config.host
         self.connection_config.port = parsed_url.port or self.connection_config.port
 
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
         for file in super().run(**kwargs):
             new_identifier = (
@@ -106,10 +106,6 @@ class SftpIndexer(FsspecIndexer):
             )
             file.identifier = new_identifier
             yield file
-
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
-    def precheck(self) -> None:
-        super().precheck()
 
     def get_metadata(self, file_data: dict) -> FileDataSourceMetadata:
         path = file_data["name"]
@@ -143,19 +139,10 @@ class SftpDownloader(FsspecDownloader):
     connector_type: str = Field(default=CONNECTOR_TYPE, init=False)
     download_config: Optional[SftpDownloaderConfig] = field(default_factory=SftpDownloaderConfig)
 
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
     def __post_init__(self):
         parsed_url = urlparse(self.download_config.remote_url)
         self.connection_config.host = parsed_url.hostname or self.connection_config.host
         self.connection_config.port = parsed_url.port or self.connection_config.port
-
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
-    def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        return super().run(file_data=file_data, **kwargs)
-
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
-    async def run_async(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        return await super().run_async(file_data=file_data, **kwargs)
 
 
 class SftpUploaderConfig(FsspecUploaderConfig):
@@ -167,22 +154,6 @@ class SftpUploader(FsspecUploader):
     connector_type: str = CONNECTOR_TYPE
     connection_config: SftpConnectionConfig
     upload_config: SftpUploaderConfig = field(default=None)
-
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
-    def __post_init__(self):
-        super().__post_init__()
-
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
-    def precheck(self) -> None:
-        super().precheck()
-
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
-    def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return super().run(path=path, file_data=file_data, **kwargs)
-
-    @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
-    async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
 sftp_source_entry = SourceRegistryEntry(


### PR DESCRIPTION
### Description
The base fsspec implementation was letting the underlying library handle any connections, but the sftp implementation never closed the SSHClient connection. This updates the code to use a context manager, allowing the code to inject any addition cleanup in case the underlying implementation isn't enough. 