### PR TITLE
Support optional 'description' field for all Notion db properties

### DIFF
--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/checkbox.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/checkbox.py
@@ -12,6 +12,7 @@ from unstructured_ingest.processes.connectors.notion.interfaces import DBCellBas
 class Checkbox(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "checkbox"
     checkbox: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/created_by.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/created_by.py
@@ -12,6 +12,7 @@ from unstructured_ingest.processes.connectors.notion.types.user import People
 class CreatedBy(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "created_by"
     created_by: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/created_time.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/created_time.py
@@ -11,6 +11,7 @@ from unstructured_ingest.processes.connectors.notion.interfaces import DBCellBas
 class CreatedTime(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "created_time"
     created_time: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/date.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/date.py
@@ -12,6 +12,7 @@ from unstructured_ingest.processes.connectors.notion.types.date import Date as D
 class Date(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "date"
     date: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/email.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/email.py
@@ -11,6 +11,7 @@ from unstructured_ingest.processes.connectors.notion.interfaces import DBCellBas
 class Email(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "email"
     email: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/files.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/files.py
@@ -12,6 +12,7 @@ from unstructured_ingest.processes.connectors.notion.types.file import FileObjec
 class Files(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "files"
     files: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/formula.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/formula.py
@@ -24,6 +24,7 @@ class FormulaProp(FromJSONMixin):
 class Formula(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     formula: FormulaProp
     type: str = "formula"
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/last_edited_by.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/last_edited_by.py
@@ -10,6 +10,11 @@ from unstructured_ingest.processes.connectors.notion.types.user import People
 
 @dataclass
 class LastEditedBy(DBPropertyBase):
+    id: str
+    name: str
+    description: Optional[str] = None
+    type: str = "last_edited_by"
+
     @classmethod
     def from_dict(cls, data: dict):
         return cls()

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/last_edited_time.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/last_edited_time.py
@@ -11,6 +11,7 @@ from unstructured_ingest.processes.connectors.notion.interfaces import DBCellBas
 class LastEditedTime(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "last_edited_time"
     last_edited_time: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/multiselect.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/multiselect.py
@@ -37,6 +37,7 @@ class MultiSelect(DBPropertyBase):
     id: str
     name: str
     multi_select: MultiSelectProp
+    description: Optional[str] = None
     type: str = "multi_select"
 
     @classmethod

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/number.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/number.py
@@ -25,6 +25,7 @@ class Number(DBPropertyBase):
     id: str
     name: str
     number: NumberProp
+    description: Optional[str] = None
     type: str = "number"
 
     @classmethod

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/phone_number.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/phone_number.py
@@ -11,6 +11,7 @@ from unstructured_ingest.processes.connectors.notion.interfaces import DBCellBas
 class PhoneNumber(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "phone_number"
     phone_number: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/relation.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/relation.py
@@ -44,6 +44,7 @@ class Relation(DBPropertyBase):
     id: str
     name: str
     relation: RelationProp
+    description: Optional[str] = None
     type: str = "relation"
 
     @classmethod

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/rich_text.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/rich_text.py
@@ -14,6 +14,7 @@ from unstructured_ingest.processes.connectors.notion.types.rich_text import (
 class RichText(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "rich_text"
     rich_text: dict = field(default_factory=dict)
 
@@ -27,6 +28,7 @@ class RichTextCell(DBCellBase):
     id: str
     rich_text: List[RichTextType]
     name: Optional[str] = None
+    description: Optional[str] = None
     type: str = "rich_text"
 
     @classmethod

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/rollup.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/rollup.py
@@ -29,6 +29,7 @@ class Rollup(DBPropertyBase):
     id: str
     name: str
     rollup: RollupProp
+    description: Optional[str] = None
     type: str = "rollup"
 
     @classmethod

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/status.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/status.py
@@ -54,6 +54,7 @@ class Status(DBPropertyBase):
     id: str
     name: str
     status: StatusProp
+    description: Optional[str] = None
     type: str = "status"
 
     @classmethod

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/title.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/title.py
@@ -12,6 +12,7 @@ from unstructured_ingest.processes.connectors.notion.types.rich_text import Rich
 class Title(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "title"
     title: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/unique_id.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/unique_id.py
@@ -15,6 +15,7 @@ from unstructured_ingest.processes.connectors.notion.interfaces import (
 class UniqueID(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "unique_id"
     unique_id: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/url.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/url.py
@@ -12,6 +12,7 @@ from unstructured_ingest.processes.connectors.notion.interfaces import DBCellBas
 class URL(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "url"
     url: dict = field(default_factory=dict)
 

--- a/unstructured_ingest/processes/connectors/notion/types/database_properties/verification.py
+++ b/unstructured_ingest/processes/connectors/notion/types/database_properties/verification.py
@@ -18,6 +18,7 @@ from unstructured_ingest.processes.connectors.notion.types.user import People
 class Verification(DBPropertyBase):
     id: str
     name: str
+    description: Optional[str] = None
     type: str = "verification"
     verification: dict = field(default_factory=dict)
 


### PR DESCRIPTION
Closes https://github.com/Unstructured-IO/unstructured-ingest/issues/439

TLDR: All database property objects returned by the Notion API have an optional `description` field that we are handling. Currently, when it is present the database will simply fail to sync.