### PR TITLE
bugfix/use columns from database to adjust data to upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-## 0.4.1-dev1
+## 0.4.1-dev2
 
 ### Enhancements
 
 * **Support img base64 in html**
 * **Fsspec support for direct URI**
+
+### Fixes
+
+* **Fix how data updated before writing to sql tables based on columns in table**
 
 ## 0.4.0
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.1-dev1"  # pragma: no cover
+__version__ = "0.4.1-dev2"  # pragma: no cover


### PR DESCRIPTION
### Description
The `_fit_to_schema` method on the sql connector base class was never taking into account the columns on the destination table. These were pulled in to drop any columns that would cause the upload to fail. 