### PR TITLE
test: Longer interval for pinecone integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.57
+
+- **test: Longer interval for pinecone integration tests**
+
 ## 1.0.56
 
 - **Fix: set correct display_name in HtmlMixin produced FileData**

--- a/test/integration/connectors/test_pinecone.py
+++ b/test/integration/connectors/test_pinecone.py
@@ -110,7 +110,7 @@ def validate_pinecone_index(
     index_name: str,
     expected_num_of_vectors: int,
     retries=30,
-    interval=1,
+    interval=5,
     namespace: str = "default",
 ) -> None:
     # Because there's a delay for the index to catch up to the recent writes, add in a retry

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.56"  # pragma: no cover
+__version__ = "1.0.57"  # pragma: no cover


### PR DESCRIPTION
Short interval times result in pinecone tests not finishing properly.
By giving these tests more time to finish, they can properly pass.