### PR TITLE
⚡️ Speed up method `MilvusUploadStager.parse_date_string` by 432%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.13-dev1
+
+* **Optimize `MilvusUploadStager.parse_date_string`**
+
+## 1.2.13-dev0
+
+* **Optimize `parse_date_string`**
+
 ## 1.2.12
 
 * **Fix: retry with wait when throttling error happens in Sharepoint connector**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
-## 1.2.13-dev1
+## 1.2.17-dev1
 
 * **Optimize `MilvusUploadStager.parse_date_string`**
-
-## 1.2.13-dev0
-
-* **Optimize `parse_date_string`**
 
 ## 1.2.12
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.12"  # pragma: no cover
+__version__ = "1.2.13-dev1"  # pragma: no cover

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.13-dev1"  # pragma: no cover
+__version__ = "1.2.17-dev1"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -1,6 +1,7 @@
 import json
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Generator, Optional
 
 from dateutil import parser
@@ -97,6 +98,14 @@ class MilvusUploadStager(UploadStager):
             return timestamp
         except ValueError:
             pass
+
+        # Try fast ISO format parsing before falling back to dateutil
+        try:
+            dt = datetime.fromisoformat(date_string.replace("Z", "+00:00"))
+            return dt.timestamp()
+        except ValueError:
+            pass
+
         return parser.parse(date_string).timestamp()
 
     def conform_dict(self, element_dict: dict, file_data: FileData) -> dict:

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -99,7 +99,6 @@ class MilvusUploadStager(UploadStager):
         except ValueError:
             pass
 
-        # Try fast ISO format parsing before falling back to dateutil
         try:
             dt = datetime.fromisoformat(date_string.replace("Z", "+00:00"))
             return dt.timestamp()


### PR DESCRIPTION
<!-- CODEFLASH_OPTIMIZATION: {"function":"MilvusUploadStager.parse_date_string","file":"unstructured_ingest/processes/connectors/milvus.py","speedup_pct":"432%","speedup_x":"4.32x","original_runtime":"130 milliseconds","best_runtime":"24.4 milliseconds","optimization_type":"general","timestamp":"2025-08-22T04:01:44.960Z","version":"1.0"} -->
### 📄 432% (4.32x) speedup for ***`MilvusUploadStager.parse_date_string` in `unstructured_ingest/processes/connectors/milvus.py`***

⏱️ Runtime :   **`130 milliseconds`**  **→** **`24.4 milliseconds`** (best of `58` runs)
### 📝 Explanation and details


The optimization introduces a fast-path for ISO format date strings using `datetime.fromisoformat()` before falling back to the slower `dateutil.parser.parse()`. 

**Key changes:**
- Added `datetime` import for native ISO parsing
- Inserted a second try-catch block that attempts `datetime.fromisoformat()` with 'Z' to '+00:00' conversion for UTC timestamps
- Only falls back to `dateutil.parser.parse()` for complex/unusual date formats

**Why this optimization works:**
The line profiler shows that `dateutil.parser.parse()` consumed 98.8% of execution time in the original code (255ms per hit). The optimized version reduces this to only 88% with 126ms per hit, because many ISO format strings are now handled by the much faster `datetime.fromisoformat()` (986ns per hit).

**Performance gains by test case type:**
- **ISO format dates**: 1500-2900% faster (e.g., `2023-06-01T12:34:56+00:00` goes from 135μs to 5.08μs)
- **Simple date formats**: 1000-1700% faster (e.g., `2023-06-01` from 39.7μs to 3.07μs)  
- **Float/int timestamps**: Minimal overhead (~1-17% slower) since they bypass both parsing attempts
- **Complex formats**: 2-35% faster due to reduced parser overhead, still use dateutil fallback
- **Bulk operations**: Dramatic improvements (5000%+ faster for 1000 ISO dates)

The optimization is most effective for ISO 8601 formatted dates, which are common in modern applications, while maintaining full compatibility with all existing date formats through the dateutil fallback.



✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **3745 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
import time
# function to test
from dataclasses import dataclass, field
from datetime import datetime, timedelta, timezone
from typing import Any

# imports
import pytest  # used for our unit tests
from dateutil import parser
from unstructured_ingest.processes.connectors.milvus import MilvusUploadStager


# Dummy UploadStager and MilvusUploadStagerConfig for standalone testing
class UploadStager:
    pass

class MilvusUploadStagerConfig:
    pass
from unstructured_ingest.processes.connectors.milvus import MilvusUploadStager

# unit tests

# ------------------- BASIC TEST CASES -------------------

def test_parse_date_string_with_unix_timestamp_str():
    # Should parse a valid float string as a timestamp (seconds since epoch)
    now = time.time()
    s = str(now)
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 1.84μs -> 1.71μs (7.23% faster)

def test_parse_date_string_with_integer_timestamp_str():
    # Should parse a valid integer string as a timestamp
    now = int(time.time())
    s = str(now)
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 1.09μs -> 1.19μs (8.15% slower)

def test_parse_date_string_with_iso8601_utc():
    # Should parse ISO8601 date string in UTC
    dt = datetime(2023, 6, 1, 12, 30, 45, tzinfo=timezone.utc)
    s = dt.isoformat()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 145μs -> 7.33μs (1890% faster)

def test_parse_date_string_with_iso8601_no_timezone():
    # Should parse ISO8601 date string without timezone (assumed local)
    dt = datetime(2023, 6, 1, 12, 30, 45)
    s = dt.isoformat()
    # parser.parse assumes local time if no tzinfo
    expected = parser.parse(s).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 58.0μs -> 3.18μs (1725% faster)

def test_parse_date_string_with_common_date_formats():
    # Should parse common date formats
    dt = datetime(2022, 12, 31, 23, 59, 59)
    # "YYYY-MM-DD HH:MM:SS"
    s1 = dt.strftime("%Y-%m-%d %H:%M:%S")
    # "MM/DD/YYYY HH:MM:SS"
    s2 = dt.strftime("%m/%d/%Y %H:%M:%S")
    # "Month DD, YYYY HH:MM:SS"
    s3 = dt.strftime("%B %d, %Y %H:%M:%S")
    for s in [s1, s2, s3]:
        expected = parser.parse(s).timestamp()
        codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 181μs -> 133μs (35.7% faster)

def test_parse_date_string_with_milliseconds():
    # Should parse float string with milliseconds
    now = time.time()
    s = "%.3f" % now
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 982ns -> 1.05μs (6.65% slower)

# ------------------- EDGE TEST CASES -------------------

def test_parse_date_string_with_invalid_string():
    # Should raise ValueError for an invalid date string
    with pytest.raises(ValueError):
        MilvusUploadStager.parse_date_string("not a date") # 37.1μs -> 39.8μs (6.72% slower)

def test_parse_date_string_with_empty_string():
    # Should raise ValueError for empty string
    with pytest.raises(ValueError):
        MilvusUploadStager.parse_date_string("") # 29.2μs -> 29.8μs (2.02% slower)

def test_parse_date_string_with_only_whitespace():
    # Should raise ValueError for whitespace string
    with pytest.raises(ValueError):
        MilvusUploadStager.parse_date_string("   ") # 41.5μs -> 42.8μs (3.18% slower)

def test_parse_date_string_with_leading_and_trailing_spaces():
    # Should parse valid date string with spaces
    dt = datetime(2021, 1, 1, 0, 0, 0)
    s = "   " + dt.isoformat() + "   "
    expected = parser.parse(dt.isoformat()).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 86.7μs -> 90.7μs (4.37% slower)

def test_parse_date_string_with_timezone_offset():
    # Should correctly parse ISO8601 with timezone offset
    dt = datetime(2020, 5, 4, 15, 0, 0, tzinfo=timezone(timedelta(hours=5, minutes=30)))
    s = dt.isoformat()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 110μs -> 6.09μs (1710% faster)

