### PR TITLE
Fixed model_fields attribute access warning in connector.py

### DIFF
--- a/unstructured_ingest/interfaces/connector.py
+++ b/unstructured_ingest/interfaces/connector.py
@@ -32,7 +32,7 @@ class ConnectionConfig(BaseModel):
         return self
 
     def _is_access_config_optional(self) -> bool:
-        access_config_type = self.model_fields["access_config"].annotation
+        access_config_type = self.__class__.model_fields["access_config"].annotation
         return (
             hasattr(access_config_type, "__origin__")
             and hasattr(access_config_type, "__args__")


### PR DESCRIPTION
Fixed warning about model_fields access being deprecated on Pydantic v2.11+ in connector.py by accessing it through the model class using `__class__`.

Example warning:
```
../../unstructured_ingest/interfaces/connector.py:35
PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated.
Instead, you should access this attribute from the model class.
Deprecated in Pydantic V2.11 to be removed in V3.0.
    access_config_type = self.model_fields["access_config"].annotation
```