### PR TITLE
fix: only send fields in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.15
+
+* **Fix: Filter out fields that aren't part of our Page subclass data model. This guards against API changes that are potentially nonbreaking.**
+
 ## 1.2.14
 
 * **Fix: IBM watsonx.data S3 bucket authentication fix**

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ tidy-ruff:
 tidy-shell:
 	shfmt -i 2 -l -w ${SHELL_FILES}
 
+## version-sync:                update references to version with most recent version from CHANGELOG.md
+.PHONY: version-sync
+version-sync:
+	scripts/version-sync.sh \
+		-f ${PACKAGE_NAME}/__version__.py release
+
 ###########
 #  CHECK  #
 ###########

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.14"  # pragma: no cover
+__version__ = "1.2.15"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/notion/types/page.py
+++ b/unstructured_ingest/processes/connectors/notion/types/page.py
@@ -1,5 +1,5 @@
 # https://developers.notion.com/reference/page
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Optional
 
 from unstructured_ingest.processes.connectors.notion.interfaces import FromJSONMixin
@@ -28,18 +28,25 @@ class Page(FromJSONMixin):
 
     @classmethod
     def from_dict(cls, data: dict):
+        data = data.copy()  # Don't modify the original
         created_by = data.pop("created_by")
         last_edited_by = data.pop("last_edited_by")
         icon = data.pop("icon")
         cover = data.pop("cover")
         parent = data.pop("parent")
+
+        # Filter data to only include fields that exist in the dataclass
+        filtered_data = {
+            k: v for k, v in data.items() if k in {field.name for field in fields(cls)}
+        }
+
         page = cls(
             created_by=PartialUser.from_dict(created_by),
             last_edited_by=PartialUser.from_dict(last_edited_by),
             icon=FileObject.from_dict(icon) if icon else None,
             cover=FileObject.from_dict(cover) if cover else None,
             parent=Parent.from_dict(parent),
-            **data,
+            **filtered_data,
         )
 
         return page


### PR DESCRIPTION
Change to fix notion CI, but also make connectors a bit more robust.

Filters fields to pass only those in the data model to the `Page` constructor.