### PR TITLE
fix: fsspec download a single file instead of downloading files that match pattern

### DIFF
--- a/unstructured_ingest/processes/connectors/fsspec/fsspec.py
+++ b/unstructured_ingest/processes/connectors/fsspec/fsspec.py
@@ -274,7 +274,7 @@ class FsspecDownloader(Downloader):
         try:
             rpath = file_data.additional_metadata["original_file_path"]
             with self.connection_config.get_client(protocol=self.protocol) as client:
-                client.get(rpath=rpath, lpath=download_path.as_posix())
+                client.get_file(rpath=rpath, lpath=download_path.as_posix())
             self.handle_directory_download(lpath=download_path)
         except Exception as e:
             raise self.wrap_error(e=e)
@@ -286,7 +286,7 @@ class FsspecDownloader(Downloader):
         try:
             rpath = file_data.additional_metadata["original_file_path"]
             with self.connection_config.get_client(protocol=self.protocol) as client:
-                await client.get(rpath=rpath, lpath=download_path.as_posix())
+                await client.get_file(rpath=rpath, lpath=download_path.as_posix())
             self.handle_directory_download(lpath=download_path)
         except Exception as e:
             raise self.wrap_error(e=e)


### PR DESCRIPTION
### Fixes:
- Use `get_file` instead of `get` method to download file in `fsspec` based connectors.


`get` matches file name patterns and doesn't allow to fetch files that use some special characters (e.g. `[` or `]`)