### PR TITLE
feat(delta-table): add record-level upsert

### DIFF
--- a/requirements/connectors/delta-table.txt
+++ b/requirements/connectors/delta-table.txt
@@ -1,3 +1,4 @@
 pandas
 deltalake
 boto3
+tenacity

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.43"  # pragma: no cover
+__version__ = "1.0.44"  # pragma: no cover


### PR DESCRIPTION
- `DeltaTableUploadStager`
  - injects `RECORD_ID_LABEL` on every row, enabling per-record tracking.

- `DeltaTableUploader.upload_dataframe`
  - deletes rows whose `record_id` matches the current file before appending new data instead of doing a full table overwrite.
  - handles concurrent writers by wrapping the delete-then-append sequence in a tenacity-based retry (`10` attempts, random 0.2-1 s back-off) that re-runs only on commit-conflict errors (“CommitFailed”, “Metadata changed”).
  - keeps the SIGABRT-work-around: runs the writer in a subprocess unless executing inside a daemon worker; error propagation unified through a single `multiprocessing.Queue`.

- refactor
  - removed duplicated queue/error-handling blocks, preserved detailed explanatory comments.
  - added `@requires_dependencies(["tenacity"], extras="delta-table")` to enforce the new optional dependency.