### PR TITLE
bugfix/only embed content with text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.2-dev0
+
+### Enhancements
+
+* **Only embed elements with text** - Only embed elements with text to avoid errors from embedders and optimize calls to APIs.
+
 ## 0.5.1
 
 ### Fixes

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.1"  # pragma: no cover
+__version__ = "0.5.2-dev0"  # pragma: no cover

--- a/unstructured_ingest/embed/bedrock.py
+++ b/unstructured_ingest/embed/bedrock.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, AsyncIterable
 from pydantic import Field, SecretStr
 
 from unstructured_ingest.embed.interfaces import (
+    EMBEDDINGS_KEY,
     AsyncBaseEmbeddingEncoder,
     BaseEmbeddingEncoder,
     EmbeddingConfig,
@@ -149,7 +150,7 @@ class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = [self.embed_query(query=e["text"]) for e in elements_with_text]
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
 
@@ -195,5 +196,5 @@ class AsyncBedrockEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
             *[self.embed_query(query=e.get("text", "")) for e in elements_with_text]
         )
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
-        return element
+            element[EMBEDDINGS_KEY] = embedding
+        return elements

--- a/unstructured_ingest/embed/bedrock.py
+++ b/unstructured_ingest/embed/bedrock.py
@@ -145,9 +145,12 @@ class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
             return response_body.get("embedding")
 
     def embed_documents(self, elements: list[dict]) -> list[dict]:
-        embeddings = [self.embed_query(query=e.get("text", "")) for e in elements]
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = [self.embed_query(query=e["text"]) for e in elements_with_text]
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
 
 @dataclass
@@ -186,8 +189,11 @@ class AsyncBedrockEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
             raise ValueError(f"Error raised by inference endpoint: {e}")
 
     async def embed_documents(self, elements: list[dict]) -> list[dict]:
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
         embeddings = await asyncio.gather(
-            *[self.embed_query(query=e.get("text", "")) for e in elements]
+            *[self.embed_query(query=e.get("text", "")) for e in elements_with_text]
         )
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return element

--- a/unstructured_ingest/embed/huggingface.py
+++ b/unstructured_ingest/embed/huggingface.py
@@ -3,7 +3,11 @@ from typing import TYPE_CHECKING, Optional
 
 from pydantic import Field
 
-from unstructured_ingest.embed.interfaces import BaseEmbeddingEncoder, EmbeddingConfig
+from unstructured_ingest.embed.interfaces import (
+    EMBEDDINGS_KEY,
+    BaseEmbeddingEncoder,
+    EmbeddingConfig,
+)
 from unstructured_ingest.utils.dep_check import requires_dependencies
 
 if TYPE_CHECKING:
