### PR TITLE
fix: Prepare for breaking change in upcoming unstructured-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 0.5.2-dev0
+## 0.5.2-dev1
 
 ### Enhancements
 
 * **Only embed elements with text** - Only embed elements with text to avoid errors from embedders and optimize calls to APIs.
+
+### Fixes
+
+* **Address forward compatibility issue in unstructured-client** - As of unstructured-client==0.30.0, the `server_url` is passed to the method rather than the client instance.
 
 ## 0.5.1
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.2-dev0"  # pragma: no cover
+__version__ = "0.5.2-dev1"  # pragma: no cover

--- a/unstructured_ingest/v2/unstructured_api.py
+++ b/unstructured_ingest/v2/unstructured_api.py
@@ -87,13 +87,16 @@ async def call_api_async(
     """
     from unstructured_client import UnstructuredClient
 
+    # Note(austin) - the sdk takes the base url, but users may pass the full endpoint
+    # For consistency, strip off the path when it's given
+    base_url = server_url[:-19] if "/general/v0/general" in server_url else server_url
+
     client = UnstructuredClient(
-        server_url=server_url,
         api_key_auth=api_key,
     )
     partition_request = create_partition_request(filename=filename, parameters_dict=api_parameters)
     try:
-        res = await client.general.partition_async(request=partition_request)
+        res = await client.general.partition_async(server_url=base_url, request=partition_request)
     except Exception as e:
         raise wrap_error(e)
 
@@ -115,13 +118,16 @@ def call_api(
     """
     from unstructured_client import UnstructuredClient
 
+    # Note(austin) - the sdk takes the base url, but users may pass the full endpoint
+    # For consistency, strip off the path when it's given
+    base_url = server_url[:-19] if "/general/v0/general" in server_url else server_url
+
     client = UnstructuredClient(
-        server_url=server_url,
         api_key_auth=api_key,
     )
     partition_request = create_partition_request(filename=filename, parameters_dict=api_parameters)
     try:
-        res = client.general.partition(request=partition_request)
+        res = client.general.partition(server_url=base_url, request=partition_request)
     except Exception as e:
         raise wrap_error(e)
 


### PR DESCRIPTION
In the unreleased 0.30.0 of `unstructured-client`, handling of the `server_url` is changing. We need to do this to integrate the platform API functions. Now, different parts of the SDK are talking to different backend services, and so it's preferred that we set the `server_url` per endpoint.

Note that for compatibility with the current version, we need to strip the `/general/v0/general` path off of the URL. We have logic to do this in the SDK, but in versions before 0.30.0 this only applies to the `server_url` passed to the client instance. So, it's a bit of a chicken and egg. Once 0.30.0 is published and pulled in this repo, we can remove these lines if we want.

Related core library fix: https://github.com/Unstructured-IO/unstructured/pull/3916