### PR TITLE
improve delta table schema evolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.5.10-dev4
+## 0.5.10-dev5
 
 ### Fixes
 
 * **Dropbox connector can now use long lived refresh token and generate access token internally**
+* **Delta Tables connector can evolve schema**
 
 ## 0.5.10-dev3
 
@@ -21,7 +22,7 @@
 
 ### Features
 
-* Add auto create collection support for AstraDB destination
+* **Add auto create collection support for AstraDB destination**
 
 ### Fixes
 

--- a/test/integration/partitioners/test_partitioner.py
+++ b/test/integration/partitioners/test_partitioner.py
@@ -65,7 +65,7 @@ async def test_partitioner_api_fast_error(partition_file: Path):
     api_key = os.getenv("UNSTRUCTURED_API_KEY")
     api_url = os.getenv("UNSTRUCTURED_API_URL")
     partitioner_config = PartitionerConfig(
-        strategy="hi_res",
+        strategy="fast",
         partition_by_api=True,
         api_key=api_key,
         partition_endpoint=api_url,

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.10-dev4"  # pragma: no cover
+__version__ = "0.5.10-dev5"  # pragma: no cover

--- a/unstructured_ingest/v2/processes/connectors/delta_table.py
+++ b/unstructured_ingest/v2/processes/connectors/delta_table.py
@@ -92,7 +92,7 @@ class DeltaTableUploadStager(UploadStager):
         output_path = Path(output_dir) / Path(f"{output_filename}.parquet")
 
         df = convert_to_pandas_dataframe(elements_dict=elements_contents)
-        df = df.dropna(axis=1, how='all')
+        df = df.dropna(axis=1, how="all")
         df.to_parquet(output_path)
 
         return output_path

--- a/unstructured_ingest/v2/processes/connectors/delta_table.py
+++ b/unstructured_ingest/v2/processes/connectors/delta_table.py
@@ -92,6 +92,7 @@ class DeltaTableUploadStager(UploadStager):
         output_path = Path(output_dir) / Path(f"{output_filename}.parquet")
 
         df = convert_to_pandas_dataframe(elements_dict=elements_contents)
+        df = df.dropna(axis=1, how='all')
         df.to_parquet(output_path)
 
         return output_path
@@ -153,6 +154,7 @@ class DeltaTableUploader(Uploader):
             "table_or_uri": updated_upload_path,
             "data": df,
             "mode": "overwrite",
+            "schema_mode": "merge",
             "storage_options": storage_options,
         }
         queue = Queue()


### PR DESCRIPTION
Delta table was erroring on uploading a column with all nulls. So we remove columns with all nulls in the pandas phase.

But this caused schema mismatch so we added argument for schema merge on upload.