### PR TITLE
fix onedrive connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.4
+
+### Fixes
+
+* **Fix AsyncIO support for OneDrive connector**
+
 ## 0.4.3
 
 ### Enhancements

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.3"  # pragma: no cover
+__version__ = "0.4.4"  # pragma: no cover

--- a/unstructured_ingest/v2/interfaces/indexer.py
+++ b/unstructured_ingest/v2/interfaces/indexer.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import Any, AsyncGenerator, Generator, Optional, TypeVar
 
 from pydantic import BaseModel

--- a/unstructured_ingest/v2/interfaces/indexer.py
+++ b/unstructured_ingest/v2/interfaces/indexer.py
@@ -22,9 +22,8 @@ class Indexer(BaseProcess, BaseConnector, ABC):
     def is_async(self) -> bool:
         return False
 
-    @abstractmethod
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
-        pass
+        raise NotImplementedError()
 
     async def run_async(self, **kwargs: Any) -> AsyncGenerator[FileData, None]:
         raise NotImplementedError()


### PR DESCRIPTION
The onedrive connector was using an unnecessary embedded asyncio loop that caused errors when running with fastapi.

It's not necessary. The connector can just be async.