### PR TITLE
fix: confluence page limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.42
+
+* **Fix document limits in Confluence connectr**
+
 ## 1.0.41
 
 * **Add `display_name` to FileData in 14 connectors**

--- a/test/integration/connectors/expected_results/confluence_limit/directory_structure.json
+++ b/test/integration/connectors/expected_results/confluence_limit/directory_structure.json
@@ -1,0 +1,5 @@
+{
+  "directory_structure": [
+    "testteamsp/1605859.html"
+  ]
+}

--- a/test/integration/connectors/expected_results/confluence_limit/downloads/testteamsp/1605859.html
+++ b/test/integration/connectors/expected_results/confluence_limit/downloads/testteamsp/1605859.html
@@ -1,0 +1,342 @@
+<body class="Document">
+ <h1>
+  test-teamspace
+ </h1>
+ <div class="contentLayout2">
+  <style>
+   [data-colorid=j7phth29td]{color:#97a0af} html[data-color-mode=dark] [data-colorid=j7phth29td]{color:#505968}[data-colorid=htm243wmel]{color:#97a0af} html[data-color-mode=dark] [data-colorid=htm243wmel]{color:#505968}[data-colorid=wsl4oz52yz]{color:#97a0af} html[data-color-mode=dark] [data-colorid=wsl4oz52yz]{color:#505968}[data-colorid=fadpol2ynl]{color:#97a0af} html[data-color-mode=dark] [data-colorid=fadpol2ynl]{color:#505968}[data-colorid=di6nl9qucy]{color:#97a0af} html[data-color-mode=dark] [data-colorid=di6nl9qucy]{color:#505968}[data-colorid=ls8nhdq6go]{color:#97a0af} html[data-color-mode=dark] [data-colorid=ls8nhdq6go]{color:#505968}[data-colorid=dtxe331c1x]{color:#97a0af} html[data-color-mode=dark] [data-colorid=dtxe331c1x]{color:#505968}[data-colorid=i0nz31fuk1]{color:#97a0af} html[data-color-mode=dark] [data-colorid=i0nz31fuk1]{color:#505968}[data-colorid=o2k2vt8ga3]{color:#97a0af} html[data-color-mode=dark] [data-colorid=o2k2vt8ga3]{color:#505968}[data-colorid=k7yo7jx0nd]{color:#97a0af} html[data-color-mode=dark] [data-colorid=k7yo7jx0nd]{color:#505968}[data-colorid=uw2cbbjt91]{color:#97a0af} html[data-color-mode=dark] [data-colorid=uw2cbbjt91]{color:#505968}[data-colorid=oy1hqksoab]{color:#97a0af} html[data-color-mode=dark] [data-colorid=oy1hqksoab]{color:#505968}[data-colorid=b5t1vk6voa]{color:#97a0af} html[data-color-mode=dark] [data-colorid=b5t1vk6voa]{color:#505968}[data-colorid=xe99wphqp3]{color:#97a0af} html[data-color-mode=dark] [data-colorid=xe99wphqp3]{color:#505968}[data-colorid=uzd00gx0g8]{color:#97a0af} html[data-color-mode=dark] [data-colorid=uzd00gx0g8]{color:#505968}[data-colorid=kh4blwq9sv]{color:#97a0af} html[data-color-mode=dark] [data-colorid=kh4blwq9sv]{color:#505968}[data-colorid=pgcm6io2mx]{color:#97a0af} html[data-color-mode=dark] [data-colorid=pgcm6io2mx]{color:#505968}[data-colorid=p1lpa9j52o]{color:#97a0af} html[data-color-mode=dark] [data-colorid=p1lpa9j52o]{color:#505968}[data-colorid=k8lomjnanq]{color:#97a0af} html[data-color-mode=dark] [data-colorid=k8lomjnanq]{color:#505968}[data-colorid=xhi2t0emka]{color:#97a0af} html[data-color-mode=dark] [data-colorid=xhi2t0emka]{color:#505968}[data-colorid=t46c5qbf9i]{color:#97a0af} html[data-color-mode=dark] [data-colorid=t46c5qbf9i]{color:#505968}[data-colorid=o41kkbuwsr]{color:#97a0af} html[data-color-mode=dark] [data-colorid=o41kkbuwsr]{color:#505968}
+  </style>
+  <div class="columnLayout fixed-width" data-layout="fixed-width">
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <div class="panel conf-macro output-block" data-hasbody="true" data-macro-id="d4bd1072-559d-4244-8678-3dde858a9261" data-macro-name="panel" style="background-color: #FFF0B3;border-width: 1px;">
+      <div class="panelContent" style="background-color: #FFF0B3;">
+       <h2 id="test-teamspace-Welcometoyourteamspace!">
+        Welcome to your team space!
+       </h2>
+       <ul>
+        <li>
+         <p>
+          We've added some suggestions and placeholders. Everything is customizable.
+         </p>
+        </li>
+        <li>
+         <p>
+          Get started with page templates:
+         </p>
+         <ul>
+          <li>
+           <p>
+            <a data-linked-resource-id="1540126" data-linked-resource-type="page" data-linked-resource-version="1" href="/wiki/spaces/MFS/pages/1540126/Template+-+Project+plan">
+             Template - Project plan
+            </a>
+           </p>
+          </li>
+          <li>
+           <p>
+            <a data-linked-resource-id="1605928" data-linked-resource-type="page" data-linked-resource-version="1" href="/wiki/spaces/MFS/pages/1605928/Template+-+Meeting+notes">
+             Template - Meeting notes
+            </a>
+           </p>
+          </li>
+          <li>
+           <p>
+            <a data-linked-resource-id="1605942" data-linked-resource-type="page" data-linked-resource-version="1" href="/wiki/spaces/MFS/pages/1605942/Template+-+Weekly+status+report">
+             Template - Weekly status report
+            </a>
+           </p>
+          </li>
+         </ul>
+        </li>
+        <li>
+         <p>
+          Check out
+          <a data-linked-resource-id="1605956" data-linked-resource-type="page" data-linked-resource-version="1" href="/wiki/spaces/MFS/pages/1605956/Get+the+most+out+of+your+team+space">
+           Get the most out of your team space
+          </a>
+          for more tips.
+         </p>
+        </li>
+       </ul>
+      </div>
+     </div>
+     <p>
+     </p>
+     <h3 id="test-teamspace-About">
+      About
+     </h3>
+     <p>
+      <em>
+       <span data-colorid="i0nz31fuk1">
+        What is your team all about?
+       </span>
+      </em>
+     </p>
+     <h3 id="test-teamspace-Missionandvision">
+      Mission and vision
+     </h3>
+     <p>
+      <em>
+       <span data-colorid="xe99wphqp3">
+        What is your team's mission? What is your vision?
+       </span>
+      </em>
+     </p>
+     <h3 id="test-teamspace-Meettheteam">
+      Meet the team
+     </h3>
+     <p>
+      <em>
+       <span data-colorid="ls8nhdq6go">
+        Add team members to your space.
+       </span>
+      </em>
+     </p>
+    </div>
+   </div>
+  </div>
+  <div class="columnLayout three-equal" data-layout="three-equal">
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <span class="confluence-embedded-file-wrapper image-center-wrapper confluence-embedded-manual-size">
+      <img class="confluence-embedded-image image-center" data-base-url="https://unstructured-ingest-test.atlassian.net/wiki" data-height="264" data-image-src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/angie.svg?version=1&amp;modificationDate=1688907281095&amp;cacheVersion=1&amp;api=v2" data-linked-resource-container-id="1605859" data-linked-resource-container-version="2" data-linked-resource-content-type="image/svg+xml" data-linked-resource-default-alias="angie.svg" data-linked-resource-id="1605883" data-linked-resource-type="attachment" data-linked-resource-version="1" data-media-id="b2fac544-e628-4eda-88d1-860ca94449de" data-media-type="file" data-unresolved-comment-count="0" data-width="264" loading="lazy" src="https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/angie.svg?version=1&amp;modificationDate=1688907281095&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257" srcset="https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/angie.svg?version=1&amp;modificationDate=1688907281095&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257 2x, https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/angie.svg?version=1&amp;modificationDate=1688907281095&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257 1x" width="442"/>
+     </span>
+     <h3 id="test-teamspace-Teammember" style="text-align: center;">
+      <span data-colorid="uzd00gx0g8">
+       Team member
+      </span>
+     </h3>
+     <p style="text-align: center;">
+      <span data-colorid="fadpol2ynl">
+       Role
+      </span>
+     </p>
+     <p style="text-align: center;">
+      <span data-colorid="oy1hqksoab">
+       Responsibility
+      </span>
+     </p>
+    </div>
+   </div>
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <span class="confluence-embedded-file-wrapper image-center-wrapper confluence-embedded-manual-size">
+      <img class="confluence-embedded-image image-center" data-base-url="https://unstructured-ingest-test.atlassian.net/wiki" data-height="264" data-image-src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/gael.svg?version=1&amp;modificationDate=1688907281775&amp;cacheVersion=1&amp;api=v2" data-linked-resource-container-id="1605859" data-linked-resource-container-version="2" data-linked-resource-content-type="image/svg+xml" data-linked-resource-default-alias="gael.svg" data-linked-resource-id="1605889" data-linked-resource-type="attachment" data-linked-resource-version="1" data-media-id="51f40dba-a514-413f-b025-ebaa46a30f6a" data-media-type="file" data-unresolved-comment-count="0" data-width="264" loading="lazy" src="https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/gael.svg?version=1&amp;modificationDate=1688907281775&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257" srcset="https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/gael.svg?version=1&amp;modificationDate=1688907281775&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257 2x, https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/gael.svg?version=1&amp;modificationDate=1688907281775&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257 1x" width="442"/>
+     </span>
+     <h3 id="test-teamspace-Teammember.1" style="text-align: center;">
+      <span data-colorid="uw2cbbjt91">
+       Team member
+      </span>
+     </h3>
+     <p style="text-align: center;">
+      <span data-colorid="wsl4oz52yz">
+       Role
+      </span>
+     </p>
+     <p style="text-align: center;">
+      <span data-colorid="p1lpa9j52o">
+       Responsibility
+      </span>
+     </p>
+    </div>
+   </div>
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <span class="confluence-embedded-file-wrapper image-center-wrapper confluence-embedded-manual-size">
+      <img class="confluence-embedded-image image-center" data-base-url="https://unstructured-ingest-test.atlassian.net/wiki" data-height="264" data-image-src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/claudia.svg?version=1&amp;modificationDate=1688907282424&amp;cacheVersion=1&amp;api=v2" data-linked-resource-container-id="1605859" data-linked-resource-container-version="2" data-linked-resource-content-type="image/svg+xml" data-linked-resource-default-alias="claudia.svg" data-linked-resource-id="1605894" data-linked-resource-type="attachment" data-linked-resource-version="1" data-media-id="5e4cbe7b-33a7-4471-9910-b651b51f163e" data-media-type="file" data-unresolved-comment-count="0" data-width="264" loading="lazy" src="https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/claudia.svg?version=1&amp;modificationDate=1688907282424&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257" srcset="https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/claudia.svg?version=1&amp;modificationDate=1688907282424&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257 2x, https://unstructured-ingest-test.atlassian.net/wiki/download/thumbnails/1605859/claudia.svg?version=1&amp;modificationDate=1688907282424&amp;cacheVersion=1&amp;api=v2&amp;width=256&amp;height=257 1x" width="442"/>
+     </span>
+     <h3 id="test-teamspace-Teammember.2" style="text-align: center;">
+      <span data-colorid="kh4blwq9sv">
+       Team member
+      </span>
+     </h3>
+     <p style="text-align: center;">
+      <span data-colorid="j7phth29td">
+       Role
+      </span>
+     </p>
+     <p style="text-align: center;">
+      <span data-colorid="pgcm6io2mx">
+       Responsibility
+      </span>
+     </p>
+    </div>
+   </div>
+  </div>
+  <div class="columnLayout fixed-width" data-layout="fixed-width">
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <p>
+     </p>
+    </div>
+   </div>
+  </div>
+  <div class="columnLayout two-equal" data-layout="two-equal">
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <h3 id="test-teamspace-Contactus">
+      Contact us
+     </h3>
+     <p>
+      <em>
+       <span data-colorid="b5t1vk6voa">
+        How can someone reach out to your team?
+       </span>
+      </em>
+     </p>
+     <ul>
+      <li>
+       <p>
+        <a class="external-link" href="mailto:team@email.com" rel="nofollow">
+         <span data-colorid="xhi2t0emka">
+          team@email.com
+         </span>
+        </a>
+       </p>
+      </li>
+      <li>
+       <p>
+        <span data-colorid="k7yo7jx0nd">
+         Tickets
+        </span>
+       </p>
+      </li>
+      <li>
+       <p>
+        <span data-colorid="o41kkbuwsr">
+         Jira board
+        </span>
+       </p>
+      </li>
+      <li>
+       <p>
+        <span data-colorid="t46c5qbf9i">
+         #channel
+        </span>
+       </p>
+      </li>
+     </ul>
+    </div>
+   </div>
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <h3 id="test-teamspace-ImportantPages">
+      Important Pages
+     </h3>
+     <p>
+      <em>
+       <span data-colorid="o2k2vt8ga3">
+        List them here
+       </span>
+      </em>
+     </p>
+     <ul>
+      <li>
+       <p>
+       </p>
+      </li>
+      <li>
+       <p>
+       </p>
+      </li>
+      <li>
+       <p>
+       </p>
+      </li>
+     </ul>
+    </div>
+   </div>
+  </div>
+  <div class="columnLayout fixed-width" data-layout="fixed-width">
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <p>
+     </p>
+    </div>
+   </div>
+  </div>
+  <div class="columnLayout three-equal" data-layout="three-equal">
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <span class="confluence-embedded-file-wrapper image-center-wrapper">
+      <img class="confluence-embedded-image image-center" data-base-url="https://unstructured-ingest-test.atlassian.net/wiki" data-height="500" data-image-src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/raised_hand.svg?version=1&amp;modificationDate=1688907283067&amp;cacheVersion=1&amp;api=v2" data-linked-resource-container-id="1605859" data-linked-resource-container-version="2" data-linked-resource-content-type="image/svg+xml" data-linked-resource-default-alias="raised_hand.svg" data-linked-resource-id="1605899" data-linked-resource-type="attachment" data-linked-resource-version="1" data-media-id="2fa368b2-e9d1-47c7-82dc-2d44c59ce164" data-media-type="file" data-unresolved-comment-count="0" data-width="511" loading="lazy" src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/raised_hand.svg?version=1&amp;modificationDate=1688907283067&amp;cacheVersion=1&amp;api=v2"/>
+     </span>
+     <h3 id="test-teamspace-OnboardingFAQs" style="text-align: center;">
+      Onboarding FAQs
+     </h3>
+     <p style="text-align: center;">
+      <em>
+       <span data-colorid="dtxe331c1x">
+        Add resources for new hires
+       </span>
+      </em>
+     </p>
+    </div>
+   </div>
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <span class="confluence-embedded-file-wrapper image-center-wrapper">
+      <img class="confluence-embedded-image image-center" data-base-url="https://unstructured-ingest-test.atlassian.net/wiki" data-height="500" data-image-src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/ledger.svg?version=1&amp;modificationDate=1688907283728&amp;cacheVersion=1&amp;api=v2" data-linked-resource-container-id="1605859" data-linked-resource-container-version="2" data-linked-resource-content-type="image/svg+xml" data-linked-resource-default-alias="ledger.svg" data-linked-resource-id="1605904" data-linked-resource-type="attachment" data-linked-resource-version="1" data-media-id="2c6a54ab-b715-4087-90c0-f453b3a10ae1" data-media-type="file" data-unresolved-comment-count="0" data-width="501" loading="lazy" src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/ledger.svg?version=1&amp;modificationDate=1688907283728&amp;cacheVersion=1&amp;api=v2"/>
+     </span>
+     <h3 id="test-teamspace-Meetingnotes" style="text-align: center;">
+      Meeting notes
+     </h3>
+     <p style="text-align: center;">
+      <em>
+       <span data-colorid="k8lomjnanq">
+        Add links to meeting notes
+       </span>
+      </em>
+     </p>
+    </div>
+   </div>
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <span class="confluence-embedded-file-wrapper image-center-wrapper">
+      <img class="confluence-embedded-image image-center" data-base-url="https://unstructured-ingest-test.atlassian.net/wiki" data-height="500" data-image-src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/astronaut.svg?version=1&amp;modificationDate=1688907284407&amp;cacheVersion=1&amp;api=v2" data-linked-resource-container-id="1605859" data-linked-resource-container-version="2" data-linked-resource-content-type="image/svg+xml" data-linked-resource-default-alias="astronaut.svg" data-linked-resource-id="1605909" data-linked-resource-type="attachment" data-linked-resource-version="1" data-media-id="b6c07064-0574-43fc-ae77-df66a4166881" data-media-type="file" data-unresolved-comment-count="0" data-width="500" loading="lazy" src="https://unstructured-ingest-test.atlassian.net/wiki/download/attachments/1605859/astronaut.svg?version=1&amp;modificationDate=1688907284407&amp;cacheVersion=1&amp;api=v2"/>
+     </span>
+     <h3 id="test-teamspace-Teamgoals" style="text-align: center;">
+      Team goals
+     </h3>
+     <p style="text-align: center;">
+      <em>
+       <span data-colorid="htm243wmel">
+        List them here
+       </span>
+      </em>
+     </p>
+    </div>
+   </div>
+  </div>
+  <div class="columnLayout fixed-width" data-layout="fixed-width">
+   <div class="cell normal" data-type="normal">
+    <div class="innerCell">
+     <h2 id="test-teamspace-Teamnews">
+      Team news
+     </h2>
+     <p>
+      <em>
+       <span data-colorid="di6nl9qucy">
+        Create a blog post to share team news. It will automatically appear here once it's published.
+       </span>
+      </em>
+     </p>
+     <div class="blog-post macro-blank-experience conf-macro output-block" data-hasbody="false" data-layout="default" data-local-id="5559e1ae-edf8-4c2b-97a7-e133d5510f8b" data-macro-id="d17a3746-1a95-4d1c-a3a5-90adfca4b4ed" data-macro-name="blog-posts">
+      <h2>
+       Blog stream
+      </h2>
+      <p>
+       Create a blog post to share news and announcements with your team and company.
+      </p>
+      <button class="aui-button create-post">
+       Create blog post
+      </button>
+     </div>
+     <p>
+     </p>
+     <hr/>
+    </div>
+   </div>
+  </div>
+ </div>
+</body>

--- a/test/integration/connectors/expected_results/confluence_limit/file_data/1605859.json
+++ b/test/integration/connectors/expected_results/confluence_limit/file_data/1605859.json
@@ -1,0 +1,58 @@
+{
+  "identifier": "1605859",
+  "connector_type": "confluence",
+  "source_identifiers": {
+    "filename": "1605859.html",
+    "fullpath": "testteamsp/1605859.html",
+    "rel_path": "testteamsp/1605859.html"
+  },
+  "metadata": {
+    "url": "https://unstructured-ingest-test.atlassian.net/pages/1605859",
+    "version": "2",
+    "record_locator": {
+      "space_id": "testteamsp",
+      "document_id": "1605859"
+    },
+    "date_created": "2023-07-09T12:54:40.304Z",
+    "date_modified": "2023-07-13T14:13:27.275Z",
+    "date_processed": "1744231490.650383",
+    "permissions_data": [
+      {
+        "read": {
+          "users": [
+            "712020:5368eedf-cecd-43e1-8b25-b2221316ee6f"
+          ],
+          "groups": [
+            "5d476b78-504f-47d2-bddb-aa45ebf77753",
+            "78cd6a04-9161-4cf9-9e96-1fd605961fc0"
+          ]
+        }
+      },
+      {
+        "update": {
+          "users": [
+            "712020:5368eedf-cecd-43e1-8b25-b2221316ee6f"
+          ],
+          "groups": [
+            "78cd6a04-9161-4cf9-9e96-1fd605961fc0"
+          ]
+        }
+      },
+      {
+        "delete": {
+          "users": [],
+          "groups": []
+        }
+      }
+    ],
+    "filesize_bytes": null
+  },
+  "additional_metadata": {
+    "space_key": "testteamsp",
+    "space_id": 1605649,
+    "document_id": "1605859"
+  },
+  "reprocess": false,
+  "local_download_path": "/private/var/folders/h7/n848df9s5yn7ml8rxb61vhyc0000gp/T/tmp8s4u1xht/testteamsp/1605859.html",
+  "display_name": "test-teamspace"
+}

--- a/test/integration/connectors/test_confluence.py
+++ b/test/integration/connectors/test_confluence.py
@@ -27,7 +27,7 @@ from unstructured_ingest.processes.connectors.confluence import (
     [
         (["testteamsp", "MFS"], 500, 100, 11, True, "confluence"),
         (["testteamsp"], 500, 1, 1, True, "confluence_limit"),
-        (["testteamsp1"], 10, 250, 301, False, "confluence_large"),
+        (["testteamsp1"], 10, 301, 301, False, "confluence_large"),
     ],
 )
 async def test_confluence_source_param(

--- a/test/integration/connectors/test_confluence.py
+++ b/test/integration/connectors/test_confluence.py
@@ -6,7 +6,6 @@ from test.integration.connectors.utils.constants import SOURCE_TAG, UNCATEGORIZE
 from test.integration.connectors.utils.validation.source import (
     SourceValidationConfigs,
     source_connector_validation,
-    source_filedata_display_name_set_check,
 )
 from test.integration.utils import requires_env
 from unstructured_ingest.processes.connectors.confluence import (
@@ -23,14 +22,30 @@ from unstructured_ingest.processes.connectors.confluence import (
 @pytest.mark.asyncio
 @pytest.mark.tags(CONNECTOR_TYPE, SOURCE_TAG, UNCATEGORIZED_TAG)
 @requires_env("CONFLUENCE_USER_EMAIL", "CONFLUENCE_API_TOKEN")
-async def test_confluence_source(temp_dir):
-    # Retrieve environment variables
+@pytest.mark.parametrize(
+    "spaces,max_num_of_spaces,max_num_of_docs_from_each_space,expected_num_files,validate_downloaded_files,test_id",
+    [
+        (["testteamsp", "MFS"], 500, 100, 11, True, "confluence"),
+        (["testteamsp"], 500, 1, 1, True, "confluence_limit"),
+        (["testteamsp1"], 10, 250, 301, False, "confluence_large"),
+    ],
+)
+async def test_confluence_source_param(
+    temp_dir,
+    spaces,
+    max_num_of_spaces,
+    max_num_of_docs_from_each_space,
+    expected_num_files,
+    validate_downloaded_files,
+    test_id,
+):
+    """
+    Integration test for the Confluence source connector using various space and document limits.
+    """
     confluence_url = "https://unstructured-ingest-test.atlassian.net"
     user_email = os.environ["CONFLUENCE_USER_EMAIL"]
     api_token = os.environ["CONFLUENCE_API_TOKEN"]
-    spaces = ["testteamsp", "MFS"]
 
-    # Create connection and indexer configurations
     access_config = ConfluenceAccessConfig(api_token=api_token)
     connection_config = ConfluenceConnectionConfig(
         url=confluence_url,
@@ -38,14 +53,12 @@ async def test_confluence_source(temp_dir):
         access_config=access_config,
     )
     index_config = ConfluenceIndexerConfig(
-        max_num_of_spaces=500,
-        max_num_of_docs_from_each_space=100,
+        max_num_of_spaces=max_num_of_spaces,
+        max_num_of_docs_from_each_space=max_num_of_docs_from_each_space,
         spaces=spaces,
     )
-
     download_config = ConfluenceDownloaderConfig(download_dir=temp_dir)
 
-    # Instantiate indexer and downloader
     indexer = ConfluenceIndexer(
         connection_config=connection_config,
         index_config=index_config,
@@ -55,64 +68,12 @@ async def test_confluence_source(temp_dir):
         download_config=download_config,
     )
 
-    # Run the source connector validation
     await source_connector_validation(
         indexer=indexer,
         downloader=downloader,
         configs=SourceValidationConfigs(
-            test_id="confluence",
-            expected_num_files=11,
-            validate_downloaded_files=True,
-            predownload_file_data_check=source_filedata_display_name_set_check,
-            postdownload_file_data_check=source_filedata_display_name_set_check,
-        ),
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.tags(CONNECTOR_TYPE, SOURCE_TAG, UNCATEGORIZED_TAG)
-@requires_env("CONFLUENCE_USER_EMAIL", "CONFLUENCE_API_TOKEN")
-async def test_confluence_source_large(temp_dir):
-    # Retrieve environment variables
-    confluence_url = "https://unstructured-ingest-test.atlassian.net"
-    user_email = os.environ["CONFLUENCE_USER_EMAIL"]
-    api_token = os.environ["CONFLUENCE_API_TOKEN"]
-    spaces = ["testteamsp1"]
-
-    # Create connection and indexer configurations
-    access_config = ConfluenceAccessConfig(api_token=api_token)
-    connection_config = ConfluenceConnectionConfig(
-        url=confluence_url,
-        username=user_email,
-        access_config=access_config,
-    )
-    index_config = ConfluenceIndexerConfig(
-        max_num_of_spaces=10,
-        max_num_of_docs_from_each_space=250,
-        spaces=spaces,
-    )
-
-    download_config = ConfluenceDownloaderConfig(download_dir=temp_dir)
-
-    # Instantiate indexer and downloader
-    indexer = ConfluenceIndexer(
-        connection_config=connection_config,
-        index_config=index_config,
-    )
-    downloader = ConfluenceDownloader(
-        connection_config=connection_config,
-        download_config=download_config,
-    )
-
-    # Run the source connector validation
-    await source_connector_validation(
-        indexer=indexer,
-        downloader=downloader,
-        configs=SourceValidationConfigs(
-            test_id="confluence_large",
-            expected_num_files=301,
-            validate_file_data=False,
-            predownload_file_data_check=source_filedata_display_name_set_check,
-            postdownload_file_data_check=source_filedata_display_name_set_check,
+            test_id=test_id,
+            expected_num_files=expected_num_files,
+            validate_downloaded_files=validate_downloaded_files,
         ),
     )

--- a/test/integration/connectors/test_confluence.py
+++ b/test/integration/connectors/test_confluence.py
@@ -23,11 +23,11 @@ from unstructured_ingest.processes.connectors.confluence import (
 @pytest.mark.tags(CONNECTOR_TYPE, SOURCE_TAG, UNCATEGORIZED_TAG)
 @requires_env("CONFLUENCE_USER_EMAIL", "CONFLUENCE_API_TOKEN")
 @pytest.mark.parametrize(
-    "spaces,max_num_of_spaces,max_num_of_docs_from_each_space,expected_num_files,validate_downloaded_files,test_id",
+    "spaces,max_num_of_spaces,max_num_of_docs_from_each_space,expected_num_files,validate_downloaded_files,validate_file_data,test_id",
     [
-        (["testteamsp", "MFS"], 500, 100, 11, True, "confluence"),
-        (["testteamsp"], 500, 1, 1, True, "confluence_limit"),
-        (["testteamsp1"], 10, 301, 301, False, "confluence_large"),
+        (["testteamsp", "MFS"], 500, 100, 11, True, True, "confluence"),
+        (["testteamsp"], 500, 1, 1, True, True, "confluence_limit"),
+        (["testteamsp1"], 10, 301, 301, False, False, "confluence_large"),
     ],
 )
 async def test_confluence_source_param(
@@ -37,6 +37,7 @@ async def test_confluence_source_param(
     max_num_of_docs_from_each_space,
     expected_num_files,
     validate_downloaded_files,
+    validate_file_data,
     test_id,
 ):
     """
@@ -75,5 +76,6 @@ async def test_confluence_source_param(
             test_id=test_id,
             expected_num_files=expected_num_files,
             validate_downloaded_files=validate_downloaded_files,
+            validate_file_data=validate_file_data
         ),
     )

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.41"  # pragma: no cover
+__version__ = "1.0.42"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -186,7 +186,6 @@ class ConfluenceIndexer(Indexer):
             pages = client.get_all_pages_from_space(
                 space=space_key,
                 start=0,
-                limit=self.index_config.max_num_of_docs_from_each_space,
                 expand=None,
                 content_type="page",  # blogpost and comment types not currently supported
                 status=None,

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -191,7 +191,11 @@ class ConfluenceIndexer(Indexer):
                 content_type="page",  # blogpost and comment types not currently supported
                 status=None,
             )
-        doc_ids = [{"space_id": space_key, "doc_id": page["id"]} for page in pages]
+        # Limit the number of documents to max_num_of_docs_from_each_space
+        # Note: this is needed because the limit field in client.get_all_pages_from_space does 
+        # not seem to work as expected
+        limited_pages = pages[: self.index_config.max_num_of_docs_from_each_space]
+        doc_ids = [{"space_id": space_key, "doc_id": page["id"]} for page in limited_pages]
         return doc_ids
 
     def run(self) -> Generator[FileData, None, None]:


### PR DESCRIPTION
The limit argument supported by the confluence client is not limiting the pages as advertised. This adds a limit to the returned results. 

Integration test was updated to a parameterized pattern to reduce duplication and include an additional test that validates the doc limit.

> [!NOTE]
> the current CI failures are unrelated to this PR and will be resolved by: https://github.com/Unstructured-IO/unstructured-ingest/pull/538