### PR TITLE
Add ability to specify a SharePoint library

### DIFF
--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -51,6 +51,11 @@ class SharepointConnectionConfig(OnedriveConnectionConfig):
                     https://[tenant]-admin.sharepoint.com.\
                     This requires the app to be registered at a tenant level"
     )
+    library: Optional[str] = Field(
+        default=None,
+        description="Sharepoint library name. If not provided, the default \
+                    drive will be used.",
+    )
 
 
 class SharepointIndexerConfig(OnedriveIndexerConfig):
@@ -77,7 +82,17 @@ class SharepointIndexer(OnedriveIndexer):
         client = await asyncio.to_thread(self.connection_config.get_client)
         try:
             site = client.sites.get_by_url(self.connection_config.site).get().execute_query()
-            site_drive_item = site.drive.get().execute_query().root
+            site_drive_item = None
+            if self.connection_config.library:
+                for drive in site.drives.get().execute_query():
+                    if drive.name == self.connection_config.library:
+                        logger.info(
+                            f"Found the requested library: {self.connection_config.library}"
+                        )
+                        site_drive_item = drive.get().execute_query().root
+                        break
+            if not site_drive_item:
+                site_drive_item = site.drive.get().execute_query().root
         except ClientRequestException:
             logger.info("Site not found")
 
@@ -119,7 +134,14 @@ class SharepointDownloader(OnedriveDownloader):
 
         try:
             site = client.sites.get_by_url(self.connection_config.site).get().execute_query()
-            site_drive_item = site.drive.get().execute_query().root
+            site_drive_item = None
+            if self.connection_config.library:
+                for drive in site.drives.get().execute_query():
+                    if drive.name == self.connection_config.library:
+                        site_drive_item = drive.get().execute_query().root
+                        break
+            if not site_drive_item:
+                site_drive_item = site.drive.get().execute_query().root
         except ClientRequestException:
             logger.info("Site not found")
         file = site_drive_item.get_by_path(server_relative_path).get().execute_query()


### PR DESCRIPTION
This is a fix for #512 

This PR allows a SharePoint document library to be chosen by name as part of `SharepointConnectionConfig`.

Example usage:

```python
    Pipeline.from_configs(
        context=ProcessorConfig(),
        indexer_config=SharepointIndexerConfig(
            path=os.getenv("SHAREPOINT_SITE_PATH"),
            recursive=True,
        ),
        downloader_config=SharepointDownloaderConfig(
            download_dir=os.getenv("LOCAL_FILE_DOWNLOAD_DIR")
        ),
        source_connection_config=SharepointConnectionConfig(
            access_config=SharepointAccessConfig(
                client_cred=os.getenv("ENTRA_ID_APP_CLIENT_SECRET"),
            ),
            site=os.getenv("SHAREPOINT_SITE_URL"),
            library=os.getenv("SHAREPOINT_SITE_LIBRARY"),  # This is the library name
            client_id=os.getenv("ENTRA_ID_APP_CLIENT_ID"),
            tenant=os.getenv("ENTRA_ID_APP_TENANT_ID"),
            authority_url=os.getenv("ENTRA_ID_TOKEN_AUTHORITY_URL"),
        ),
        partitioner_config=PartitionerConfig(
            partition_by_api=False,  # Was True
            # api_key=os.getenv("UNSTRUCTURED_API_KEY"),
            # partition_endpoint=os.getenv("UNSTRUCTURED_API_URL"),
            additional_partition_args={
                "reprocess": True,
                "split_pdf_page": True,
                "split_pdf_allow_failed": True,
                "split_pdf_concurrency_level": 15,
            },
        ),
        # chunker_config=ChunkerConfig(chunking_strategy="by_title"),
        # embedder_config=EmbedderConfig(embedding_provider="huggingface"),
        # uploader_config=LocalUploaderConfig(output_dir=os.getenv("LOCAL_FILE_OUTPUT_DIR"))
    ).run()
```