### PR TITLE
feat/support ndjson in pipeline

### DIFF
--- a/unstructured_ingest/v2/interfaces/file_data.py
+++ b/unstructured_ingest/v2/interfaces/file_data.py
@@ -102,7 +102,7 @@ def file_data_from_file(path: str) -> FileData:
     try:
         return BatchFileData.from_file(path=path)
     except ValidationError:
-        logger.debug(f"{path} not valid for batch file data")
+        logger.debug(f"{path} not detected as batch file data")
 
     return FileData.from_file(path=path)
 

--- a/unstructured_ingest/v2/interfaces/upload_stager.py
+++ b/unstructured_ingest/v2/interfaces/upload_stager.py
@@ -39,7 +39,6 @@ class UploadStager(BaseProcess, ABC):
         output_path = Path(output_filename)
         output_filename = f"{Path(output_filename).stem}{output_path.suffix}"
         output_path = Path(output_dir) / Path(f"{output_filename}")
-        output_path.parent.mkdir(parents=True, exist_ok=True)
         return output_path
 
     def stream_update(self, input_file: Path, output_file: Path, file_data: FileData) -> None:
@@ -53,16 +52,12 @@ class UploadStager(BaseProcess, ABC):
                     writer.f.flush()
 
     def process_whole(self, input_file: Path, output_file: Path, file_data: FileData) -> None:
-        with input_file.open() as in_f:
-            elements_contents = json.load(in_f)
-
+        elements_contents = self.get_data(elements_filepath=input_file)
         conformed_elements = [
             self.conform_dict(element_dict=element, file_data=file_data)
             for element in elements_contents
         ]
