### PR TITLE
fix: SQL stager and Snowflake uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-* **Fix SQL uploader stager** - When passed `output_filename` without a suffix it resulted in unsupported file format error. The fix forces output file format to be `.json`.
+* **Fix SQL uploader stager** - When passed `output_filename` without a suffix it resulted in unsupported file format error. `.json` suffix will be added to output filename if it doesn't have one.
 * **Fix Snowflake uploader** - Unexpected `columns` argument was passed to `_fit_to_schema` method inside SnowflakeUploader `upload_dataframe` method.
 
 ## 0.3.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.16-dev0
+
+### Fixes
+
+* **Fix SQL uploader stager** - When passed `output_filename` without a suffix it resulted in unsupported file format error. The fix forces output file format to be `.json`.
+* **Fix Snowflake uploader** - Unexpected `columns` argument was passed to `_fit_to_schema` method inside SnowflakeUploader `upload_dataframe` method.
+
 ## 0.3.15
 
 ### Enhancements

--- a/test/unit/v2/connectors/sql/test_sql.py
+++ b/test/unit/v2/connectors/sql/test_sql.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from unstructured_ingest.v2.interfaces.file_data import FileData, SourceIdentifiers
+from unstructured_ingest.v2.processes.connectors.sql.sql import SQLUploadStager
+
+
+@pytest.fixture
+def mock_instance() -> SQLUploadStager:
+    return SQLUploadStager()
+
+
+@pytest.mark.parametrize(
+    ("output_filename", "expected"),
+    [
+        ("filename_with_suffix.ndjson", "filename_with_suffix.ndjson"),
+        ("filename_without_suffix", "filename_without_suffix.json"),
+    ],
+)
+def test_run_output_filename_suffix(
+    mocker: MockerFixture, mock_instance: SQLUploadStager, output_filename: str, expected: str
+):
+    elements_filename = "elements.json"
+    output_dir = Path("/tmp/test/output_dir")
+
+    # Mocks
+    mock_get_data = mocker.patch(
+        "unstructured_ingest.v2.processes.connectors.sql.sql.get_data",
+        return_value=[{"key": "value"}, {"key": "value2"}],
+    )
+    mock_conform_dict = mocker.patch.object(
+        SQLUploadStager, "conform_dict", side_effect=lambda element_dict, file_data: element_dict
+    )
+    mock_conform_dataframe = mocker.patch.object(
+        SQLUploadStager, "conform_dataframe", side_effect=lambda df: df
+    )
+    mock_get_output_path = mocker.patch.object(
+        SQLUploadStager, "get_output_path", return_value=output_dir / expected
+    )
+    mock_write_output = mocker.patch.object(SQLUploadStager, "write_output")
+
+    # Act
+    result = mock_instance.run(
+        elements_filepath=Path(elements_filename),
+        file_data=FileData(
+            identifier="test",
+            connector_type="test",
+            source_identifiers=SourceIdentifiers(
+                filename=elements_filename, fullpath=elements_filename
+            ),
+        ),
+        output_dir=output_dir,
+        output_filename=output_filename,
+    )
+
+    # Assert
+    mock_get_data.assert_called_once_with(path=Path(elements_filename))
+    assert mock_conform_dict.call_count == 2
+    mock_conform_dataframe.assert_called_once()
+    mock_get_output_path.assert_called_once_with(output_filename=expected, output_dir=output_dir)
+    mock_write_output.assert_called_once_with(
+        output_path=output_dir / expected, data=[{"key": "value"}, {"key": "value2"}]
+    )
+    assert result.name == expected

--- a/test/unit/v2/connectors/sql/test_sql.py
+++ b/test/unit/v2/connectors/sql/test_sql.py
@@ -13,16 +13,24 @@ def mock_instance() -> SQLUploadStager:
 
 
 @pytest.mark.parametrize(
-    ("output_filename", "expected"),
+    ("input_filepath", "output_filename", "expected"),
     [
-        ("filename_with_suffix.ndjson", "filename_with_suffix.ndjson"),
-        ("filename_without_suffix", "filename_without_suffix.json"),
+        (
+            "/path/to/input_file.ndjson",
+            "output_file.ndjson",
+            "output_file.ndjson",
+        ),
+        ("input_file.txt", "output_file.json", "output_file.txt"),
+        ("/path/to/input_file.json", "output_file", "output_file.json"),
     ],
 )
 def test_run_output_filename_suffix(
-    mocker: MockerFixture, mock_instance: SQLUploadStager, output_filename: str, expected: str
+    mocker: MockerFixture,
+    mock_instance: SQLUploadStager,
+    input_filepath: str,
+    output_filename: str,
+    expected: str,
 ):
-    elements_filename = "elements.json"
     output_dir = Path("/tmp/test/output_dir")
 
     # Mocks
@@ -43,20 +51,18 @@ def test_run_output_filename_suffix(
 
     # Act
     result = mock_instance.run(
-        elements_filepath=Path(elements_filename),
+        elements_filepath=Path(input_filepath),
         file_data=FileData(
             identifier="test",
             connector_type="test",
-            source_identifiers=SourceIdentifiers(
-                filename=elements_filename, fullpath=elements_filename
-            ),
+            source_identifiers=SourceIdentifiers(filename=input_filepath, fullpath=input_filepath),
         ),
         output_dir=output_dir,
         output_filename=output_filename,
     )
 
     # Assert
-    mock_get_data.assert_called_once_with(path=Path(elements_filename))
+    mock_get_data.assert_called_once_with(path=Path(input_filepath))
     assert mock_conform_dict.call_count == 2
     mock_conform_dataframe.assert_called_once()
     mock_get_output_path.assert_called_once_with(output_filename=expected, output_dir=output_dir)

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.15"  # pragma: no cover
+__version__ = "0.3.16-dev0"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/sql/snowflake.py
+++ b/unstructured_ingest/v2/processes/connectors/sql/snowflake.py
@@ -170,7 +170,7 @@ class SnowflakeUploader(SQLUploader):
                 f"{self.upload_config.record_id_key}, skipping delete"
             )
         df.replace({np.nan: None}, inplace=True)