@@ -56,5 +60,5 @@ class HuggingFaceEmbeddingEncoder(BaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = self._embed_documents([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements

--- a/unstructured_ingest/embed/huggingface.py
+++ b/unstructured_ingest/embed/huggingface.py
@@ -52,6 +52,9 @@ class HuggingFaceEmbeddingEncoder(BaseEmbeddingEncoder):
         return embeddings.tolist()
 
     def embed_documents(self, elements: list[dict]) -> list[dict]:
-        embeddings = self._embed_documents([e.get("text", "") for e in elements])
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = self._embed_documents([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements

--- a/unstructured_ingest/embed/interfaces.py
+++ b/unstructured_ingest/embed/interfaces.py
@@ -26,27 +26,6 @@ class BaseEncoder(ABC):
         if possible"""
         return e
 
-    @staticmethod
-    def _add_embeddings_to_elements(
-        elements: list[dict], embeddings: list[list[float]]
-    ) -> list[dict]:
-        """
-        Add embeddings to elements.
-
-        Args:
-            elements (list[Element]): List of elements.
-            embeddings (list[list[float]]): List of embeddings.
-
-        Returns:
-            list[Element]: Elements with embeddings added.
-        """
-        assert len(elements) == len(embeddings)
-        elements_w_embedding = []
-        for i, element in enumerate(elements):
-            element["embeddings"] = embeddings[i]
-            elements_w_embedding.append(element)
-        return elements
-
 
 @dataclass
 class BaseEmbeddingEncoder(BaseEncoder, ABC):

--- a/unstructured_ingest/embed/interfaces.py
+++ b/unstructured_ingest/embed/interfaces.py
@@ -6,6 +6,8 @@ from typing import Optional
 import numpy as np
 from pydantic import BaseModel, Field
 
+EMBEDDINGS_KEY = "embeddings"
+
 
 class EmbeddingConfig(BaseModel):
     batch_size: Optional[int] = Field(

--- a/unstructured_ingest/embed/mixedbreadai.py
+++ b/unstructured_ingest/embed/mixedbreadai.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from pydantic import Field, SecretStr
 
 from unstructured_ingest.embed.interfaces import (
+    EMBEDDINGS_KEY,
     AsyncBaseEmbeddingEncoder,
     BaseEmbeddingEncoder,
     EmbeddingConfig,
@@ -138,7 +139,7 @@ class MixedbreadAIEmbeddingEncoder(BaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = self._embed([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
     def embed_query(self, query: str) -> list[float]:
@@ -217,7 +218,7 @@ class AsyncMixedbreadAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = await self._embed([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
     async def embed_query(self, query: str) -> list[float]:

--- a/unstructured_ingest/embed/mixedbreadai.py
+++ b/unstructured_ingest/embed/mixedbreadai.py
@@ -134,8 +134,12 @@ class MixedbreadAIEmbeddingEncoder(BaseEmbeddingEncoder):
         Returns:
             list[Element]: Elements with embeddings.
         """
-        embeddings = self._embed([e.get("text", "") for e in elements])
-        return self._add_embeddings_to_elements(elements, embeddings)
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = self._embed([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
     def embed_query(self, query: str) -> list[float]:
         """
@@ -209,8 +213,12 @@ class AsyncMixedbreadAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         Returns:
             list[Element]: Elements with embeddings.
         """
-        embeddings = await self._embed([e.get("text", "") for e in elements])
-        return self._add_embeddings_to_elements(elements, embeddings)
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = await self._embed([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
     async def embed_query(self, query: str) -> list[float]:
         """

--- a/unstructured_ingest/embed/octoai.py
+++ b/unstructured_ingest/embed/octoai.py
@@ -89,7 +89,9 @@ class OctoAIEmbeddingEncoder(BaseEmbeddingEncoder):
         return response.data[0].embedding
 
     def embed_documents(self, elements: list[dict]) -> list[dict]:
-        texts = [e.get("text", "") for e in elements]
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        texts = [e["text"] for e in elements_with_text]
         embeddings = []
         client = self.config.get_client()
         try:
@@ -100,8 +102,9 @@ class OctoAIEmbeddingEncoder(BaseEmbeddingEncoder):
                 embeddings.extend([data.embedding for data in response.data])
         except Exception as e:
             raise self.wrap_error(e=e)
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
 
 @dataclass
@@ -122,7 +125,9 @@ class AsyncOctoAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         return response.data[0].embedding
 
     async def embed_documents(self, elements: list[dict]) -> list[dict]:
-        texts = [e.get("text", "") for e in elements]
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        texts = [e["text"] for e in elements_with_text]
         client = self.config.get_async_client()
         embeddings = []
         try:
@@ -133,5 +138,6 @@ class AsyncOctoAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
                 embeddings.extend([data.embedding for data in response.data])
         except Exception as e:
             raise self.wrap_error(e=e)
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements

--- a/unstructured_ingest/embed/octoai.py
+++ b/unstructured_ingest/embed/octoai.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from pydantic import Field, SecretStr
 
 from unstructured_ingest.embed.interfaces import (
+    EMBEDDINGS_KEY,
     AsyncBaseEmbeddingEncoder,
     BaseEmbeddingEncoder,
     EmbeddingConfig,
@@ -103,7 +104,7 @@ class OctoAIEmbeddingEncoder(BaseEmbeddingEncoder):
         except Exception as e:
             raise self.wrap_error(e=e)
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
 
@@ -139,5 +140,5 @@ class AsyncOctoAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         except Exception as e:
             raise self.wrap_error(e=e)
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements

--- a/unstructured_ingest/embed/openai.py
+++ b/unstructured_ingest/embed/openai.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from pydantic import Field, SecretStr
 
 from unstructured_ingest.embed.interfaces import (
+    EMBEDDINGS_KEY,
     AsyncBaseEmbeddingEncoder,
     BaseEmbeddingEncoder,
     EmbeddingConfig,
@@ -95,7 +96,7 @@ class OpenAIEmbeddingEncoder(BaseEmbeddingEncoder):
         except Exception as e:
             raise self.wrap_error(e=e)
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
 
@@ -131,5 +132,5 @@ class AsyncOpenAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         except Exception as e:
             raise self.wrap_error(e=e)
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements

--- a/unstructured_ingest/embed/openai.py
+++ b/unstructured_ingest/embed/openai.py
@@ -82,7 +82,9 @@ class OpenAIEmbeddingEncoder(BaseEmbeddingEncoder):
 
     def embed_documents(self, elements: list[dict]) -> list[dict]:
         client = self.config.get_client()
-        texts = [e.get("text", "") for e in elements]
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        texts = [e["text"] for e in elements_with_text]
         embeddings = []
         try:
             for batch in batch_generator(texts, batch_size=self.config.batch_size or len(texts)):
@@ -92,8 +94,9 @@ class OpenAIEmbeddingEncoder(BaseEmbeddingEncoder):
                 embeddings.extend([data.embedding for data in response.data])
         except Exception as e:
             raise self.wrap_error(e=e)
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
 
 @dataclass
@@ -115,7 +118,9 @@ class AsyncOpenAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
 
     async def embed_documents(self, elements: list[dict]) -> list[dict]:
         client = self.config.get_async_client()
-        texts = [e.get("text", "") for e in elements]
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        texts = [e["text"] for e in elements_with_text]
         embeddings = []
         try:
             for batch in batch_generator(texts, batch_size=self.config.batch_size or len(texts)):
@@ -125,5 +130,6 @@ class AsyncOpenAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
                 embeddings.extend([data.embedding for data in response.data])
         except Exception as e:
             raise self.wrap_error(e=e)
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements

--- a/unstructured_ingest/embed/togetherai.py
+++ b/unstructured_ingest/embed/togetherai.py
@@ -67,8 +67,12 @@ class TogetherAIEmbeddingEncoder(BaseEmbeddingEncoder):
         return self._embed_documents(elements=[query])[0]
 
     def embed_documents(self, elements: list[dict]) -> list[dict]:
-        embeddings = self._embed_documents([e.get("text", "") for e in elements])
-        return self._add_embeddings_to_elements(elements, embeddings)
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = self._embed_documents([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
     def _embed_documents(self, elements: list[str]) -> list[list[float]]:
         client = self.config.get_client()
@@ -98,8 +102,12 @@ class AsyncTogetherAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         return embedding[0]
 
     async def embed_documents(self, elements: list[dict]) -> list[dict]:
-        embeddings = await self._embed_documents([e.get("text", "") for e in elements])
-        return self._add_embeddings_to_elements(elements, embeddings)
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = await self._embed_documents([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
     async def _embed_documents(self, elements: list[str]) -> list[list[float]]:
         client = self.config.get_async_client()

--- a/unstructured_ingest/embed/togetherai.py
+++ b/unstructured_ingest/embed/togetherai.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from pydantic import Field, SecretStr
 
 from unstructured_ingest.embed.interfaces import (
+    EMBEDDINGS_KEY,
     AsyncBaseEmbeddingEncoder,
     BaseEmbeddingEncoder,
     EmbeddingConfig,
@@ -71,7 +72,7 @@ class TogetherAIEmbeddingEncoder(BaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = self._embed_documents([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
     def _embed_documents(self, elements: list[str]) -> list[list[float]]:
@@ -106,7 +107,7 @@ class AsyncTogetherAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = await self._embed_documents([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
     async def _embed_documents(self, elements: list[str]) -> list[list[float]]:

--- a/unstructured_ingest/embed/vertexai.py
+++ b/unstructured_ingest/embed/vertexai.py
@@ -75,9 +75,12 @@ class VertexAIEmbeddingEncoder(BaseEmbeddingEncoder):
         return self._embed_documents(elements=[query])[0]
 
     def embed_documents(self, elements: list[dict]) -> list[dict]:
-        embeddings = self._embed_documents([e.get("text", "") for e in elements])
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = self._embed_documents([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
     @requires_dependencies(
         ["vertexai"],
@@ -110,9 +113,12 @@ class AsyncVertexAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         return embedding[0]
 
     async def embed_documents(self, elements: list[dict]) -> list[dict]:
-        embeddings = await self._embed_documents([e.get("text", "") for e in elements])
-        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
-        return elements_with_embeddings
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = await self._embed_documents([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
     @requires_dependencies(
         ["vertexai"],

--- a/unstructured_ingest/embed/vertexai.py
+++ b/unstructured_ingest/embed/vertexai.py
@@ -9,6 +9,7 @@ from pydantic import Field, Secret, ValidationError
 from pydantic.functional_validators import BeforeValidator
 
 from unstructured_ingest.embed.interfaces import (
+    EMBEDDINGS_KEY,
     AsyncBaseEmbeddingEncoder,
     BaseEmbeddingEncoder,
     EmbeddingConfig,
@@ -79,7 +80,7 @@ class VertexAIEmbeddingEncoder(BaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = self._embed_documents([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
     @requires_dependencies(
@@ -117,7 +118,7 @@ class AsyncVertexAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = await self._embed_documents([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
     @requires_dependencies(

--- a/unstructured_ingest/embed/voyageai.py
+++ b/unstructured_ingest/embed/voyageai.py
@@ -107,8 +107,12 @@ class VoyageAIEmbeddingEncoder(BaseEmbeddingEncoder):
         return embeddings
 
     def embed_documents(self, elements: list[dict]) -> list[dict]:
-        embeddings = self._embed_documents([e.get("text", "") for e in elements])
-        return self._add_embeddings_to_elements(elements, embeddings)
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = self._embed_documents([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
     def embed_query(self, query: str) -> list[float]:
         return self._embed_documents(elements=[query])[0]
@@ -135,8 +139,12 @@ class AsyncVoyageAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         return embeddings
 
     async def embed_documents(self, elements: list[dict]) -> list[dict]:
-        embeddings = await self._embed_documents([e.get("text", "") for e in elements])
-        return self._add_embeddings_to_elements(elements, embeddings)
+        elements = elements.copy()
+        elements_with_text = [e for e in elements if e.get("text")]
+        embeddings = await self._embed_documents([e["text"] for e in elements_with_text])
+        for element, embedding in zip(elements_with_text, embeddings):
+            element["embedding"] = embedding
+        return elements
 
     async def embed_query(self, query: str) -> list[float]:
         embedding = await self._embed_documents(elements=[query])

--- a/unstructured_ingest/embed/voyageai.py
+++ b/unstructured_ingest/embed/voyageai.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 from pydantic import Field, SecretStr
 
 from unstructured_ingest.embed.interfaces import (
+    EMBEDDINGS_KEY,
     AsyncBaseEmbeddingEncoder,
     BaseEmbeddingEncoder,
     EmbeddingConfig,
@@ -111,7 +112,7 @@ class VoyageAIEmbeddingEncoder(BaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = self._embed_documents([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
     def embed_query(self, query: str) -> list[float]:
@@ -143,7 +144,7 @@ class AsyncVoyageAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
         elements_with_text = [e for e in elements if e.get("text")]
         embeddings = await self._embed_documents([e["text"] for e in elements_with_text])
         for element, embedding in zip(elements_with_text, embeddings):
-            element["embedding"] = embedding
+            element[EMBEDDINGS_KEY] = embedding
         return elements
 
     async def embed_query(self, query: str) -> list[float]:


### PR DESCRIPTION
### Description
Embedders were updated to only process elements that have text content. This avoids issues with APIs that break when sending an empty string or `None` and generally optimizes how many calls are being made to the APIs if we know ahead of time a blank text won't lead to any embeddings. 