def test_parse_date_string_with_dst_transition():
    # Should parse a date string during DST transition (ambiguous time)
    # Example: US Eastern, Nov 1, 2020, 1:30am occurs twice (EDT and EST)
    ambiguous_time = "2020-11-01 01:30:00"
    # parser.parse will pick local time, but we can at least assert it returns a float
    codeflash_output = MilvusUploadStager.parse_date_string(ambiguous_time); result = codeflash_output # 74.4μs -> 3.83μs (1843% faster)

def test_parse_date_string_with_far_future_date():
    # Should parse a far future date
    dt = datetime(2500, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
    s = dt.isoformat()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 101μs -> 4.42μs (2203% faster)

def test_parse_date_string_with_far_past_date():
    # Should parse a far past date
    dt = datetime(1900, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
    s = dt.isoformat()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 99.1μs -> 4.25μs (2234% faster)

def test_parse_date_string_with_negative_unix_timestamp():
    # Should parse negative unix timestamp (before epoch)
    dt = datetime(1960, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
    s = str(dt.timestamp())
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 1.10μs -> 1.13μs (2.83% slower)

def test_parse_date_string_with_scientific_notation():
    # Should parse float string in scientific notation
    now = time.time()
    s = "{:e}".format(now)
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 1.01μs -> 1.06μs (4.91% slower)

def test_parse_date_string_with_only_date():
    # Should parse date string with no time (should default to midnight)
    dt = datetime(2022, 7, 4)
    s = dt.strftime("%Y-%m-%d")
    expected = parser.parse(s).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 39.9μs -> 3.36μs (1089% faster)

def test_parse_date_string_with_only_time():
    # Should parse time string (today's date, time specified)
    s = "15:45:30"
    # parser.parse will use today's date
    expected = parser.parse(s).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 37.1μs -> 39.8μs (6.80% slower)

def test_parse_date_string_with_weird_format():
    # Should parse a weird but valid format
    s = "1st of January 2023, 10:00am"
    expected = parser.parse(s).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(s); result = codeflash_output # 88.6μs -> 90.8μs (2.44% slower)

# ------------------- LARGE SCALE TEST CASES -------------------



def test_parse_date_string_large_batch_invalid():
    # Should raise ValueError for all invalid strings in a large batch
    invalids = ["", "foo", "2022-13-01", "99/99/9999", "2022-12-32", "25:61:61", "2022-02-29"] * 100
    for s in invalids:
        with pytest.raises(ValueError):
            MilvusUploadStager.parse_date_string(s)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
#------------------------------------------------
from dataclasses import dataclass, field
from datetime import datetime, timedelta, timezone

# imports
import pytest  # used for our unit tests
from dateutil import parser
from unstructured_ingest.processes.connectors.milvus import MilvusUploadStager


# Mocking UploadStager and MilvusUploadStagerConfig for testability
class UploadStager:
    pass

class MilvusUploadStagerConfig:
    pass
from unstructured_ingest.processes.connectors.milvus import MilvusUploadStager

# unit tests

# --------------------------
# 1. Basic Test Cases
# --------------------------

def test_parse_date_string_with_float_timestamp():
    # Should parse a float timestamp string directly
    ts = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(str(ts)) # 1.70μs -> 1.99μs (14.4% slower)

def test_parse_date_string_with_int_timestamp():
    # Should parse an integer timestamp string directly
    ts = int(datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp())
    codeflash_output = MilvusUploadStager.parse_date_string(str(ts)) # 978ns -> 1.06μs (7.74% slower)

def test_parse_date_string_with_iso_format():
    # Should parse ISO 8601 format date string
    dt = datetime(2024, 6, 1, 12, 34, 56, tzinfo=timezone.utc)
    codeflash_output = MilvusUploadStager.parse_date_string(dt.isoformat()) # 135μs -> 5.08μs (2570% faster)

def test_parse_date_string_with_common_format():
    # Should parse common date format (e.g., 'YYYY-MM-DD HH:MM:SS')
    dt = datetime(2022, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
    date_str = dt.strftime('%Y-%m-%d %H:%M:%S')
    # parser assumes naive datetime is local, so force UTC for test
    expected = parser.parse(date_str).replace(tzinfo=timezone.utc).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str); result = codeflash_output # 58.9μs -> 3.52μs (1572% faster)

def test_parse_date_string_with_rfc_2822_format():
    # Should parse RFC 2822 format (e.g., 'Wed, 02 Oct 2002 13:00:00 GMT')
    date_str = "Wed, 02 Oct 2002 13:00:00 GMT"
    expected = parser.parse(date_str).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 94.2μs -> 100μs (6.34% slower)

# --------------------------
# 2. Edge Test Cases
# --------------------------

def test_parse_date_string_with_leading_and_trailing_spaces():
    # Should ignore leading/trailing whitespace
    dt = datetime(2023, 5, 4, 3, 2, 1, tzinfo=timezone.utc)
    date_str = "   " + dt.isoformat() + "   "
    expected = dt.timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str.strip()) # 98.5μs -> 3.60μs (2634% faster)

def test_parse_date_string_with_milliseconds():
    # Should parse timestamp with milliseconds
    ts = 1680000000.123
    codeflash_output = MilvusUploadStager.parse_date_string(str(ts)) # 1.10μs -> 1.11μs (1.52% slower)

def test_parse_date_string_with_microseconds():
    # Should parse timestamp with microseconds
    ts = 1680000000.123456
    codeflash_output = MilvusUploadStager.parse_date_string(str(ts)) # 2.60μs -> 2.57μs (1.01% faster)

def test_parse_date_string_with_timezone_offset():
    # Should parse date string with timezone offset
    date_str = "2023-06-01T12:34:56+05:30"
    expected = parser.parse(date_str).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 78.4μs -> 4.17μs (1783% faster)

def test_parse_date_string_with_naive_datetime():
    # Should parse naive datetime as local time (dateutil default)
    date_str = "2023-06-01 12:34:56"
    expected = parser.parse(date_str).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 55.8μs -> 3.07μs (1717% faster)

def test_parse_date_string_with_invalid_string():
    # Should raise ValueError for completely invalid string
    with pytest.raises(ValueError):
        MilvusUploadStager.parse_date_string("not a date") # 34.9μs -> 37.8μs (7.70% slower)

def test_parse_date_string_with_empty_string():
    # Should raise ValueError for empty string
    with pytest.raises(ValueError):
        MilvusUploadStager.parse_date_string("") # 27.4μs -> 28.6μs (3.97% slower)

def test_parse_date_string_with_negative_timestamp():
    # Should parse negative timestamp (before 1970)
    ts = -1234567890.0
    codeflash_output = MilvusUploadStager.parse_date_string(str(ts)) # 1.15μs -> 1.23μs (6.18% slower)

def test_parse_date_string_with_far_future_date():
    # Should parse far future date
    dt = datetime(2999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
    date_str = dt.isoformat()
    expected = dt.timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 105μs -> 3.80μs (2689% faster)

def test_parse_date_string_with_far_past_date():
    # Should parse far past date
    dt = datetime(1900, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
    date_str = dt.isoformat()
    expected = dt.timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 101μs -> 3.37μs (2919% faster)

def test_parse_date_string_with_partial_date():
    # Should parse partial date (e.g., '2023-06-01')
    date_str = "2023-06-01"
    expected = parser.parse(date_str).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 39.7μs -> 3.07μs (1194% faster)

def test_parse_date_string_with_only_year():
    # Should parse only year (e.g., '2023')
    date_str = "2023"
    expected = parser.parse(date_str).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 761ns -> 734ns (3.68% faster)

def test_parse_date_string_with_unusual_separator():
    # Should parse date with unusual separator (e.g., '2023/06/01')
    date_str = "2023/06/01"
    expected = parser.parse(date_str).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 39.1μs -> 42.0μs (6.95% slower)

def test_parse_date_string_with_tab_newline():
    # Should parse date string with tab/newline characters
    dt = datetime(2023, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
    date_str = "\t\n" + dt.isoformat() + "\n"
    expected = dt.timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str.strip()) # 96.8μs -> 3.56μs (2621% faster)

def test_parse_date_string_with_large_float_string():
    # Should parse a very large float string (far future)
    ts = 32503680000.0  # year 3000
    codeflash_output = MilvusUploadStager.parse_date_string(str(ts)) # 1.04μs -> 1.08μs (4.16% slower)

def test_parse_date_string_with_zero():
    # Should parse "0" as the epoch
    codeflash_output = MilvusUploadStager.parse_date_string("0") # 855ns -> 904ns (5.42% slower)

def test_parse_date_string_with_plus_sign():
    # Should parse "+1234567890" as float
    ts = 1234567890.0
    codeflash_output = MilvusUploadStager.parse_date_string("+1234567890") # 847ns -> 1.03μs (17.8% slower)

def test_parse_date_string_with_minus_sign():
    # Should parse "-1234567890" as float
    ts = -1234567890.0
    codeflash_output = MilvusUploadStager.parse_date_string("-1234567890") # 949ns -> 970ns (2.16% slower)

def test_parse_date_string_with_scientific_notation():
    # Should parse scientific notation for timestamp
    ts = 1.686e9
    codeflash_output = MilvusUploadStager.parse_date_string(str(ts)) # 929ns -> 899ns (3.34% faster)

def test_parse_date_string_with_ambiguous_format():
    # Should parse ambiguous format (e.g., '01/02/2003')
    date_str = "01/02/2003"
    expected = parser.parse(date_str).timestamp()
    codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 41.5μs -> 42.6μs (2.57% slower)

# --------------------------
# 3. Large Scale Test Cases
# --------------------------

def test_parse_date_string_many_iso_dates():
    # Should handle a large number of ISO date strings efficiently
    base = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
    for i in range(1000):
        dt = base + timedelta(seconds=i)
        date_str = dt.isoformat()
        codeflash_output = MilvusUploadStager.parse_date_string(date_str) # 68.0ms -> 1.30ms (5121% faster)

def test_parse_date_string_many_float_timestamps():
    # Should handle a large number of float timestamp strings efficiently
    for i in range(1000):
        ts = 1600000000.0 + i
        codeflash_output = MilvusUploadStager.parse_date_string(str(ts)) # 365μs -> 354μs (3.11% faster)

def test_parse_date_string_mixed_formats():
    # Should handle a mix of formats in bulk
    base = datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
    for i in range(333):
        # ISO format
        dt = base + timedelta(days=i)
        codeflash_output = MilvusUploadStager.parse_date_string(dt.isoformat()) # 22.7ms -> 523μs (4247% faster)
        # Float timestamp
        ts = 1700000000.0 + i
        codeflash_output = MilvusUploadStager.parse_date_string(str(ts))
        # Common date format
        date_str = dt.strftime('%Y-%m-%d %H:%M:%S') # 176μs -> 133μs (32.1% faster)
        expected = parser.parse(date_str).replace(tzinfo=timezone.utc).timestamp()
        codeflash_output = MilvusUploadStager.parse_date_string(date_str); result = codeflash_output


#------------------------------------------------
from unstructured_ingest.processes.connectors.milvus import MilvusUploadStager
import pytest

def test_MilvusUploadStager_parse_date_string():
    with pytest.raises(ParserError, match='Unknown\\ string\\ format:\\ \\+\x00'):
        MilvusUploadStager.parse_date_string('+\x00')
```

</details>


To edit these changes `git checkout codeflash/optimize-MilvusUploadStager.parse_date_string-memb04o3` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)