### PR TITLE
fix: dropbox connector can now refresh token by itself

### DIFF
--- a/test_e2e/src/dropbox.sh
+++ b/test_e2e/src/dropbox.sh
@@ -24,15 +24,15 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-if [ -z "$DROPBOX_APP_KEY" ] || [ -z "$DROPBOX_APP_SECRET" ] || [ -z "$DROPBOX_REFRESH_TOKEN" ]; then
-  echo "Skipping Dropbox ingest test because one or more of these env vars is not set:"
-  echo "DROPBOX_APP_KEY, DROPBOX_APP_SECRET, DROPBOX_REFRESH_TOKEN"
-  exit 8
-fi
+#if [ -z "$DROPBOX_APP_KEY" ] || [ -z "$DROPBOX_APP_SECRET" ] || [ -z "$DROPBOX_REFRESH_TOKEN" ]; then
+#  echo "Skipping Dropbox ingest test because one or more of these env vars is not set:"
+#  echo "DROPBOX_APP_KEY, DROPBOX_APP_SECRET, DROPBOX_REFRESH_TOKEN"
+#  exit 8
+#fi
 
 # Get a new access token from Dropbox
-DROPBOX_RESPONSE=$(curl https://api.dropbox.com/oauth2/token -d refresh_token="$DROPBOX_REFRESH_TOKEN" -d grant_type=refresh_token -d client_id="$DROPBOX_APP_KEY" -d client_secret="$DROPBOX_APP_SECRET")
-DROPBOX_ACCESS_TOKEN=$(jq -r '.access_token' <<<"$DROPBOX_RESPONSE")
+#DROPBOX_RESPONSE=$(curl https://api.dropbox.com/oauth2/token -d refresh_token="$DROPBOX_REFRESH_TOKEN" -d grant_type=refresh_token -d client_id="$DROPBOX_APP_KEY" -d client_secret="$DROPBOX_APP_SECRET")
+#DROPBOX_ACCESS_TOKEN=$(jq -r '.access_token' <<<"$DROPBOX_RESPONSE")
 
 RUN_SCRIPT=${RUN_SCRIPT:-./unstructured_ingest/main.py}
 PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
@@ -47,7 +47,9 @@ PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
   --reprocess \
   --output-dir "$OUTPUT_DIR" \
   --verbose \
-  --token "$DROPBOX_ACCESS_TOKEN" \
+  --refresh_token "$DROPBOX_REFRESH_TOKEN"
+  --app_key "$DROPBOX_APP_KEY"
+  --app_secret "$DROPBOX_APP_SECRET"
   --recursive \
   --remote-url "dropbox://test-input/" \
   --work-dir "$WORK_DIR"


### PR DESCRIPTION
Dropbox connector was using only short-lived (4h) access token which for testing purposes was generated out of the long lived refresh token and user creds. Now this method is incorporated in the dropbox connector itself so we don't have to keep refreshing configuration.