### PR TITLE
fix: handling path containing url unicode chars

### DIFF
--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -4,6 +4,7 @@ import os
 import random
 import shutil
 import tempfile
+from urllib.parse import unquote
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Optional, TypeVar
@@ -60,6 +61,7 @@ class FileConfig(BaseModel):
 
     def __init__(self, **data):
         protocol, path_without_protocol = data["remote_url"].split("://")
+        path_without_protocol = unquote(path_without_protocol)
         data["protocol"] = protocol
         data["path_without_protocol"] = path_without_protocol
         super().__init__(**data)
@@ -105,8 +107,12 @@ class FsspecIndexer(Indexer):
                 **self.connection_config.get_access_config(),
             )
             files = fs.ls(path=self.index_config.path_without_protocol, detail=True)
+            if files is None:
+                logger.error(f"[{CONNECTOR_TYPE}]fs.ls returned None for path: {self.index_config.path_without_protocol}")
+                raise SourceConnectionError("No files returned. Check if path is correct.")
             valid_files = [x.get("name") for x in files if x.get("type") == "file"]
             if not valid_files:
+                logger.warning(f"[{CONNECTOR_TYPE}]There was no files found at path: {self.index_config.path_without_protocol}")
                 return
             file_to_sample = valid_files[0]
             logger.debug(f"attempting to make HEAD request for file: {file_to_sample}")


### PR DESCRIPTION
This fix should allow fsspec connector to correctly handle paths containing whitespace and other url like characters like: %20.
Also slightly improved error logging for debug purposes.