### PR TITLE
remove deletion operation in es connector

### DIFF
--- a/test/integration/connectors/elasticsearch/test_elasticsearch.py
+++ b/test/integration/connectors/elasticsearch/test_elasticsearch.py
@@ -280,11 +280,6 @@ async def test_elasticsearch_destination(
     with get_client() as client:
         validate_count(client=client, expected_count=expected_count, index_name=destination_index)
 
-    # Rerun and make sure the same documents get updated
-    uploader.run(path=staged_filepath, file_data=file_data)
-    with get_client() as client:
-        validate_count(client=client, expected_count=expected_count, index_name=destination_index)
-
 
 @pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, NOSQL_TAG)
 def test_elasticsearch_destination_precheck_fail():
@@ -333,3 +328,50 @@ def test_elasticsearch_stager(
         stager=stager,
         tmp_dir=tmp_path,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, NOSQL_TAG)
+async def test_elasticsearch_upsert_destination(
+    upload_file: Path,
+    destination_index: str,
+    tmp_path: Path,
+):
+    file_data = FileData(
+        source_identifiers=SourceIdentifiers(fullpath=upload_file.name, filename=upload_file.name),
+        connector_type=CONNECTOR_TYPE,
+        identifier="mock file data",
+    )
+    connection_config = ElasticsearchConnectionConfig(
+        access_config=ElasticsearchAccessConfig(password=ES_PASSWORD),
+        username=ES_USERNAME,
+        hosts=["http://localhost:9200"],
+    )
+    stager = ElasticsearchUploadStager(
+        upload_stager_config=ElasticsearchUploadStagerConfig(index_name=destination_index)
+    )
+
+    uploader = ElasticsearchUploader(
+        connection_config=connection_config,
+        upload_config=ElasticsearchUploaderConfig(index_name=destination_index),
+    )
+    staged_filepath = stager.run(
+        elements_filepath=upload_file,
+        file_data=file_data,
+        output_dir=tmp_path,
+        output_filename=upload_file.name,
+    )
+    uploader.precheck()
+    uploader.run(path=staged_filepath, file_data=file_data)
+
+    # Run validation
+    with staged_filepath.open() as f:
+        staged_elements = json.load(f)
+    expected_count = len(staged_elements)
+    with get_client() as client:
+        validate_count(client=client, expected_count=expected_count, index_name=destination_index)
+
+    # Rerun and make sure the same documents get updated
+    uploader.run(path=staged_filepath, file_data=file_data)
+    with get_client() as client:
+        validate_count(client=client, expected_count=expected_count, index_name=destination_index)


### PR DESCRIPTION
in ES connector, function delete_by_record_id is not necessary, because when document_id already exists in the index, we want to replace the record with new content, which is equivalent to upsert operation. deleting existing records is dangerous because it may remove unintended content inadvertently. For more details see:
https://linear.app/unstructured/issue/ENG-360/upsert-in-elastic-incorrectly-implemented