### PR TITLE
feat: added metadata storage in dynamic fields for Milvus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.39
+
+* **Added metadata export to milvus destination connector**
+
 ## 1.0.38
 
 * **Fix pinecone serverless_region default value to be compatible with starter plans**

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -177,8 +177,7 @@ async def test_milvus_destination(
     upload_file_with_embeddings = add_fake_embeddings(upload_file, tmp_path)
     file_data = FileData(
         source_identifiers=SourceIdentifiers(
-            fullpath=upload_file_with_embeddings.name,
-            filename=upload_file_with_embeddings.name,
+            fullpath=str(upload_file), filename=upload_file.stem
         ),
         connector_type=CONNECTOR_TYPE,
         identifier="mock file data",
@@ -221,8 +220,7 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
     upload_file_with_embeddings = add_fake_embeddings(upload_file, tmp_path)
     file_data = FileData(
         source_identifiers=SourceIdentifiers(
-            fullpath=upload_file_with_embeddings.name,
-            filename=upload_file_with_embeddings.name,
+            fullpath=str(upload_file), filename=upload_file.stem
         ),
         connector_type=CONNECTOR_TYPE,
         identifier="metadata_test_file",
@@ -307,8 +305,7 @@ async def test_milvus_metadata_filtering_without_dynamic_fields(
     upload_file_with_embeddings = add_fake_embeddings(upload_file, tmp_path)
     file_data = FileData(
         source_identifiers=SourceIdentifiers(
-            fullpath=upload_file_with_embeddings.name,
-            filename=upload_file_with_embeddings.name,
+            fullpath=str(upload_file), filename=upload_file.stem
         ),
         connector_type=CONNECTOR_TYPE,
         identifier="no_dynamic_test_file",

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -115,7 +115,8 @@ def collection():
                 index_params=index_params,
             )
             print(
-                f"Created collection {COLLECTION_WITHOUT_DYNAMIC_FIELDS}: {collection_resp_no_dynamic}"
+                f"Created collection {COLLECTION_WITHOUT_DYNAMIC_FIELDS}: \
+                {collection_resp_no_dynamic}"
             )
 
             yield EXISTENT_COLLECTION_NAME
@@ -236,7 +237,8 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
 
     assert (
         len(metadata_found) > 0
-    ), f"Expected to find metadata fields in staged data. Available keys: {list(sample_element.keys())}"
+    ), f"Expected to find metadata fields in staged data.\
+   Available keys: {list(sample_element.keys())}"
     print(f"Found metadata fields: {metadata_found}")
 
     uploader.run(path=staged_filepath, file_data=file_data)
@@ -261,7 +263,8 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
 
         assert (
             len(stored_metadata) > 0
-        ), f"Expected metadata fields to be stored in Milvus. Available fields: {list(sample_result.keys())}"
+        ), f"Expected metadata fields to be stored in Milvus. \
+        Available fields: {list(sample_result.keys())}"
         print(f"Successfully stored metadata fields: {stored_metadata}")
 
         # Verify filename is specifically stored if present
@@ -319,17 +322,16 @@ async def test_milvus_metadata_filtering_without_dynamic_fields(
         )
 
         assert len(results) > 0, "Should have results from the uploaded data"
-
+        
         # Verify that only core fields are present (no metadata fields)
         sample_result = results[0]
-        core_fields = {"id", "record_id", "embeddings"}
-        present_metadata_fields = set(sample_result.keys()) & set(
-            ALLOWED_METADATA_FIELDS
+        core_fields = {'id', 'record_id', 'embeddings'}
+        
+        # The result should only contain the fields defined in the schema
+        assert set(sample_result.keys()) == core_fields, (
+            "Unexpected fields found in collection with dynamic fields disabled. "
+            f"Expected: {core_fields}, Found: {set(sample_result.keys())}"
         )
-
-        # Should have minimal or no metadata fields when dynamic fields are disabled
-        print(f"Fields present in result: {list(sample_result.keys())}")
-        print(f"Metadata fields that got through: {present_metadata_fields}")
 
 
 @pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -359,10 +359,10 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
     expected_fields = ["filename", "filetype", "languages"]
     metadata_found = [field for field in expected_fields if field in sample_element]
 
-    assert len(metadata_found) == len(
-        expected_fields
-    ), f"Expected to find metadata fields in staged data. \
-   Found: {metadata_found}, Available keys: {list(sample_element.keys())}"
+    assert len(metadata_found) == len(expected_fields), (
+        "Expected to find metadata fields in staged data. "
+        f"Found: {metadata_found}, Available keys: {list(sample_element.keys())}"
+    )
     logger.debug(f"Found metadata fields: {metadata_found}")
 
     logger.debug("Running uploader...")
@@ -398,10 +398,10 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
             if field in sample_result:
                 stored_metadata.append(field)
 
-        assert (
-            len(stored_metadata) > 0
-        ), f"Expected metadata fields to be stored in Milvus. \
-        Available fields: {list(sample_result.keys())}"
+        assert len(stored_metadata) > 0, (
+            "Expected metadata fields to be stored in Milvus. "
+            f"Available fields: {list(sample_result.keys())}"
+        )
         logger.debug(f"Successfully stored metadata fields: {stored_metadata}")
 
         # Verify filename is specifically stored if present

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -27,20 +27,23 @@ from test.integration.connectors.utils.validation.destination import (
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
 from unstructured_ingest.error import DestinationConnectionError
 from unstructured_ingest.processes.connectors.milvus import (
+    ALLOWED_METADATA_FIELDS,
     CONNECTOR_TYPE,
     MilvusConnectionConfig,
     MilvusUploader,
     MilvusUploaderConfig,
     MilvusUploadStager,
+    MilvusUploadStagerConfig,
 )
 
 DB_NAME = "test_database"
 EXISTENT_COLLECTION_NAME = "test_collection"
+COLLECTION_WITHOUT_DYNAMIC_FIELDS = "test_collection_no_dynamic"
 NONEXISTENT_COLLECTION_NAME = "nonexistent_collection"
 DB_URI = "http://localhost:19530"
 
 
-def get_schema() -> CollectionSchema:
+def get_schema(enable_dynamic_field: bool = True) -> CollectionSchema:
     id_field = FieldSchema(
         name="id", dtype=DataType.INT64, description="primary field", is_primary=True, auto_id=True
     )
@@ -48,7 +51,7 @@ def get_schema() -> CollectionSchema:
     record_id_field = FieldSchema(name="record_id", dtype=DataType.VARCHAR, max_length=64)
 
     schema = CollectionSchema(
-        enable_dynamic_field=True,
+        enable_dynamic_field=enable_dynamic_field,
         fields=[
             id_field,
             record_id_field,
@@ -82,32 +85,42 @@ def collection():
 
             print(f"Created database {DB_NAME}: {database_resp}")
 
-            # Create the collection
-            schema = get_schema()
+            # Create the collection with dynamic fields enabled
+            schema = get_schema(enable_dynamic_field=True)
             index_params = get_index_params()
             collection_resp = milvus_client.create_collection(
                 collection_name=EXISTENT_COLLECTION_NAME, schema=schema, index_params=index_params
             )
             print(f"Created collection {EXISTENT_COLLECTION_NAME}: {collection_resp}")
+
+            # Create a second collection without dynamic fields for testing
+            schema_no_dynamic = get_schema(enable_dynamic_field=False)
+            collection_resp_no_dynamic = milvus_client.create_collection(
+                collection_name=COLLECTION_WITHOUT_DYNAMIC_FIELDS, 
+                schema=schema_no_dynamic, 
+                index_params=index_params
+            )
+            print(f"Created collection {COLLECTION_WITHOUT_DYNAMIC_FIELDS}: {collection_resp_no_dynamic}")
+
             yield EXISTENT_COLLECTION_NAME
         finally:
             milvus_client.close()
 
 
-def get_count(client: MilvusClient) -> int:
+def get_count(client: MilvusClient, collection_name: str = "test_collection") -> int:
     count_field = "count(*)"
-    resp = client.query(collection_name="test_collection", output_fields=[count_field])
+    resp = client.query(collection_name=collection_name, output_fields=[count_field])
     return resp[0][count_field]
 
 
 def validate_count(
-    client: MilvusClient, expected_count: int, retries: int = 10, interval: int = 1
+    client: MilvusClient, expected_count: int, collection_name: str = "test_collection", retries: int = 10, interval: int = 1
 ) -> None:
-    current_count = get_count(client=client)
+    current_count = get_count(client=client, collection_name=collection_name)
     retry_count = 0
     while current_count != expected_count and retry_count < retries:
         time.sleep(interval)
-        current_count = get_count(client=client)
+        current_count = get_count(client=client, collection_name=collection_name)
         retry_count += 1
     assert current_count == expected_count, (
         f"Expected count ({expected_count}) doesn't match how "
@@ -152,6 +165,164 @@ async def test_milvus_destination(
     uploader.run(path=staged_filepath, file_data=file_data)
     with uploader.get_client() as client:
         validate_count(client=client, expected_count=expected_count)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+async def test_milvus_metadata_storage_with_dynamic_fields(
+    upload_file: Path,
+    collection: str,
+    tmp_path: Path,
+):
+    """Test that metadata is properly stored when dynamic fields are enabled."""
+    file_data = FileData(
+        source_identifiers=SourceIdentifiers(fullpath="test_document.pdf", filename="test_document.pdf"),
+        connector_type=CONNECTOR_TYPE,
+        identifier="metadata_test_file",
+    )
+    
+    stager = MilvusUploadStager()
+    uploader = MilvusUploader(
+        connection_config=MilvusConnectionConfig(uri=DB_URI),
+        upload_config=MilvusUploaderConfig(collection_name=collection, db_name=DB_NAME),
+    )
+    
+    # Verify dynamic fields are enabled
+    assert uploader.has_dynamic_fields_enabled(), "Collection should have dynamic fields enabled"
+    
+    staged_filepath = stager.run(
+        elements_filepath=upload_file,
+        file_data=file_data,
+        output_dir=tmp_path,
+        output_filename=upload_file.name,
+    )
+    
+    # Load staged data to check what metadata was extracted
+    with staged_filepath.open() as f:
+        staged_elements = json.load(f)
+    
+    # Verify that metadata fields are present in staged data
+    sample_element = staged_elements[0]
+    metadata_found = []
+    for field in ALLOWED_METADATA_FIELDS:
+        if field in sample_element:
+            metadata_found.append(field)
+    
+    assert len(metadata_found) > 0, f"Expected to find metadata fields in staged data. Available keys: {list(sample_element.keys())}"
+    print(f"Found metadata fields: {metadata_found}")
+    
+    uploader.run(path=staged_filepath, file_data=file_data)
+    
+    # Query the uploaded data to verify metadata was stored
+    with uploader.get_client() as client:
+        # Query with specific record ID
+        results = client.query(
+            collection_name=collection,
+            filter=f'record_id == "{file_data.identifier}"',
+            output_fields=["*"]  # Get all fields including dynamic fields
+        )
+        
+        assert len(results) > 0, "Should have results from the uploaded data"
+        
+        # Check that metadata fields are present in the results
+        sample_result = results[0]
+        stored_metadata = []
+        for field in metadata_found:
+            if field in sample_result:
+                stored_metadata.append(field)
+        
+        assert len(stored_metadata) > 0, f"Expected metadata fields to be stored in Milvus. Available fields: {list(sample_result.keys())}"
+        print(f"Successfully stored metadata fields: {stored_metadata}")
+        
+        # Verify filename is specifically stored if present
+        if "filename" in stored_metadata:
+            assert sample_result["filename"] == "test_document.pdf", "Filename should be correctly stored"
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+async def test_milvus_metadata_filtering_without_dynamic_fields(
+    upload_file: Path,
+    collection: str,
+    tmp_path: Path,
+):
+    """Test that metadata is properly filtered when dynamic fields are not enabled."""
+    file_data = FileData(
+        source_identifiers=SourceIdentifiers(fullpath="test_document.pdf", filename="test_document.pdf"),
+        connector_type=CONNECTOR_TYPE,
+        identifier="no_dynamic_test_file",
+    )
+    
+    stager = MilvusUploadStager()
+    uploader = MilvusUploader(
+        connection_config=MilvusConnectionConfig(uri=DB_URI),
+        upload_config=MilvusUploaderConfig(collection_name=COLLECTION_WITHOUT_DYNAMIC_FIELDS, db_name=DB_NAME),
+    )
+    
+    # Verify dynamic fields are NOT enabled
+    assert not uploader.has_dynamic_fields_enabled(), "Collection should NOT have dynamic fields enabled"
+    
+    staged_filepath = stager.run(
+        elements_filepath=upload_file,
+        file_data=file_data,
+        output_dir=tmp_path,
+        output_filename=upload_file.name,
+    )
+    
+    # This should not raise an error even though metadata fields are present in staged data
+    uploader.run(path=staged_filepath, file_data=file_data)
+    
+    # Verify data was uploaded successfully
+    with uploader.get_client() as client:
+        results = client.query(
+            collection_name=COLLECTION_WITHOUT_DYNAMIC_FIELDS,
+            filter=f'record_id == "{file_data.identifier}"',
+            output_fields=["*"]
+        )
+        
+        assert len(results) > 0, "Should have results from the uploaded data"
+        
+        # Verify that only core fields are present (no metadata fields)
+        sample_result = results[0]
+        core_fields = {'id', 'record_id', 'embeddings'}
+        present_metadata_fields = set(sample_result.keys()) & set(ALLOWED_METADATA_FIELDS)
+        
+        # Should have minimal or no metadata fields when dynamic fields are disabled
+        print(f"Fields present in result: {list(sample_result.keys())}")
+        print(f"Metadata fields that got through: {present_metadata_fields}")
+
+
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+def test_dynamic_fields_detection(collection: str):
+    """Test that dynamic field detection works correctly."""
+    # Test with dynamic fields enabled
+    uploader_with_dynamic = MilvusUploader(
+        connection_config=MilvusConnectionConfig(uri=DB_URI),
+        upload_config=MilvusUploaderConfig(db_name=DB_NAME, collection_name=collection),
+    )
+    assert uploader_with_dynamic.has_dynamic_fields_enabled(), "Should detect dynamic fields are enabled"
+    
+    # Test with dynamic fields disabled
+    uploader_without_dynamic = MilvusUploader(
+        connection_config=MilvusConnectionConfig(uri=DB_URI),
+        upload_config=MilvusUploaderConfig(db_name=DB_NAME, collection_name=COLLECTION_WITHOUT_DYNAMIC_FIELDS),
+    )
+    assert not uploader_without_dynamic.has_dynamic_fields_enabled(), "Should detect dynamic fields are disabled"
+
+
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+def test_metadata_fields_configuration():
+    """Test that metadata fields can be configured in the stager."""
+    # Test default metadata fields
+    stager_default = MilvusUploadStager()
+    assert stager_default.upload_stager_config.metadata_fields == list(ALLOWED_METADATA_FIELDS)
+    
+    # Test custom metadata fields
+    custom_fields = ["filename", "page_number"]
+    stager_custom = MilvusUploadStager(
+        upload_stager_config=MilvusUploadStagerConfig(metadata_fields=custom_fields)
+    )
+    assert stager_custom.upload_stager_config.metadata_fields == custom_fields
 
 
 @pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -292,7 +292,7 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
         # Verify filename is specifically stored if present
         if "filename" in stored_metadata:
             assert (
-                sample_result["filename"] == upload_file.name
+                sample_result["filename"] == upload_file.stem
             ), "Filename should be correctly stored"
 
 

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -34,7 +34,6 @@ from unstructured_ingest.processes.connectors.milvus import (
     MilvusUploader,
     MilvusUploaderConfig,
     MilvusUploadStager,
-    MilvusUploadStagerConfig,
 )
 
 logger = logging.getLogger(__name__)

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import time
 from pathlib import Path
 
@@ -36,6 +37,8 @@ from unstructured_ingest.processes.connectors.milvus import (
     MilvusUploadStager,
     MilvusUploadStagerConfig,
 )
+
+logger = logging.getLogger(__name__)
 
 DB_NAME = "test_database"
 EXISTENT_COLLECTION_NAME = "test_collection"
@@ -132,7 +135,7 @@ def collection():
                 database_resp = milvus_client._get_connection().create_database(
                     db_name=DB_NAME,
                 )
-                print(f"Created database {DB_NAME}: {database_resp}")
+                logger.debug(f"Created database {DB_NAME}: {database_resp}")
             milvus_client.using_database(db_name=DB_NAME)
 
             # Create the collection with dynamic fields enabled
@@ -145,12 +148,12 @@ def collection():
                 schema=schema,
                 index_params=index_params,
             )
-            print(f"Created collection {EXISTENT_COLLECTION_NAME}: {collection_resp}")
+            logger.debug(f"Created collection {EXISTENT_COLLECTION_NAME}: {collection_resp}")
             desc_dynamic = milvus_client.describe_collection(
                 collection_name=EXISTENT_COLLECTION_NAME,
             )
-            print(f"Post-creation description for '{EXISTENT_COLLECTION_NAME}':")
-            print(json.dumps(desc_dynamic, indent=2, cls=NpEncoder))
+            logger.debug(f"Post-creation description for '{EXISTENT_COLLECTION_NAME}':")
+            logger.debug(json.dumps(desc_dynamic, indent=2, cls=NpEncoder))
 
             # Create a second collection without dynamic fields for testing
             schema_no_dynamic = get_schema(enable_dynamic_field=False)
@@ -165,15 +168,15 @@ def collection():
                 schema=schema_no_dynamic,
                 index_params=index_params,
             )
-            print(
+            logger.debug(
                 f"Created collection {COLLECTION_WITHOUT_DYNAMIC_FIELDS}: "
                 f"{collection_resp_no_dynamic}",
             )
             desc_no_dynamic = milvus_client.describe_collection(
                 collection_name=COLLECTION_WITHOUT_DYNAMIC_FIELDS,
             )
-            print(f"Post-creation description for '{COLLECTION_WITHOUT_DYNAMIC_FIELDS}':")
-            print(json.dumps(desc_no_dynamic, indent=2, cls=NpEncoder))
+            logger.debug(f"Post-creation description for '{COLLECTION_WITHOUT_DYNAMIC_FIELDS}':")
+            logger.debug(json.dumps(desc_no_dynamic, indent=2, cls=NpEncoder))
 
             yield EXISTENT_COLLECTION_NAME
         finally:
@@ -212,7 +215,7 @@ async def test_milvus_destination(
     collection: str,
     tmp_path: Path,
 ):
-    print("\n--- Running test_milvus_destination ---")
+    logger.debug("\n--- Running test_milvus_destination ---")
     upload_file_with_embeddings = add_fake_embeddings(upload_file, tmp_path)
     file_data = FileData(
         source_identifiers=SourceIdentifiers(
@@ -234,32 +237,32 @@ async def test_milvus_destination(
     )
     with staged_filepath.open() as f:
         staged_elements = json.load(f)
-    print(f"Number of staged elements: {len(staged_elements)}")
+    logger.debug(f"Number of staged elements: {len(staged_elements)}")
     if staged_elements:
-        print("Sample staged element for test_milvus_destination:")
-        print(json.dumps(get_printable_sample(staged_elements[0]), indent=2))
+        logger.debug("Sample staged element for test_milvus_destination:")
+        logger.debug(json.dumps(get_printable_sample(staged_elements[0]), indent=2))
     uploader.precheck()
-    print("Running uploader for the first time...")
+    logger.debug("Running uploader for the first time...")
     uploader.run(path=staged_filepath, file_data=file_data)
-    print("First uploader run finished.")
+    logger.debug("First uploader run finished.")
 
     # Run validation
     with staged_filepath.open() as f:
         staged_elements = json.load(f)
     expected_count = len(staged_elements)
     with uploader.get_client() as client:
-        print(f"Validating count, expecting: {expected_count}")
+        logger.debug(f"Validating count, expecting: {expected_count}")
         validate_count(client=client, expected_count=expected_count)
-        print("Count validation successful.")
+        logger.debug("Count validation successful.")
 
     # Rerun and make sure the same documents get updated
-    print("Running uploader for the second time (rerun)...")
+    logger.debug("Running uploader for the second time (rerun)...")
     uploader.run(path=staged_filepath, file_data=file_data)
-    print("Second uploader run finished.")
+    logger.debug("Second uploader run finished.")
     with uploader.get_client() as client:
-        print(f"Validating count on rerun, expecting: {expected_count}")
+        logger.debug(f"Validating count on rerun, expecting: {expected_count}")
         validate_count(client=client, expected_count=expected_count)
-        print("Count validation on rerun successful.")
+        logger.debug("Count validation on rerun successful.")
 
 
 @pytest.mark.asyncio
@@ -270,7 +273,7 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
     tmp_path: Path,
 ):
     """Test that metadata is properly stored when dynamic fields are enabled."""
-    print("\n--- Running test_milvus_metadata_storage_with_dynamic_fields ---")
+    logger.debug("\n--- Running test_milvus_metadata_storage_with_dynamic_fields ---")
     upload_file_with_embeddings = add_fake_embeddings(upload_file, tmp_path)
     file_data = FileData(
         source_identifiers=SourceIdentifiers(
@@ -301,10 +304,10 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
     # Load staged data to check what metadata was extracted
     with staged_filepath.open() as f:
         staged_elements = json.load(f)
-    print(f"Number of staged elements: {len(staged_elements)}")
+    logger.debug(f"Number of staged elements: {len(staged_elements)}")
     if staged_elements:
-        print("Sample staged element before upload:")
-        print(json.dumps(get_printable_sample(staged_elements[0]), indent=2))
+        logger.debug("Sample staged element before upload:")
+        logger.debug(json.dumps(get_printable_sample(staged_elements[0]), indent=2))
 
     # Verify that metadata fields are present in staged data
     sample_element = staged_elements[0]
@@ -317,25 +320,25 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
         len(metadata_found) > 0
     ), f"Expected to find metadata fields in staged data.\
    Available keys: {list(sample_element.keys())}"
-    print(f"Found metadata fields: {metadata_found}")
+    logger.debug(f"Found metadata fields: {metadata_found}")
 
-    print("Running uploader...")
+    logger.debug("Running uploader...")
     uploader.run(path=staged_filepath, file_data=file_data)
-    print("Uploader finished.")
+    logger.debug("Uploader finished.")
 
     # Query the uploaded data to verify metadata was stored
     with uploader.get_client() as client:
         # Query with specific record ID
-        print(f"Querying collection '{collection}' for record_id '{file_data.identifier}'")
+        logger.debug(f"Querying collection '{collection}' for record_id '{file_data.identifier}'")
         results = client.query(
             collection_name=collection,
             filter=f'record_id == "{file_data.identifier}"',
             output_fields=["*"],  # Get all fields including dynamic fields
         )
-        print(f"Query returned {len(results)} results.")
+        logger.debug(f"Query returned {len(results)} results.")
         if results:
-            print("Sample query result:")
-            print(json.dumps(get_printable_sample(results[0]), indent=2, cls=NpEncoder))
+            logger.debug("Sample query result:")
+            logger.debug(json.dumps(get_printable_sample(results[0]), indent=2, cls=NpEncoder))
 
         assert len(results) > 0, "Should have results from the uploaded data"
 
@@ -350,7 +353,7 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
             len(stored_metadata) > 0
         ), f"Expected metadata fields to be stored in Milvus. \
         Available fields: {list(sample_result.keys())}"
-        print(f"Successfully stored metadata fields: {stored_metadata}")
+        logger.debug(f"Successfully stored metadata fields: {stored_metadata}")
 
         # Verify filename is specifically stored if present
         if "filename" in stored_metadata:
@@ -367,7 +370,7 @@ async def test_milvus_metadata_filtering_without_dynamic_fields(
     tmp_path: Path,
 ):
     """Test that metadata is properly filtered when dynamic fields are not enabled."""
-    print("\n--- Running test_milvus_metadata_filtering_without_dynamic_fields ---")
+    logger.debug("\n--- Running test_milvus_metadata_filtering_without_dynamic_fields ---")
     upload_file_with_embeddings = add_fake_embeddings(upload_file, tmp_path)
     file_data = FileData(
         source_identifiers=SourceIdentifiers(
@@ -399,19 +402,19 @@ async def test_milvus_metadata_filtering_without_dynamic_fields(
 
     with staged_filepath.open() as f:
         staged_elements = json.load(f)
-    print(f"Number of staged elements: {len(staged_elements)}")
+    logger.debug(f"Number of staged elements: {len(staged_elements)}")
     if staged_elements:
-        print("Sample staged element before upload:")
-        print(json.dumps(get_printable_sample(staged_elements[0]), indent=2))
+        logger.debug("Sample staged element before upload:")
+        logger.debug(json.dumps(get_printable_sample(staged_elements[0]), indent=2))
 
     # This should not raise an error even though metadata fields are present in staged data
-    print("Running uploader...")
+    logger.debug("Running uploader...")
     uploader.run(path=staged_filepath, file_data=file_data)
-    print("Uploader finished.")
+    logger.debug("Uploader finished.")
 
     # Verify data was uploaded successfully
     with uploader.get_client() as client:
-        print(
+        logger.debug(
             f"Querying collection '{COLLECTION_WITHOUT_DYNAMIC_FIELDS}' "
             f"for record_id '{file_data.identifier}'"
         )
@@ -421,10 +424,10 @@ async def test_milvus_metadata_filtering_without_dynamic_fields(
             output_fields=["*"],
         )
 
-        print(f"Query returned {len(results)} results.")
+        logger.debug(f"Query returned {len(results)} results.")
         if results:
-            print("Sample query result:")
-            print(json.dumps(get_printable_sample(results[0]), indent=2, cls=NpEncoder))
+            logger.debug("Sample query result:")
+            logger.debug(json.dumps(get_printable_sample(results[0]), indent=2, cls=NpEncoder))
         assert len(results) > 0, "Should have results from the uploaded data"
 
         # Verify that only core fields are present (no metadata fields)

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -200,7 +200,7 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
     """Test that metadata is properly stored when dynamic fields are enabled."""
     file_data = FileData(
         source_identifiers=SourceIdentifiers(
-            fullpath="test_document.pdf", filename="test_document.pdf"
+            fullpath=upload_file.name, filename=upload_file.name
         ),
         connector_type=CONNECTOR_TYPE,
         identifier="metadata_test_file",
@@ -270,7 +270,7 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
         # Verify filename is specifically stored if present
         if "filename" in stored_metadata:
             assert (
-                sample_result["filename"] == "test_document.pdf"
+                sample_result["filename"] == upload_file.name
             ), "Filename should be correctly stored"
 
 
@@ -284,7 +284,7 @@ async def test_milvus_metadata_filtering_without_dynamic_fields(
     """Test that metadata is properly filtered when dynamic fields are not enabled."""
     file_data = FileData(
         source_identifiers=SourceIdentifiers(
-            fullpath="test_document.pdf", filename="test_document.pdf"
+            fullpath=upload_file.name, filename=upload_file.name
         ),
         connector_type=CONNECTOR_TYPE,
         identifier="no_dynamic_test_file",

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -29,7 +29,6 @@ from test.integration.connectors.utils.validation.destination import (
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
 from unstructured_ingest.error import DestinationConnectionError
 from unstructured_ingest.processes.connectors.milvus import (
-    ALLOWED_METADATA_FIELDS,
     CONNECTOR_TYPE,
     MilvusConnectionConfig,
     MilvusUploader,
@@ -358,15 +357,13 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
 
     # Verify that metadata fields are present in staged data
     sample_element = staged_elements[0]
-    metadata_found = []
-    for field in ALLOWED_METADATA_FIELDS:
-        if field in sample_element:
-            metadata_found.append(field)
+    expected_fields = ["filename", "filetype", "languages"]
+    metadata_found = [field for field in expected_fields if field in sample_element]
 
-    assert (
-        len(metadata_found) > 0
-    ), f"Expected to find metadata fields in staged data.\
-   Available keys: {list(sample_element.keys())}"
+    assert len(metadata_found) == len(
+        expected_fields
+    ), f"Expected to find metadata fields in staged data. \
+   Found: {metadata_found}, Available keys: {list(sample_element.keys())}"
     logger.debug(f"Found metadata fields: {metadata_found}")
 
     logger.debug("Running uploader...")
@@ -522,23 +519,6 @@ def test_dynamic_fields_detection(collection: str):
     assert (
         not uploader_without_dynamic.has_dynamic_fields_enabled()
     ), "Should detect dynamic fields are disabled"
-
-
-@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
-def test_metadata_fields_configuration():
-    """Test that metadata fields can be configured in the stager."""
-    # Test default metadata fields
-    stager_default = MilvusUploadStager()
-    assert stager_default.upload_stager_config.metadata_fields == list(
-        ALLOWED_METADATA_FIELDS
-    )
-
-    # Test custom metadata fields
-    custom_fields = ["filename", "page_number"]
-    stager_custom = MilvusUploadStager(
-        upload_stager_config=MilvusUploadStagerConfig(metadata_fields=custom_fields)
-    )
-    assert stager_custom.upload_stager_config.metadata_fields == custom_fields
 
 
 @pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -337,7 +337,7 @@ async def test_milvus_metadata_storage_with_dynamic_fields(
         # Verify filename is specifically stored if present
         if "filename" in stored_metadata:
             assert (
-                sample_result["filename"] == upload_file.stem
+                sample_result["filename"] == upload_file.name
             ), "Filename should be correctly stored"
 
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.38"  # pragma: no cover
+__version__ = "1.0.39"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -167,6 +167,10 @@ class MilvusUploadStager(UploadStager):
         # (will be stored in dynamic fields if supported)
         working_data.update(flattened_metadata)
 
+        # Overwrite filename from file_data, this ensures the one from the source connector is used
+        if file_data.source_identifiers.filename:
+            working_data["filename"] = file_data.source_identifiers.filename
+
         # TODO: milvus sdk doesn't seem to support defaults via the schema yet,
         #  remove once that gets updated
         defaults = {"is_continuation": False}

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -105,7 +105,7 @@ class MilvusUploadStager(UploadStager):
             flattened_metadata = flatten_dict(
                 metadata,
                 separator="_",
-                flatten_lists=True,
+                flatten_lists=False,
                 remove_none=True,
             )
             working_data.update(flattened_metadata)

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -156,7 +156,11 @@ class MilvusUploadStager(UploadStager):
         # Apply the original flatten_metadata logic first
         if self.upload_stager_config.flatten_metadata and metadata:
             working_data.update(
-                flatten_dict(metadata, keys_to_omit=["data_source_record_locator"])
+                flatten_dict(
+                    metadata,
+                    keys_to_omit=["data_source_record_locator"],
+                    remove_none=True,
+                )
             )
 
         # Add the extracted metadata as separate fields

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -190,7 +190,7 @@ class MilvusUploadStager(UploadStager):
             "last_modified",
         ]
 
-        json_dumps_fields = ["data_source_permissions_data"]
+        json_dumps_fields = ["languages", "data_source_permissions_data"]
 
         for datetime_column in datetime_columns:
             if datetime_column in working_data:
@@ -309,6 +309,19 @@ class MilvusUploader(Uploader):
 
         # Check if collection supports dynamic fields
         dynamic_fields_enabled = self.has_dynamic_fields_enabled()
+
+        # If dynamic fields are enabled, 'languages' field needs to be a list
+        if dynamic_fields_enabled:
+            logger.info("Dynamic fields enabled, ensuring 'languages' field is a list.")
+            for item in data:
+                if "languages" in item and isinstance(item["languages"], str):
+                    try:
+                        item["languages"] = json.loads(item["languages"])
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning(
+                            f"Could not JSON decode languages field: {item['languages']}. "
+                            "Leaving as string.",
+                        )
 
         # If dynamic fields are not enabled, we need to filter out the metadata fields
         # to avoid insertion errors for fields not defined in the schema

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -167,10 +167,6 @@ class MilvusUploadStager(UploadStager):
         # (will be stored in dynamic fields if supported)
         working_data.update(flattened_metadata)
 
-        # Overwrite filename from file_data, this ensures the one from the source connector is used
-        if file_data.source_identifiers.filename:
-            working_data["filename"] = file_data.source_identifiers.filename
-
         # TODO: milvus sdk doesn't seem to support defaults via the schema yet,
         #  remove once that gets updated
         defaults = {"is_continuation": False}

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -128,8 +128,8 @@ class MilvusUploadStager(UploadStager):
         working_data = element_dict.copy()
 
         # Check if we should extract metadata for dynamic fields
-        # We'll extract metadata similar to Pinecone, but only include it if dynamic fields are supported
-        embeddings = working_data.pop("embeddings", None)
+        # We'll extract metadata similar to Pinecone
+        # but only include it if dynamic fields are supported
         metadata: dict[str, Any] = working_data.pop("metadata", {})
         data_source = metadata.pop("data_source", {})
         coordinates = metadata.pop("coordinates", {})
@@ -159,7 +159,8 @@ class MilvusUploadStager(UploadStager):
                 flatten_dict(metadata, keys_to_omit=["data_source_record_locator"])
             )
 
-        # Add the extracted metadata as separate fields (will be stored in dynamic fields if supported)
+        # Add the extracted metadata as separate fields
+        # (will be stored in dynamic fields if supported)
         working_data.update(flattened_metadata)
 
         # TODO: milvus sdk doesn't seem to support defaults via the schema yet,
@@ -254,11 +255,13 @@ class MilvusUploader(Uploader):
                 dynamic_fields_enabled = self.has_dynamic_fields_enabled()
                 if dynamic_fields_enabled:
                     logger.info(
-                        f"Collection '{self.upload_config.collection_name}' has dynamic fields enabled - metadata will be stored"
+                        f"Collection '{self.upload_config.collection_name}' \
+                       has dynamic fields enabled - metadata will be stored"
                     )
                 else:
                     logger.info(
-                        f"Collection '{self.upload_config.collection_name}' does not have dynamic fields enabled - metadata will not be stored"
+                        f"Collection '{self.upload_config.collection_name}' \
+                        does not have dynamic fields enabled - metadata will not be stored"
                     )
 
         except MilvusException as milvus_exception:
@@ -319,7 +322,7 @@ class MilvusUploader(Uploader):
                     # but typically include id, embeddings, record_id, and basic document fields
                     if (
                         key in ["id", "embeddings", "vector", RECORD_ID_LABEL]
-                        or not key in ALLOWED_METADATA_FIELDS
+                        or key not in ALLOWED_METADATA_FIELDS
                     ):
                         filtered_item[key] = value
                 filtered_data.append(filtered_item)

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -190,7 +190,7 @@ class MilvusUploadStager(UploadStager):
             "last_modified",
         ]
 
-        json_dumps_fields = ["languages", "data_source_permissions_data"]
+        json_dumps_fields = ["data_source_permissions_data"]
 
         for datetime_column in datetime_columns:
             if datetime_column in working_data:

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generator, Optional, Union
+from typing import TYPE_CHECKING, Any, Generator, Optional
 
 from dateutil import parser
 from pydantic import Field, Secret


### PR DESCRIPTION
Added tests for dynamic field usage and metadata storage in Milvus connector.
Now all the metadata in files should go into dynamic filed in a collection if it's available. If it's not we omit saving it. 
Previously it wasn't saved at all.