### PR TITLE
fix(UNTRACKED): confluence and html mixin fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
-## 0.4.3-dev1
+## 0.4.3-dev2
 
 ### Enhancements
 
 * **Add support for allow list when downloading from raw html**
 * **Add support for setting up destination as part of uploader**
+
+### Fixes
+
+* **Fix HtmlMixin error when saving downloaded files**
+* **Fix Confluence Downloader error when downloading embedded files**
 
 ## 0.4.2
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.3-dev1"  # pragma: no cover
+__version__ = "0.4.3-dev2"  # pragma: no cover

--- a/unstructured_ingest/utils/html.py
+++ b/unstructured_ingest/utils/html.py
@@ -112,6 +112,8 @@ class HtmlMixin(BaseModel):
     def write_content(self, content: bytes, path: Path) -> None:
         if path.exists() and path.is_file() and not self.force_download:
             return
+        if not path.parent.exists():
+            path.parent.mkdir(parents=True)
         with path.open("wb") as f:
             f.write(content)
 

--- a/unstructured_ingest/v2/processes/connectors/confluence.py
+++ b/unstructured_ingest/v2/processes/connectors/confluence.py
@@ -196,10 +196,18 @@ class ConfluenceDownloader(Downloader):
     ) -> list[DownloadResponse]:
         if not self.download_config.extract_files:
             return []
+        url = current_file_data.metadata.url
+        if url is None:
+            logger.warning(
+                f"""Missing URL for file: {current_file_data.source_identifiers.filename}.
+                Skipping file extraction."""
+            )
+            return []
         filepath = current_file_data.source_identifiers.relative_path
         download_path = Path(self.download_dir) / filepath
         download_dir = download_path.with_suffix("")
         return self.download_config.extract_embedded_files(
+            url=url,
             download_dir=download_dir,
             original_filedata=current_file_data,
             html=html,


### PR DESCRIPTION
Confluence downloader error (occurred when trying to download embedded files):

```sh
TypeError: HtmlMixin.extract_embedded_files() missing 1 required positional argument: 'url'
```

HtmlMixin error (occurred when saving embedded files):

```sh
FileNotFoundError: [Errno 2] No such file or directory: 'downloads/confluence-out-new/~712020ddff175da68a46f2b5099b0b55fa5e4b/524291/2201.11903-6.pdf'
```
