### PR TITLE
fix downloading larger files with onedrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.5
+
+### Fixes
+
+* **Fix downloading large files for OneDrive**
+
 ## 0.4.4
 
 ### Fixes

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.4"  # pragma: no cover
+__version__ = "0.4.5"  # pragma: no cover

--- a/unstructured_ingest/v2/pipeline/pipeline.py
+++ b/unstructured_ingest/v2/pipeline/pipeline.py
@@ -203,7 +203,14 @@ class Pipeline:
 
     def get_indices(self) -> list[dict]:
         if self.indexer_step.process.is_async():
-            indices = asyncio.run(self.indexer_step.run_async())
+
+            async def run_async():
+                output = []
+                async for i in self.indexer_step.run_async():
+                    output.append(i)
+                return output
+
+            indices = asyncio.run(run_async())
         else:
             indices = self.indexer_step.run()
         indices_inputs = [{"file_data_path": i} for i in indices]

--- a/unstructured_ingest/v2/processes/connectors/onedrive.py
+++ b/unstructured_ingest/v2/processes/connectors/onedrive.py
@@ -223,7 +223,7 @@ class OnedriveDownloader(Downloader):
     download_config: OnedriveDownloaderConfig
 
     @SourceConnectionNetworkError.wrap
-    def _fetch_file(self, file_data: FileData):
+    def _fetch_file(self, file_data: FileData) -> DriveItem:
         if file_data.source_identifiers is None or not file_data.source_identifiers.fullpath:
             raise ValueError(
                 f"file data doesn't have enough information to get "
@@ -257,7 +257,7 @@ class OnedriveDownloader(Downloader):
                     file.download_session(f, chunk_size=1024 * 1024 * 100).execute_query()
             else:
                 with download_path.open(mode="wb") as f:
-                    file.download(f).execute_query()
+                    file.download_session(f).execute_query()
             return self.generate_download_response(file_data=file_data, download_path=download_path)
         except Exception as e:
             logger.error(f"[{CONNECTOR_TYPE}] Exception during downloading: {e}", exc_info=True)


### PR DESCRIPTION
Larger files would be returned as a list and throw errors like this:

```
ERROR    [onedrive] Exception during downloading: a bytes-like object is required, not 'list'                                                                                   Traceback (most recent call last):                                                                                                                                                                                    File "/usr/lib/python3.12/site-packages/unstructured_ingest/v2/processes/connectors/onedrive.py", line 284, in run                                                                                                    file.download(f).execute_query()                                                                                                                                                                                  File "/usr/lib/python3.12/site-packages/office365/runtime/client_object.py", line 55, in execute_query                                                                                                                self.context.execute_query()                                                                                                                                                                                      File "/usr/lib/python3.12/site-packages/office365/runtime/client_runtime_context.py", line 173, in execute_query                                                                                                      self.pending_request().execute_query(qry)                                                                                                                                                                         File "/usr/lib/python3.12/site-packages/office365/runtime/client_request.py", line 39, in execute_query                                                                                                               self.afterExecute.notify(response)                                                                                                                                                                                File "/usr/lib/python3.12/site-packages/office365/runtime/types/event_handler.py", line 41, in notify                                                                                                                 listener(*args, **kwargs)                                                                                                                                                                                         File "/usr/lib/python3.12/site-packages/office365/runtime/client_runtime_context.py", line 141, in _process_response                                                                                                  action(resp if include_response else query.return_type)                                                                                                                                                           File "/usr/lib/python3.12/site-packages/office365/onedrive/driveitems/driveItem.py", line 361, in _save_content                                                                                                       file_object.write(return_type.value)                                                                                                                                                                            TypeError: a bytes-like object is required, not 'list'
```