### PR TITLE
Fix: Add 'description' field to notion database Select property

### DIFF
--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/select.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/select.py
@@ -38,6 +38,7 @@ class Select(DBPropertyBase):
     id: str
     name: str
     select: SelectProp
+    description: Optional[str] = None
     type: str = "select"
 
     @classmethod


### PR DESCRIPTION
See https://github.com/Unstructured-IO/unstructured-ingest/issues/439

Tested this by adding this line to `/Users/<user>/Library/Python/3.9/lib/python/site-packages/unstructured_ingest` and the Notion db download error went away.