-
-        with open(output_file, "w") as out_f:
-            json.dump(conformed_elements, out_f, indent=2)
+        self.save_data(output_filepath=output_file, content=conformed_elements)
 
     def run(
         self,

--- a/unstructured_ingest/v2/pipeline/pipeline.py
+++ b/unstructured_ingest/v2/pipeline/pipeline.py
@@ -111,6 +111,13 @@ class Pipeline:
         uploader_connector_type = self.uploader_step.process.connector_type
         registry_entry = destination_registry[uploader_connector_type]
         if registry_entry.upload_stager and self.stager_step is None:
+            try:
+                self.stager_step = UploadStageStep(
+                    process=registry_entry.upload_stager(), context=self.context
+                )
+                return
+            except Exception as e:
+                logger.debug(f"failed to instantiate required stager on user's behalf: {e}")
             raise ValueError(
                 f"pipeline with uploader type {self.uploader_step.process.__class__.__name__} "
                 f"expects a stager of type {registry_entry.upload_stager.__name__} "

--- a/unstructured_ingest/v2/pipeline/steps/chunk.py
+++ b/unstructured_ingest/v2/pipeline/steps/chunk.py
@@ -1,6 +1,6 @@
 import asyncio
 import hashlib
-import json
+import ndjson
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
@@ -38,7 +38,7 @@ class ChunkStep(PipelineStep):
         return not filepath.exists()
 
     def get_output_filepath(self, filename: Path) -> Path:
-        hashed_output_file = f"{self.get_hash(extras=[filename.name])}.json"
+        hashed_output_file = f"{self.get_hash(extras=[filename.name])}.ndjson"
         filepath = (self.cache_dir / hashed_output_file).resolve()
         filepath.parent.mkdir(parents=True, exist_ok=True)
         return filepath
@@ -46,7 +46,7 @@ class ChunkStep(PipelineStep):
     def _save_output(self, output_filepath: str, chunked_content: list[dict]):
         with open(str(output_filepath), "w") as f:
             logger.debug(f"writing chunker output to: {output_filepath}")
-            json.dump(chunked_content, f, indent=2)
+            ndjson.dump(chunked_content, f)
 
     async def _run_async(
         self, fn: Callable, path: str, file_data_path: str, **kwargs

--- a/unstructured_ingest/v2/pipeline/steps/chunk.py
+++ b/unstructured_ingest/v2/pipeline/steps/chunk.py
@@ -1,9 +1,10 @@
 import asyncio
 import hashlib
-import ndjson
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
+
+import ndjson
 
 from unstructured_ingest.v2.interfaces import FileData
 from unstructured_ingest.v2.interfaces.file_data import file_data_from_file

--- a/unstructured_ingest/v2/pipeline/steps/partition.py
+++ b/unstructured_ingest/v2/pipeline/steps/partition.py
@@ -1,6 +1,6 @@
 import asyncio
 import hashlib
-import json
+import ndjson
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
@@ -38,7 +38,7 @@ class PartitionStep(PipelineStep):
         return not filepath.exists()
 
     def get_output_filepath(self, filename: Path) -> Path:
-        hashed_output_file = f"{self.get_hash(extras=[filename.name])}.json"
+        hashed_output_file = f"{self.get_hash(extras=[filename.name])}.ndjson"
         filepath = (self.cache_dir / hashed_output_file).resolve()
         filepath.parent.mkdir(parents=True, exist_ok=True)
         return filepath
@@ -46,7 +46,7 @@ class PartitionStep(PipelineStep):
     def _save_output(self, output_filepath: str, partitioned_content: list[dict]):
         with open(str(output_filepath), "w") as f:
             logger.debug(f"writing partitioned output to: {output_filepath}")
-            json.dump(partitioned_content, f, indent=2)
+            ndjson.dump(partitioned_content, f)
 
     async def _run_async(
         self, fn: Callable, path: str, file_data_path: str

--- a/unstructured_ingest/v2/pipeline/steps/partition.py
+++ b/unstructured_ingest/v2/pipeline/steps/partition.py
@@ -1,9 +1,10 @@
 import asyncio
 import hashlib
-import ndjson
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
+
+import ndjson
 
 from unstructured_ingest.v2.interfaces import FileData
 from unstructured_ingest.v2.interfaces.file_data import file_data_from_file

--- a/unstructured_ingest/v2/processes/chunker.py
+++ b/unstructured_ingest/v2/processes/chunker.py
@@ -1,10 +1,10 @@
+import json
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
-import json
-import ndjson
 
+import ndjson
 from pydantic import BaseModel, Field, SecretStr
 
 from unstructured_ingest.utils.chunking import assign_and_map_hash_ids

--- a/unstructured_ingest/v2/processes/connectors/databricks/volumes.py
+++ b/unstructured_ingest/v2/processes/connectors/databricks/volumes.py
@@ -187,9 +187,9 @@ class DatabricksVolumesUploader(Uploader, ABC):
     upload_config: DatabricksVolumesUploaderConfig
     connection_config: DatabricksVolumesConnectionConfig
 
-    def get_output_path(self, file_data: FileData) -> str:
+    def get_output_path(self, file_data: FileData, suffix: str = ".json") -> str:
         return os.path.join(
-            self.upload_config.path, f"{file_data.source_identifiers.filename}.json"
+            self.upload_config.path, f"{file_data.source_identifiers.filename}{suffix}"
         )
 
     def precheck(self) -> None:
@@ -199,7 +199,7 @@ class DatabricksVolumesUploader(Uploader, ABC):
             raise self.connection_config.wrap_error(e=e)
 
     def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        output_path = self.get_output_path(file_data=file_data)
+        output_path = self.get_output_path(file_data=file_data, suffix=path.suffix)
         with open(path, "rb") as elements_file:
             try:
                 self.connection_config.get_client().files.upload(

--- a/unstructured_ingest/v2/processes/connectors/databricks/volumes_aws.py
+++ b/unstructured_ingest/v2/processes/connectors/databricks/volumes_aws.py
@@ -17,6 +17,10 @@ from unstructured_ingest.v2.processes.connectors.databricks.volumes import (
     DatabricksVolumesUploader,
     DatabricksVolumesUploaderConfig,
 )
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 CONNECTOR_TYPE = "databricks_volumes_aws"
 
@@ -76,6 +80,8 @@ databricks_aws_volumes_destination_entry = DestinationRegistryEntry(
     connection_config=DatabricksAWSVolumesConnectionConfig,
     uploader=DatabricksAWSVolumesUploader,
     uploader_config=DatabricksAWSVolumesUploaderConfig,
+    upload_stager=BlobStoreUploadStager,
+    upload_stager_config=BlobStoreUploadStagerConfig,
 )
 
 databricks_aws_volumes_source_entry = SourceRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/databricks/volumes_azure.py
+++ b/unstructured_ingest/v2/processes/connectors/databricks/volumes_azure.py
@@ -17,6 +17,10 @@ from unstructured_ingest.v2.processes.connectors.databricks.volumes import (
     DatabricksVolumesUploader,
     DatabricksVolumesUploaderConfig,
 )
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 CONNECTOR_TYPE = "databricks_volumes_azure"
 
@@ -91,6 +95,8 @@ databricks_azure_volumes_destination_entry = DestinationRegistryEntry(
     connection_config=DatabricksAzureVolumesConnectionConfig,
     uploader=DatabricksAzureVolumesUploader,
     uploader_config=DatabricksAzureVolumesUploaderConfig,
+    upload_stager_config=BlobStoreUploadStagerConfig,
+    upload_stager=BlobStoreUploadStager,
 )
 
 databricks_azure_volumes_source_entry = SourceRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/databricks/volumes_gcp.py
+++ b/unstructured_ingest/v2/processes/connectors/databricks/volumes_gcp.py
@@ -17,6 +17,10 @@ from unstructured_ingest.v2.processes.connectors.databricks.volumes import (
     DatabricksVolumesUploader,
     DatabricksVolumesUploaderConfig,
 )
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 CONNECTOR_TYPE = "databricks_volumes_gcp"
 
@@ -74,6 +78,8 @@ databricks_gcp_volumes_destination_entry = DestinationRegistryEntry(
     connection_config=DatabricksGoogleVolumesConnectionConfig,
     uploader=DatabricksGoogleVolumesUploader,
     uploader_config=DatabricksGoogleVolumesUploaderConfig,
+    upload_stager=BlobStoreUploadStager,
+    upload_stager_config=BlobStoreUploadStagerConfig,
 )
 
 databricks_gcp_volumes_source_entry = SourceRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/databricks/volumes_native.py
+++ b/unstructured_ingest/v2/processes/connectors/databricks/volumes_native.py
@@ -17,6 +17,10 @@ from unstructured_ingest.v2.processes.connectors.databricks.volumes import (
     DatabricksVolumesUploader,
     DatabricksVolumesUploaderConfig,
 )
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 CONNECTOR_TYPE = "databricks_volumes"
 
@@ -75,6 +79,8 @@ databricks_native_volumes_destination_entry = DestinationRegistryEntry(
     connection_config=DatabricksNativeVolumesConnectionConfig,
     uploader=DatabricksNativeVolumesUploader,
     uploader_config=DatabricksNativeVolumesUploaderConfig,
+    upload_stager=BlobStoreUploadStager,
+    upload_stager_config=BlobStoreUploadStagerConfig,
 )
 
 databricks_native_volumes_source_entry = SourceRegistryEntry(

--- a/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/azure.py
@@ -26,6 +26,10 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecUploaderConfig,
 )
 from unstructured_ingest.v2.processes.connectors.fsspec.utils import json_serial, sterilize_dict
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 if TYPE_CHECKING:
     from adlfs import AzureBlobFileSystem
@@ -194,4 +198,6 @@ azure_destination_entry = DestinationRegistryEntry(
     uploader=AzureUploader,
     uploader_config=AzureUploaderConfig,
     connection_config=AzureConnectionConfig,
+    upload_stager_config=BlobStoreUploadStagerConfig,
+    upload_stager=BlobStoreUploadStager,
 )

--- a/unstructured_ingest/v2/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/box.py
@@ -28,6 +28,10 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecUploaderConfig,
 )
 from unstructured_ingest.v2.processes.connectors.utils import conform_string_to_dict
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 if TYPE_CHECKING:
     from boxfs import BoxFileSystem
@@ -167,4 +171,6 @@ box_destination_entry = DestinationRegistryEntry(
     uploader=BoxUploader,
     uploader_config=BoxUploaderConfig,
     connection_config=BoxConnectionConfig,
+    upload_stager=BlobStoreUploadStager,
+    upload_stager_config=BlobStoreUploadStagerConfig,
 )

--- a/unstructured_ingest/v2/processes/connectors/fsspec/dropbox.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/dropbox.py
@@ -32,6 +32,10 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecUploader,
     FsspecUploaderConfig,
 )
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 if TYPE_CHECKING:
     from dropboxdrivefs import DropboxDriveFileSystem
@@ -165,4 +169,6 @@ dropbox_destination_entry = DestinationRegistryEntry(
     uploader=DropboxUploader,
     uploader_config=DropboxUploaderConfig,
     connection_config=DropboxConnectionConfig,
+    upload_stager=BlobStoreUploadStager,
+    upload_stager_config=BlobStoreUploadStagerConfig,
 )

--- a/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -308,12 +308,12 @@ class FsspecUploader(Uploader):
         except Exception as e:
             raise self.wrap_error(e=e)
 
-    def get_upload_path(self, file_data: FileData) -> Path:
+    def get_upload_path(self, file_data: FileData, suffix: str = ".json") -> Path:
         upload_path = (
             Path(self.upload_config.path_without_protocol)
             / file_data.source_identifiers.relative_path
         )
-        updated_upload_path = upload_path.parent / f"{upload_path.name}.json"
+        updated_upload_path = upload_path.parent / f"{upload_path.name}{suffix}"
         return updated_upload_path
 
     def run(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
@@ -324,7 +324,7 @@ class FsspecUploader(Uploader):
             client.upload(lpath=path_str, rpath=upload_path.as_posix())
 
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        upload_path = self.get_upload_path(file_data=file_data)
+        upload_path = self.get_upload_path(file_data=file_data, suffix=path.suffix)
         path_str = str(path.resolve())
         # Odd that fsspec doesn't run exists() as async even when client support async
         logger.debug(f"writing local file {path_str} to {upload_path}")

--- a/unstructured_ingest/v2/processes/connectors/fsspec/gcs.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/gcs.py
@@ -28,6 +28,10 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecUploader,
     FsspecUploaderConfig,
 )
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 if TYPE_CHECKING:
     from gcsfs import GCSFileSystem
@@ -194,4 +198,6 @@ gcs_destination_entry = DestinationRegistryEntry(
     uploader=GcsUploader,
     uploader_config=GcsUploaderConfig,
     connection_config=GcsConnectionConfig,
+    upload_stager=BlobStoreUploadStager,
+    upload_stager_config=BlobStoreUploadStagerConfig,
 )

--- a/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/s3.py
@@ -26,6 +26,10 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecUploader,
     FsspecUploaderConfig,
 )
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 CONNECTOR_TYPE = "s3"
 
@@ -182,4 +186,6 @@ s3_destination_entry = DestinationRegistryEntry(
     uploader=S3Uploader,
     uploader_config=S3UploaderConfig,
     connection_config=S3ConnectionConfig,
+    upload_stager=BlobStoreUploadStager,
+    upload_stager_config=BlobStoreUploadStagerConfig,
 )

--- a/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/v2/processes/connectors/fsspec/sftp.py
@@ -26,6 +26,10 @@ from unstructured_ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecUploader,
     FsspecUploaderConfig,
 )
+from unstructured_ingest.v2.processes.utils.blob_storage import (
+    BlobStoreUploadStager,
+    BlobStoreUploadStagerConfig,
+)
 
 if TYPE_CHECKING:
     from fsspec.implementations.sftp import SFTPFileSystem
@@ -168,4 +172,6 @@ sftp_destination_entry = DestinationRegistryEntry(
     uploader=SftpUploader,
     uploader_config=SftpUploaderConfig,
     connection_config=SftpConnectionConfig,
+    upload_stager_config=BlobStoreUploadStagerConfig,
+    upload_stager=BlobStoreUploadStager,
 )

--- a/unstructured_ingest/v2/processes/embedder.py
+++ b/unstructured_ingest/v2/processes/embedder.py
@@ -186,14 +186,13 @@ class Embedder(BaseProcess, ABC):
     config: EmbedderConfig
 
     def get_data(self, elements_filepath: Path) -> list[dict]:
-        if elements_filepath.suffix == ".json":
-            with elements_filepath.open() as f:
+        with elements_filepath.open() as f:
+            if elements_filepath.suffix == ".json":
                 return json.load(f)
-        elif elements_filepath.suffix == ".ndjson":
-            with elements_filepath.open() as f:
+            elif elements_filepath.suffix == ".ndjson":
                 return ndjson.load(f)
-        else:
-            raise ValueError(f"Unsupported input format: {elements_filepath}")
+            else:
+                raise ValueError(f"Unsupported input format: {elements_filepath}")
 
     def run(self, elements_filepath: Path, **kwargs: Any) -> list[dict]:
         # TODO update base embedder classes to support async

--- a/unstructured_ingest/v2/processes/utils/blob_storage.py
+++ b/unstructured_ingest/v2/processes/utils/blob_storage.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from unstructured_ingest.v2.interfaces import FileData, UploadStager, UploadStagerConfig
+
+
+class BlobStoreUploadStagerConfig(UploadStagerConfig):
+    pass
+
+
+@dataclass
+class BlobStoreUploadStager(UploadStager):
+    upload_stager_config: BlobStoreUploadStagerConfig = field(
+        default_factory=BlobStoreUploadStagerConfig
+    )
+
+    def run(
+        self,
+        elements_filepath: Path,
+        file_data: FileData,
+        output_dir: Path,
+        output_filename: str,
+        **kwargs: Any,
+    ) -> Path:
+        output_file = self.get_output_path(output_filename=output_filename, output_dir=output_dir)
+        # Always save as json
+        data = self.get_data(elements_filepath)
+        self.save_data(output_filepath=output_file.with_suffix(".json"), content=data)
+        return output_file.with_suffix(".json")


### PR DESCRIPTION
### Description
Make sure that each step can correctly handle content being passed around as either json or ndjson. For connectors that upload to blob storage, to maintain backwards compatibility, a stager was introduced to make sure the content it converted back into json if ndjson for upload. 