### PR TITLE
fix: Revert closing connection in SFTP `get_client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## 0.3.12-dev3
+## 0.3.12-dev4
 
 ### Enhancements
 
 * **Migrate Vectara Destination Connector to v2**
+
+### Fixes
+* **Revert closing connection in SFTP source** which caused more closed socket errors
 
 ## 0.3.12-dev2
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.12-dev3"  # pragma: no cover
+__version__ = "0.3.12-dev4"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
@@ -74,15 +74,8 @@ class SftpConnectionConfig(FsspecConnectionConfig):
     @contextmanager
     @requires_dependencies(["paramiko", "fsspec"], extras="sftp")
     def get_client(self, protocol: str) -> Generator["SFTPFileSystem", None, None]:
-        # The paramiko.SSHClient() client that's opened by the SFTPFileSystem
-        # never gets closed so explicitly adding that as part of this context manager
-        from fsspec import get_filesystem_class
-
-        client: SFTPFileSystem = get_filesystem_class(protocol)(
-            **self.get_access_config(),
-        )
-        yield client
-        client.client.close()
+        with super().get_client(protocol=protocol) as client:
+            yield client
 
 
 @dataclass


### PR DESCRIPTION
Not closing the client was thought to be a cause of a bug with socket being closed in a inappropriate way.
It seems however that the issue persist and with us closing the connection ourselves we end up with next calls using the same filesystem failing due to closed socket.

We revert the change to avoid this new issue while investigating the root cause. Sample code which would fail because we close the client can be taken from the [SFTP Source documentation](https://docs.unstructured.io/open-source/ingest/source-connectors/sftp)