-        self._fit_to_schema(df=df, columns=self.get_table_columns())
+        self._fit_to_schema(df=df)
 
         columns = list(df.columns)
         stmt = "INSERT INTO {table_name} ({columns}) VALUES({values})".format(

--- a/unstructured_ingest/v2/processes/connectors/sql/sql.py
+++ b/unstructured_ingest/v2/processes/connectors/sql/sql.py
@@ -310,9 +310,8 @@ class SQLUploadStager(UploadStager):
         )
         df = self.conform_dataframe(df=df)
 
-        output_filename = (
-            output_filename if Path(output_filename).suffix else f"{output_filename}.json"
-        )
+        output_filename_suffix = Path(elements_filepath).suffix
+        output_filename = f"{Path(output_filename).stem}{output_filename_suffix}"
         output_path = self.get_output_path(output_filename=output_filename, output_dir=output_dir)
 
         self.write_output(output_path=output_path, data=df.to_dict(orient="records"))

--- a/unstructured_ingest/v2/processes/connectors/sql/sql.py
+++ b/unstructured_ingest/v2/processes/connectors/sql/sql.py
@@ -310,6 +310,8 @@ class SQLUploadStager(UploadStager):
         )
         df = self.conform_dataframe(df=df)
 
+        output_file = Path(output_filename)
+        output_filename = f"{output_file.stem}.json"
         output_path = self.get_output_path(output_filename=output_filename, output_dir=output_dir)
 
         self.write_output(output_path=output_path, data=df.to_dict(orient="records"))

--- a/unstructured_ingest/v2/processes/connectors/sql/sql.py
+++ b/unstructured_ingest/v2/processes/connectors/sql/sql.py
@@ -310,8 +310,9 @@ class SQLUploadStager(UploadStager):
         )
         df = self.conform_dataframe(df=df)
 
-        output_file = Path(output_filename)
-        output_filename = f"{output_file.stem}.json"
+        output_filename = (
+            output_filename if Path(output_filename).suffix else f"{output_filename}.json"
+        )
         output_path = self.get_output_path(output_filename=output_filename, output_dir=output_dir)
 
         self.write_output(output_path=output_path, data=df.to_dict(orient="records"))


### PR DESCRIPTION
### SQL stager error

**When passed `output_filename` without a suffix it resulted in unsupported file format error. The fix adds `.json` suffix, if the filename doesn't have one already.**

NOTE: Originally discovered in stager plugin. Output filename is passed without suffix.

```sh
controller   | handle: <Handle JobInvoker.process_in_pool.<locals>._done_callback(<Task finishe...1cb266fc081')>) at /home/controller/invoker/job_invoker.py:480>
controller   | Traceback (most recent call last):
controller   |   File "/usr/lib/python3.12/asyncio/events.py", line 88, in _run
controller   |     self._context.run(self._callback, *self._args)
controller   |   File "/home/controller/invoker/job_invoker.py", line 484, in _done_callback
controller   |     fut.result()
controller   |   File "/home/controller/invoker/job_invoker.py", line 457, in process_record
controller   |     raise e
controller   |   File "/home/controller/invoker/job_invoker.py", line 451, in process_record
controller   |     await self._process_record(record=record)
controller   |   File "/home/controller/invoker/job_invoker.py", line 421, in _process_record
controller   |     res = await self.invoke_plugin(inputs=job_inputs, record_ids=[record_id])
controller   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
controller   |   File "/home/controller/invoker/job_invoker.py", line 203, in invoke_plugin
controller   |     raise PluginError(
controller   | controller.invoker.base_invoker.PluginError: PluginError: failed to invoke plugin: [ValueError] Unsupported output format: /home/data/stager/71cb266fc081
```
![Screenshot from 2025-01-17 13-52-55](https://github.com/user-attachments/assets/31f8c06a-cb9a-4775-bf54-e9bf43d104d8)


### Snowflake uploader error

**Unexpected `columns` argument was passed to `_fit_to_schema` method inside SnowflakeUploader `upload_dataframe` method.**

```sh
2025-01-17 13:34:21,438 SpawnPoolWorker-11 ERROR    Exception raised while running upload
Traceback (most recent call last):
  File "/home/marek/unstructured/unstructured-ingest/unstructured_ingest/v2/pipeline/interfaces.py", line 171, in run_async
    return await self._run_async(fn=fn, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/marek/unstructured/unstructured-ingest/unstructured_ingest/v2/pipeline/steps/upload.py", line 53, in _run_async
    fn(**fn_kwargs)
  File "/home/marek/unstructured/unstructured-ingest/unstructured_ingest/v2/processes/connectors/sql/sql.py", line 451, in run
    self.upload_dataframe(df=df, file_data=file_data)
  File "/home/marek/unstructured/unstructured-ingest/unstructured_ingest/v2/processes/connectors/sql/snowflake.py", line 173, in upload_dataframe
    self._fit_to_schema(df=df, columns=self.get_table_columns())
TypeError: SQLUploader._fit_to_schema() got an unexpected keyword argument 'columns'
```