### PR TITLE
fix(UNTRACKED): Fix ChromaDB integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.3.14-dev0
+## 0.3.14-dev1
 
 ### Fixes
 
 * **Fix Neo4j Uploader string enum error**
+* **Fix ChromaDB Destination failing integration tests** - issue lies within the newest ChromaDB release, fix freezes it's version to 0.6.2.
 
 ## 0.3.13
 

--- a/test/integration/connectors/test_chroma.py
+++ b/test/integration/connectors/test_chroma.py
@@ -27,7 +27,7 @@ from unstructured_ingest.v2.processes.connectors.chroma import (
 @pytest.fixture
 def chroma_instance():
     with container_context(
-        image="chromadb/chroma:latest",
+        image="chromadb/chroma:0.6.2",
         ports={8000: 8000},
         name="chroma_int_test",
         healthcheck=HealthCheck(

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.14-dev0"  # pragma: no cover
+__version__ = "0.3.14-dev1"  # pragma: no cover


### PR DESCRIPTION
There is an issue with the newest ChromaDB image release. The fix freezes image used for integration tests to v. 0.6.2.