### PR TITLE
⚡️ Speed up method `GoogleDriveIndexer.count_files_recursively` by 29%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.2.13-dev2
+
+* **Optimize `GoogleDriveIndexer.count_files_recursively`**
+
+## 1.2.13-dev1
+
+* **Optimize `MilvusUploadStager.parse_date_string`**
+
+## 1.2.13-dev0
+
+* **Optimize `parse_date_string`**
+
 ## 1.2.12
 
 * **Fix: retry with wait when throttling error happens in Sharepoint connector**

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.12"  # pragma: no cover
+__version__ = "1.2.13-dev2"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -189,6 +189,9 @@ class GoogleDriveIndexer(Indexer):
         """
         count = 0
         stack = [folder_id]
+        # Pre-compute lower-case extension set for O(1) lookup
+        valid_exts = set(e.lower() for e in extensions) if extensions else None
+
         while stack:
             current_folder = stack.pop()
             # Always list all items under the current folder.
@@ -212,7 +215,6 @@ class GoogleDriveIndexer(Indexer):
                         if extensions:
                             # Use a case-insensitive comparison for the file extension.
                             file_ext = (item.get("fileExtension") or "").lower()
-                            valid_exts = [e.lower() for e in extensions]
                             if file_ext in valid_exts:
                                 count += 1
                         else:


### PR DESCRIPTION
<!-- CODEFLASH_OPTIMIZATION: {"function":"GoogleDriveIndexer.count_files_recursively","file":"unstructured_ingest/processes/connectors/google_drive.py","speedup_pct":"29%","speedup_x":"0.29x","original_runtime":"2.25 milliseconds","best_runtime":"1.74 milliseconds","optimization_type":"general","timestamp":"2025-08-22T10:35:37.636Z","version":"1.0"} -->
### 📄 29% (0.29x) speedup for ***`GoogleDriveIndexer.count_files_recursively` in `unstructured_ingest/processes/connectors/google_drive.py`***

⏱️ Runtime :   **`2.25 milliseconds`**  **→** **`1.74 milliseconds`** (best of `54` runs)
### 📝 Explanation and details


The optimization achieves a **29% speedup** by eliminating redundant computation in the extension filtering logic. 

**What was optimized:**
- **Pre-computed extension set**: Instead of creating `[e.lower() for e in extensions]` for every single file processed (line that took 13.4% of runtime), the extensions are converted to a lowercase `set` once at the beginning
- **O(1) set lookup**: Changed from O(n) list membership check to O(1) set membership check using `if file_ext in valid_exts`

**Why this is faster:**
In the original code, for each file encountered, a new list of lowercased extensions was created and then searched linearly. With 2,028 hits on that line consuming 13.4% of total runtime, this was a major bottleneck. The optimized version does this computation just once (46 hits, 0.5% of runtime) and uses set membership which is significantly faster for lookups.

**Performance characteristics:**
- **Small datasets**: Minimal impact (tests show 0-8% variance, mostly slower due to set creation overhead)  
- **Large datasets with extension filtering**: Dramatic improvements - the `test_large_folder_with_extension_filter` shows **112% speedup** when filtering 999 files, and `test_large_with_extension_filter` shows **110% speedup** for 1000 files
- **No extension filtering**: Negligible impact since the optimization only affects the filtering path

The optimization is most beneficial for scenarios with many files and extension filtering enabled, which matches typical Google Drive indexing use cases.



✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **43 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
from dataclasses import dataclass, field
from types import SimpleNamespace

# imports
import pytest  # used for our unit tests
# function to test
from googleapiclient.discovery import Resource as GoogleAPIResource
from unstructured_ingest.interfaces import Indexer
from unstructured_ingest.processes.connectors.google_drive import \
    GoogleDriveIndexer

# ------------- Helper Classes for Mocking Google Drive API -------------

class MockListResponse:
    """Mock the .execute() response of the files().list() call."""
    def __init__(self, files=None, nextPageToken=None):
        self._files = files if files is not None else []
        self._nextPageToken = nextPageToken

    def execute(self):
        return {
            "files": self._files,
            "nextPageToken": self._nextPageToken,
        }

class MockFilesClient:
    """
    Mocks the files().list() method of Google Drive API.
    Takes a mapping: folder_id -> list of file/folder dicts.
    Supports pagination via 'pageSize' and 'pageToken'.
    """
    def __init__(self, folder_structure):
        # folder_structure: dict of folder_id -> list of file/folder dicts
        self.folder_structure = folder_structure
        self.calls = []  # for debugging

    def list(self, supportsAllDrives, includeItemsFromAllDrives, spaces, q, fields, pageToken=None, pageSize=1000):
        # Extract folder_id from query string
        # query is like "'folder_id' in parents"
        folder_id = q.split("'")[1]
        files = self.folder_structure.get(folder_id, [])
        # Pagination
        if pageToken is None:
            start = 0
        else:
            start = int(pageToken)
        end = start + pageSize
        page_files = files[start:end]
        if end < len(files):
            nextPageToken = str(end)
        else:
            nextPageToken = None
        self.calls.append((folder_id, start, end))
        return MockListResponse(files=page_files, nextPageToken=nextPageToken)

# ------------- Unit Tests -------------

# ----------- BASIC TEST CASES -----------

def test_empty_folder():
    """Folder contains no files or folders."""
    structure = {"root": []}
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 9.21μs -> 9.50μs (3.11% slower)

def test_folder_with_only_files():
    """Folder contains only files, no subfolders."""
    structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 6.61μs -> 6.90μs (4.26% slower)

def test_folder_with_files_and_subfolders():
    """Folder contains files and one subfolder."""
    structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub1": [
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 9.38μs -> 9.78μs (4.13% slower)

def test_nested_folders_multiple_levels():
    """Folder tree with multiple levels of nesting."""
    structure = {
        "root": [
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
        ],
        "sub1": [
            {"id": "sub2", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub2": [
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
            {"id": "f3", "mimeType": "image/png", "fileExtension": "png"},
        ],
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 11.6μs -> 11.5μs (0.854% faster)

def test_extension_filter_basic():
    """Count only files with a given extension, case-insensitive."""
    structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "TXT"},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
            {"id": "f3", "mimeType": "image/png", "fileExtension": "PNG"},
        ]
    }
    client = MockFilesClient(structure)
    # Only count .txt and .png files
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["txt", "png"]) # 9.54μs -> 10.2μs (6.04% slower)

def test_extension_filter_with_none_and_empty():
    """Files with missing or empty fileExtension should not be counted."""
    structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": None},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": ""},
            {"id": "f3", "mimeType": "image/png", "fileExtension": "png"},
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf", "png"]) # 8.69μs -> 8.34μs (4.15% faster)

# ----------- EDGE TEST CASES -----------

def test_folder_with_only_subfolders():
    """Folder contains only subfolders, no files."""
    structure = {
        "root": [
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
            {"id": "sub2", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub1": [],
        "sub2": [],
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 10.9μs -> 11.0μs (0.891% slower)

def test_deeply_nested_empty_folders():
    """Deep folder structure, but no files at any level."""
    structure = {
        "root": [{"id": "sub1", "mimeType": "application/vnd.google-apps.folder"}],
        "sub1": [{"id": "sub2", "mimeType": "application/vnd.google-apps.folder"}],
        "sub2": [{"id": "sub3", "mimeType": "application/vnd.google-apps.folder"}],
        "sub3": [],
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 12.1μs -> 12.4μs (2.89% slower)

def test_files_with_missing_extension_key():
    """Some files do not have a fileExtension key at all."""
    structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain"},  # no fileExtension
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf"]) # 7.70μs -> 8.11μs (5.03% slower)



def test_files_with_mixed_case_extensions():
    """Extensions filter should be case-insensitive."""
    structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "TxT"},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "PDF"},
            {"id": "f3", "mimeType": "image/png", "fileExtension": "PnG"},
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["txt", "pdf"]) # 12.9μs -> 14.0μs (7.90% slower)

def test_files_with_duplicate_ids():
    """Files with duplicate IDs in different folders should all be counted."""
    structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub1": [
            {"id": "f1", "mimeType": "application/pdf", "fileExtension": "pdf"},  # same id as above
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 9.81μs -> 9.84μs (0.315% slower)

def test_files_with_no_mimeType():
    """Files with missing mimeType should be counted as files (not folders)."""
    structure = {
        "root": [
            {"id": "f1", "fileExtension": "txt"},  # no mimeType
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub1": [
            {"id": "f2", "fileExtension": "pdf"},  # no mimeType
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 9.43μs -> 9.22μs (2.19% faster)

def test_files_with_folder_mimeType_but_extension():
    """A folder with a fileExtension should still be treated as a folder."""
    structure = {
        "root": [
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder", "fileExtension": "pdf"},
            {"id": "f1", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ],
        "sub1": [
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf"]) # 11.1μs -> 11.5μs (3.71% slower)

# ----------- LARGE SCALE TEST CASES -----------

def test_large_flat_folder():
    """A flat folder with 999 files, no subfolders."""
    structure = {
        "root": [
            {"id": f"f{i}", "mimeType": "application/pdf", "fileExtension": "pdf"} for i in range(999)
        ]
    }
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 116μs -> 109μs (6.39% faster)

def test_large_nested_structure():
    """A folder with 10 subfolders, each with 99 files."""
    structure = {
        "root": [
            {"id": f"sub{i}", "mimeType": "application/vnd.google-apps.folder"} for i in range(10)
        ]
    }
    for i in range(10):
        structure[f"sub{i}"] = [
            {"id": f"f{i}_{j}", "mimeType": "application/pdf", "fileExtension": "pdf"} for j in range(99)
        ]
    client = MockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 136μs -> 137μs (0.298% slower)

def test_large_tree_with_mixed_files_and_folders():
    """A tree with 5 top-level subfolders, each with 5 subfolders, each with 20 files."""
    structure = {"root": []}
    for i in range(5):
        sub_id = f"sub{i}"
        structure["root"].append({"id": sub_id, "mimeType": "application/vnd.google-apps.folder"})
        structure[sub_id] = []
        for j in range(5):
            subsub_id = f"sub{i}_{j}"
            structure[sub_id].append({"id": subsub_id, "mimeType": "application/vnd.google-apps.folder"})
            structure[subsub_id] = [
                {"id": f"f{i}_{j}_{k}", "mimeType": "application/pdf", "fileExtension": "pdf"} for k in range(20)
            ]
    client = MockFilesClient(structure)
    # 5*5*20 = 500 files
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 120μs -> 120μs (0.806% slower)

def test_large_pagination():
    """Test that pagination is handled correctly (folder with 500 files, pageSize=100)."""
    # We'll tweak the MockFilesClient to use pageSize=100 in the test
    structure = {
        "root": [
            {"id": f"f{i}", "mimeType": "application/pdf", "fileExtension": "pdf"} for i in range(500)
        ]
    }
    class PaginationMockFilesClient(MockFilesClient):
        def list(self, *args, **kwargs):
            # Force pageSize=100 for this test
            kwargs["pageSize"] = 100
            return super().list(*args, **kwargs)
    client = PaginationMockFilesClient(structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 75.0μs -> 76.6μs (2.01% slower)

def test_large_with_extension_filter():
    """Large folder with mixed extensions, filter for a specific extension."""
    structure = {
        "root": [
            {"id": f"f{i}", "mimeType": "application/pdf", "fileExtension": "pdf"} if i % 2 == 0
            else {"id": f"f{i}", "mimeType": "text/plain", "fileExtension": "txt"}
            for i in range(1000)
        ]
    }
    client = MockFilesClient(structure)
    # Only even-indexed files are pdf (500 files)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf"]) # 493μs -> 234μs (110% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
#------------------------------------------------
from dataclasses import dataclass, field

# imports
import pytest  # used for our unit tests
# function to test
from googleapiclient.discovery import Resource as GoogleAPIResource
from unstructured_ingest.interfaces import Indexer
from unstructured_ingest.processes.connectors.google_drive import \
    GoogleDriveIndexer

# Helper classes for mocking Google Drive API

class FakeListResponse:
    """Mock response for files().list().execute()"""
    def __init__(self, files, nextPageToken=None):
        self._files = files
        self._nextPageToken = nextPageToken

    def execute(self):
        return {"files": self._files, "nextPageToken": self._nextPageToken}


class FakeFilesClient:
    """
    Mocks the files().list().execute() API.
    The structure is:
        folder_id -> list of file dicts (with id, mimeType, fileExtension)
        Optionally, for pagination, a folder_id can map to a list of (files, nextPageToken) tuples.
    """
    def __init__(self, folder_structure, paginated=False):
        self.folder_structure = folder_structure
        self.paginated = paginated
        self.calls = []  # Track calls for debugging

    def list(self, supportsAllDrives, includeItemsFromAllDrives, spaces, q, fields, pageToken, pageSize):
        folder_id = q.split("'")[1]
        self.calls.append((folder_id, pageToken))
        if not self.paginated:
            files = self.folder_structure.get(folder_id, [])
            return FakeListResponse(files)
        else:
            # folder_structure[folder_id] is a list of (files, nextPageToken) tuples
            pages = self.folder_structure.get(folder_id, [])
            if not pageToken:
                # Return first page
                files, nextPageToken = pages[0]
                return FakeListResponse(files, nextPageToken)
            else:
                # Find the page with the given token
                for files, token in pages:
                    if token == pageToken:
                        # Return next page (or empty if last)
                        idx = pages.index((files, token))
                        if idx + 1 < len(pages):
                            files2, nextPageToken2 = pages[idx + 1]
                            return FakeListResponse(files2, nextPageToken2)
                        else:
                            return FakeListResponse([], None)
                return FakeListResponse([], None)

# -------------------- UNIT TESTS --------------------

# BASIC TEST CASES

def test_empty_folder():
    # Test counting files in an empty folder (should return 0)
    folder_structure = {
        "root": []
    }
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 7.03μs -> 7.44μs (5.52% slower)

def test_folder_with_files_only():
    # Test folder containing only files (no subfolders)
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 4.97μs -> 5.33μs (6.78% slower)

def test_folder_with_subfolders_and_files():
    # Test folder containing files and one subfolder with files
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub1": [
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
            {"id": "f3", "mimeType": "image/png", "fileExtension": "png"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 7.82μs -> 8.03μs (2.62% slower)

def test_folder_with_multiple_levels_of_subfolders():
    # Test nested subfolders (root -> sub1 -> sub2)
    folder_structure = {
        "root": [
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub1": [
            {"id": "sub2", "mimeType": "application/vnd.google-apps.folder"},
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
        ],
        "sub2": [
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 9.02μs -> 9.09μs (0.726% slower)

def test_folder_with_only_subfolders_no_files():
    # Test folder with only subfolders, no files anywhere
    folder_structure = {
        "root": [
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
            {"id": "sub2", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub1": [],
        "sub2": [],
    }
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 8.74μs -> 9.06μs (3.52% slower)

def test_extension_filter_basic():
    # Test counting files with extension filter
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
            {"id": "f3", "mimeType": "image/png", "fileExtension": "png"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    # Only count 'pdf' files
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf"]) # 7.88μs -> 8.14μs (3.20% slower)
    # Count 'pdf' and 'png'
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf", "png"]) # 4.96μs -> 4.82μs (2.95% faster)

def test_extension_filter_case_insensitive():
    # Test that extension filter is case-insensitive
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "TXT"},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "Pdf"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["txt"]) # 6.56μs -> 7.07μs (7.24% slower)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["PDF"]) # 3.97μs -> 4.09μs (3.03% slower)

def test_extension_filter_with_missing_fileExtension():
    # Test files with missing fileExtension field
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain"},  # No fileExtension
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    # Only 'f2' should be counted with extension filter
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf"]) # 6.57μs -> 6.81μs (3.54% slower)
    # Without extension filter, both should be counted
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 3.01μs -> 3.07μs (1.92% slower)

# EDGE TEST CASES


def test_files_with_none_fileExtension():
    # Test files where fileExtension is explicitly None
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": None},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    # Only f2 should be counted with extension filter
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf"]) # 9.82μs -> 10.7μs (8.14% slower)
    # Both should be counted without extension filter
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 3.14μs -> 3.21μs (2.15% slower)

def test_files_with_empty_fileExtension():
    # Test files where fileExtension is empty string
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": ""},
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    # Only f2 should match extension filter
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf"]) # 7.30μs -> 7.71μs (5.41% slower)
    # Both should be counted without extension filter
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 2.91μs -> 3.07μs (5.40% slower)

def test_folder_with_no_files_key_in_response():
    # Test when the API returns no 'files' key in the response (should be treated as empty)
    class NoFilesKeyClient:
        def list(self, **kwargs):
            class Resp:
                def execute(self):
                    return {}
            return Resp()
    client = NoFilesKeyClient()
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 13.9μs -> 14.1μs (0.981% slower)


def test_folder_with_files_key_but_empty_list():
    # Test when the API returns 'files': []
    class EmptyFilesKeyClient:
        def list(self, **kwargs):
            class Resp:
                def execute(self):
                    return {"files": []}
            return Resp()
    client = EmptyFilesKeyClient()
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 14.8μs -> 15.1μs (1.50% slower)

def test_files_with_missing_mimeType():
    # Test files with missing mimeType (should be counted as files, not folders)
    folder_structure = {
        "root": [
            {"id": "f1", "fileExtension": "txt"},  # No mimeType
            {"id": "f2", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    # Both should be counted as files
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 7.48μs -> 7.96μs (6.00% slower)


def test_files_with_other_mimeType():
    # Test files with random mimeType (should be counted as files, not folders)
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "application/zip", "fileExtension": "zip"},
            {"id": "f2", "mimeType": "image/jpeg", "fileExtension": "jpg"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 8.38μs -> 8.84μs (5.19% slower)

def test_folder_with_duplicate_file_ids():
    # Test files with duplicate ids in different folders (should count all)
    folder_structure = {
        "root": [
            {"id": "f1", "mimeType": "text/plain", "fileExtension": "txt"},
            {"id": "sub1", "mimeType": "application/vnd.google-apps.folder"},
        ],
        "sub1": [
            {"id": "f1", "mimeType": "application/pdf", "fileExtension": "pdf"},
        ]
    }
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 8.16μs -> 8.40μs (2.92% slower)

# LARGE SCALE TEST CASES

def test_large_flat_folder():
    # Test a flat folder with 999 files
    files = [{"id": f"f{i}", "mimeType": "text/plain", "fileExtension": "txt"} for i in range(999)]
    folder_structure = {"root": files}
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 109μs -> 110μs (0.734% slower)

def test_large_nested_folders():
    # Test a folder with 10 levels of nesting, each with 10 files
    folder_structure = {}
    prev = "root"
    total_files = 0
    for depth in range(10):
        sub = f"sub{depth}"
        # Each folder has 10 files
        files = [{"id": f"f{depth}_{i}", "mimeType": "text/plain", "fileExtension": "txt"} for i in range(10)]
        folder_structure[prev] = [{"id": sub, "mimeType": "application/vnd.google-apps.folder"}] + files
        prev = sub
        total_files += 10
    # Last folder has 10 files, no subfolders
    folder_structure[prev] = [{"id": f"f_last_{i}", "mimeType": "text/plain", "fileExtension": "txt"} for i in range(10)]
    total_files += 10
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 32.5μs -> 33.2μs (2.25% slower)

def test_large_folder_with_extension_filter():
    # Test a flat folder with 500 txt files, 499 pdf files, filter for pdf
    files = (
        [{"id": f"t{i}", "mimeType": "text/plain", "fileExtension": "txt"} for i in range(500)] +
        [{"id": f"p{i}", "mimeType": "application/pdf", "fileExtension": "pdf"} for i in range(499)]
    )
    folder_structure = {"root": files}
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root", extensions=["pdf"]) # 490μs -> 231μs (112% faster)

def test_large_pagination():
    # Test paginated results: folder with 3 pages of 400 files each (total 1200 files, but we limit to 999)
    # We'll only test up to 999 files due to the instructions.
    files1 = [{"id": f"f{i}", "mimeType": "text/plain", "fileExtension": "txt"} for i in range(333)]
    files2 = [{"id": f"f{i}", "mimeType": "text/plain", "fileExtension": "txt"} for i in range(333, 666)]
    files3 = [{"id": f"f{i}", "mimeType": "text/plain", "fileExtension": "txt"} for i in range(666, 999)]
    folder_structure = {
        "root": [
            (files1, "page1"),
            (files2, "page2"),
            (files3, None),
        ]
    }
    client = FakeFilesClient(folder_structure, paginated=True)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 115μs -> 117μs (1.08% slower)

def test_large_tree_with_mixed_files_and_folders():
    # Test a tree with 10 folders, each with 10 subfolders, each with 9 files (total: 10*10*9 = 900)
    folder_structure = {}
    for i in range(10):
        root_sub = f"sub{i}"
        folder_structure["root"] = folder_structure.get("root", []) + [{"id": root_sub, "mimeType": "application/vnd.google-apps.folder"}]
        for j in range(10):
            sub_sub = f"{root_sub}_{j}"
            folder_structure[root_sub] = folder_structure.get(root_sub, []) + [{"id": sub_sub, "mimeType": "application/vnd.google-apps.folder"}]
            # Each sub_sub has 9 files
            files = [{"id": f"{sub_sub}_f{k}", "mimeType": "text/plain", "fileExtension": "txt"} for k in range(9)]
            folder_structure[sub_sub] = files
    client = FakeFilesClient(folder_structure)
    codeflash_output = GoogleDriveIndexer.count_files_recursively(client, "root") # 281μs -> 285μs (1.15% slower)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


To edit these changes `git checkout codeflash/optimize-GoogleDriveIndexer.count_files_recursively-memp2nq3` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)