### PR TITLE
fix Milvus stager to use correct exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.12-dev1
+
+* **Fix: fix Milvus stager to use correct exception**
+
 ## 1.2.12-dev0
 
 * **Fix: confluence integration test to use new link and credential**

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.12-dev0"  # pragma: no cover
+__version__ = "1.2.12-dev1"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -10,7 +10,6 @@ from unstructured_ingest.data_types.file_data import FileData
 from unstructured_ingest.error import (
     DestinationConnectionError,
     KeyError,
-    ValueError,
     WriteError,
 )
 from unstructured_ingest.interfaces import (


### PR DESCRIPTION
the correct exception to catch here is Python built in ValueError, not UnstructuredIngestError.ValueError