### PR TITLE
fix(delta-table): normalize S3 LocationConstraint values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.47
+
+* **Fix delta-table: normalize S3 LocationConstraint values to handle us-east-1 and EU buckets**
+
 ## 1.0.46
 
 * **Fix delta-table `pyo3_runtime.PanicException: Forked process detected` on Linux**

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.46"  # pragma: no cover
+__version__ = "1.0.47"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/delta_table.py
+++ b/unstructured_ingest/processes/connectors/delta_table.py
@@ -280,10 +280,10 @@ class DeltaTableUploader(Uploader):
 def _normalize_location_constraint(location: Optional[str]) -> str:
     """Return canonical AWS region name for a LocationConstraint value.
 
-    The S3 GetBucketLocation operation returns *null* (→ ``None``) for buckets in
-    the legacy **us-east-1** region and ``"EU"`` for very old buckets that were
-    created in the historical **EU** region (now **eu-west-1**).  For every other
-    region the API already returns the correct AWS region string.  This helper
+    The S3 GetBucketLocation operation returns `null` (`None`) for buckets in
+    the legacy `us-east-1` region and `EU` for very old buckets that were
+    created in the historical `EU` region (now `eu-west-1`). For every other
+    region the API already returns the correct AWS region string. This helper
     normalises the legacy values so callers can reliably compare regions.
 
     Args:


### PR DESCRIPTION
The S3 GetBucketLocation operation returns `null` (`None`) for buckets in the legacy `us-east-1` region and `EU` for very old buckets that were created in the historical `EU` region (now `eu-west-1`). For every other region the API already returns the correct AWS region string.
Add a function that normalizes bucket location.