### PR TITLE
fix: bump together ai model used in testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.42
+
+* **Replace no longer supported TogetherAI test model**
+
 ## 1.0.41
 
 * **Add `display_name` to FileData in 14 connectors**

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.41"  # pragma: no cover
+__version__ = "1.0.42"  # pragma: no cover

--- a/unstructured_ingest/embed/togetherai.py
+++ b/unstructured_ingest/embed/togetherai.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class TogetherAIEmbeddingConfig(EmbeddingConfig):
     api_key: SecretStr = Field(description="API key for Together AI")
     embedder_model_name: str = Field(
-        default="togethercomputer/m2-bert-80M-8k-retrieval",
+        default="togethercomputer/m2-bert-80M-32k-retrieval",
         alias="model_name",
         description="Together AI model name",
     )


### PR DESCRIPTION
we were using m2-bert-80M-8k-retrieval which is no longer supported. bumped to: m2-bert-80M-32k-retrieval