### PR TITLE
feat: html mixin metadata improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.56-dev0
+
+- **Feat: improve HtmlMixin produced metadata**
+
 ## 1.0.55
 
 * **Fix: add precheck method to SharePoint connector**

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.55"  # pragma: no cover
+__version__ = "1.0.56-dev0"  # pragma: no cover

--- a/unstructured_ingest/utils/html.py
+++ b/unstructured_ingest/utils/html.py
@@ -129,6 +129,7 @@ class HtmlMixin(BaseModel):
         )
         result_file_data = file_data.model_copy(deep=True)
         result_file_data.metadata.url = url
+        result_file_data.display_name = f"{result_file_data.display_name or ''} > {filename}"
         if result_file_data.metadata.record_locator is None:
             result_file_data.metadata.record_locator = {}
         result_file_data.metadata.record_locator["parent_url"] = url


### PR DESCRIPTION
Update the `display_name` metadata field for `FileData` produced by `HtmlMixin` to reflect relation between parent HTML file and downloaded file.

Format of the display name: `{parent-display-name} > {child-filename}`