### PR TITLE
feat/enforce embedder api keys if SDK defaults to os env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.18
+
+* **Enforce api key if SDK defaults to os env var**
+
 ## 1.0.17
 
 * **Support optional API keys for embedders**

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.17"  # pragma: no cover
+__version__ = "1.0.18"  # pragma: no cover

--- a/unstructured_ingest/embed/azure_openai.py
+++ b/unstructured_ingest/embed/azure_openai.py
@@ -25,9 +25,8 @@ class AzureOpenAIEmbeddingConfig(OpenAIEmbeddingConfig):
     def get_client(self) -> "AzureOpenAI":
         from openai import AzureOpenAI
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
         return AzureOpenAI(
-            api_key=api_key,
+            api_key=self.api_key.get_secret_value(),
             api_version=self.api_version,
             azure_endpoint=self.azure_endpoint,
         )
@@ -36,9 +35,8 @@ class AzureOpenAIEmbeddingConfig(OpenAIEmbeddingConfig):
     def get_async_client(self) -> "AsyncAzureOpenAI":
         from openai import AsyncAzureOpenAI
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
         return AsyncAzureOpenAI(
-            api_key=api_key,
+            api_key=self.api_key.get_secret_value(),
             api_version=self.api_version,
             azure_endpoint=self.azure_endpoint,
         )

--- a/unstructured_ingest/embed/octoai.py
+++ b/unstructured_ingest/embed/octoai.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from pydantic import Field, SecretStr
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class OctoAiEmbeddingConfig(EmbeddingConfig):
-    api_key: Optional[SecretStr] = Field(description="API key for OctoAI", default=None)
+    api_key: SecretStr = Field(description="API key for OctoAI")
     embedder_model_name: str = Field(
         default="thenlper/gte-large", alias="model_name", description="octoai model name"
     )
@@ -77,8 +77,7 @@ class OctoAiEmbeddingConfig(EmbeddingConfig):
         """Creates an OpenAI python client to embed elements. Uses the OpenAI SDK."""
         from openai import OpenAI
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
-        return OpenAI(api_key=api_key, base_url=self.base_url)
+        return OpenAI(api_key=self.api_key.get_secret_value(), base_url=self.base_url)
 
     @requires_dependencies(
         ["openai", "tiktoken"],
@@ -88,8 +87,7 @@ class OctoAiEmbeddingConfig(EmbeddingConfig):
         """Creates an OpenAI python client to embed elements. Uses the OpenAI SDK."""
         from openai import AsyncOpenAI
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
-        return AsyncOpenAI(api_key=api_key, base_url=self.base_url)
+        return AsyncOpenAI(api_key=self.api_key.get_secret_value(), base_url=self.base_url)
 
 
 @dataclass

--- a/unstructured_ingest/embed/openai.py
+++ b/unstructured_ingest/embed/openai.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class OpenAIEmbeddingConfig(EmbeddingConfig):
-    api_key: Optional[SecretStr] = Field(description="API key for OpenAI", default=None)
+    api_key: SecretStr = Field(description="API key for OpenAI")
     embedder_model_name: str = Field(
         default="text-embedding-ada-002", alias="model_name", description="OpenAI model name"
     )
@@ -88,15 +88,13 @@ class OpenAIEmbeddingConfig(EmbeddingConfig):
     def get_client(self) -> "OpenAI":
         from openai import OpenAI
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
-        return OpenAI(api_key=api_key, base_url=self.base_url)
+        return OpenAI(api_key=self.api_key.get_secret_value(), base_url=self.base_url)
 
     @requires_dependencies(["openai"], extras="openai")
     def get_async_client(self) -> "AsyncOpenAI":
         from openai import AsyncOpenAI
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
-        return AsyncOpenAI(api_key=api_key, base_url=self.base_url)
+        return AsyncOpenAI(api_key=self.api_key.get_secret_value(), base_url=self.base_url)
 
 
 @dataclass

--- a/unstructured_ingest/embed/togetherai.py
+++ b/unstructured_ingest/embed/togetherai.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, SecretStr
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class TogetherAIEmbeddingConfig(EmbeddingConfig):
-    api_key: Optional[SecretStr] = Field(description="API key for Together AI", default=None)
+    api_key: SecretStr = Field(description="API key for Together AI")
     embedder_model_name: str = Field(
         default="togethercomputer/m2-bert-80M-8k-retrieval",
         alias="model_name",
@@ -58,15 +58,13 @@ class TogetherAIEmbeddingConfig(EmbeddingConfig):
     def get_client(self) -> "Together":
         from together import Together
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
-        return Together(api_key=api_key)
+        return Together(api_key=self.api_key.get_secret_value())
 
     @requires_dependencies(["together"], extras="togetherai")
     def get_async_client(self) -> "AsyncTogether":
         from together import AsyncTogether
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
-        return AsyncTogether(api_key=api_key)
+        return AsyncTogether(api_key=self.api_key.get_secret_value())
 
 
 @dataclass

--- a/unstructured_ingest/embed/voyageai.py
+++ b/unstructured_ingest/embed/voyageai.py
@@ -26,7 +26,7 @@ class VoyageAIEmbeddingConfig(EmbeddingConfig):
         le=128,
         description="Batch size for embedding requests. VoyageAI has a limit of 128.",
     )
-    api_key: Optional[SecretStr] = Field(description="API key for VoyageAI", default=None)
+    api_key: SecretStr = Field(description="API key for VoyageAI")
     embedder_model_name: str = Field(
         default="voyage-3", alias="model_name", description="VoyageAI model name"
     )
@@ -65,9 +65,8 @@ class VoyageAIEmbeddingConfig(EmbeddingConfig):
         """Creates a VoyageAI python client to embed elements."""
         from voyageai import Client as VoyageAIClient
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
         client = VoyageAIClient(
-            api_key=api_key,
+            api_key=self.api_key.get_secret_value(),
             max_retries=self.max_retries,
             timeout=self.timeout_in_seconds,
         )
@@ -81,9 +80,8 @@ class VoyageAIEmbeddingConfig(EmbeddingConfig):
         """Creates a VoyageAI python client to embed elements."""
         from voyageai import AsyncClient as AsyncVoyageAIClient
 
-        api_key = self.api_key.get_secret_value() if self.api_key else None
         client = AsyncVoyageAIClient(
-            api_key=api_key,
+            api_key=self.api_key.get_secret_value(),
             max_retries=self.max_retries,
             timeout=self.timeout_in_seconds,
         )


### PR DESCRIPTION
### Description
To have more control over how api keys are handled, enforce that one is passed in explicitly rather than letting the underlying SDK default to an os environment variable. 