### PR TITLE
feat: Add BM25 lexical search support for Milvus destination

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,10 @@ test = [
     "htmlBuilder",
     "office365-rest-python-client",
 ]
+dev = [
+    "pymilvus>=2.6.9",
+    "pytest>=9.0.2",
+]
 
 [project.scripts]
 unstructured-ingest = "unstructured_ingest.main:main"

--- a/test/unit/processes/connectors/test_milvus.py
+++ b/test/unit/processes/connectors/test_milvus.py
@@ -1,0 +1,95 @@
+import pytest
+
+from unstructured_ingest.processes.connectors.milvus import (
+    MilvusUploadStager,
+    MilvusUploadStagerConfig,
+)
+from unstructured_ingest.utils.dep_check import dependency_exists
+
+# Skip all tests if pymilvus is not available
+pytestmark = pytest.mark.skipif(
+    not dependency_exists("pymilvus"),
+    reason="pymilvus is not installed. Install with: pip install 'unstructured-ingest[milvus]'",
+)
+
+
+def test_enable_lexical_search_flag_default():
+    """Test that enable_lexical_search defaults to False."""
+    config = MilvusUploadStagerConfig()
+    assert config.enable_lexical_search is False
+
+
+def test_enable_lexical_search_flag_enabled():
+    """Test that enable_lexical_search can be set to True."""
+    config = MilvusUploadStagerConfig(enable_lexical_search=True)
+    assert config.enable_lexical_search is True
+
+
+def test_create_bm25_schema_basic():
+    """Test that create_bm25_schema produces correct schema structure."""
+    schema, index_params = MilvusUploadStager.create_bm25_schema(
+        collection_name="test_collection"
+    )
+
+    # Check schema has correct fields
+    field_names = [field.name for field in schema.fields]
+    assert "text" in field_names
+    assert "sparse_vector" in field_names
+    assert "embedding" in field_names
+    assert "id" in field_names
+
+    # Check text field has enable_analyzer
+    text_field = next(f for f in schema.fields if f.name == "text")
+    assert text_field.params.get("enable_analyzer") is True
+
+    # Check sparse_vector field type
+    from pymilvus import DataType
+    sparse_vector_field = next(f for f in schema.fields if f.name == "sparse_vector")
+    assert sparse_vector_field.dtype == DataType.SPARSE_FLOAT_VECTOR
+
+    # Check BM25 function exists
+    assert len(schema.functions) == 1
+    bm25_fn = schema.functions[0]
+    assert bm25_fn.name == "bm25_fn"
+    assert "text" in bm25_fn.input_field_names
+    assert "sparse_vector" in bm25_fn.output_field_names
+
+
+def test_create_bm25_schema_custom_vector_dim():
+    """Test that create_bm25_schema respects custom vector dimension."""
+    schema, index_params = MilvusUploadStager.create_bm25_schema(
+        collection_name="test_collection",
+        vector_dim=768
+    )
+
+    embedding_field = next(f for f in schema.fields if f.name == "embedding")
+    assert embedding_field.params["dim"] == 768
+
+
+def test_create_bm25_schema_index_params():
+    """Test that create_bm25_schema returns correct index parameters."""
+    schema, index_params = MilvusUploadStager.create_bm25_schema(
+        collection_name="test_collection"
+    )
+
+    assert "embedding" in index_params
+    assert "sparse_vector" in index_params
+
+    assert index_params["embedding"]["metric_type"] == "COSINE"
+    assert index_params["sparse_vector"]["index_type"] == "SPARSE_INVERTED_INDEX"
+    assert index_params["sparse_vector"]["metric_type"] == "BM25"
+
+
+def test_create_bm25_schema_dynamic_field():
+    """Test that create_bm25_schema respects enable_dynamic_field setting."""
+    schema_enabled, _ = MilvusUploadStager.create_bm25_schema(
+        collection_name="test_collection",
+        enable_dynamic_field=True
+    )
+    assert schema_enabled.enable_dynamic_field is True
+
+    schema_disabled, _ = MilvusUploadStager.create_bm25_schema(
+        collection_name="test_collection",
+        enable_dynamic_field=False
+    )
+    assert schema_disabled.enable_dynamic_field is False

--- a/unstructured_ingest/processes/connectors/milvus.py
+++ b/unstructured_ingest/processes/connectors/milvus.py
@@ -84,6 +84,12 @@ class MilvusUploadStagerConfig(UploadStagerConfig):
     flatten_metadata: bool = True
     """If set - flatten "metadata" key and put contents directly into data"""
 
+    enable_lexical_search: bool = Field(
+        default=False,
+        description="Enable BM25 full-text search. Requires Milvus 2.5+ and collection "
+        "schema with BM25 function. See documentation for schema setup."
+    )
+
 
 @dataclass
 class MilvusUploadStager(UploadStager):
@@ -155,6 +161,98 @@ class MilvusUploadStager(UploadStager):
                 working_data[json_dumps_field] = json.dumps(working_data[json_dumps_field])
         working_data[RECORD_ID_LABEL] = file_data.identifier
         return working_data
+
+    @staticmethod
+    @requires_dependencies(["pymilvus"], extras="milvus")
+    def create_bm25_schema(
+        collection_name: str,
+        vector_dim: int = 384,
+        enable_dynamic_field: bool = True
+    ):
+        """Create a Milvus collection schema with BM25 full-text search support.
+
+        This helper creates a schema compatible with Milvus 2.5+ BM25 Function API that
+        automatically generates sparse vectors from text content for lexical search.
+
+        Args:
+            collection_name: Name for the collection
+            vector_dim: Dimension of dense embedding vectors (default: 384)
+            enable_dynamic_field: Allow dynamic fields in documents (default: True)
+
+        Returns:
+            tuple: (schema, index_params) ready for MilvusClient.create_collection()
+
+        Example:
+            >>> from pymilvus import MilvusClient
+            >>> from unstructured_ingest.processes.connectors.milvus import MilvusUploadStager
+            >>>
+            >>> client = MilvusClient(uri="http://localhost:19530")
+            >>> schema, index_params = MilvusUploadStager.create_bm25_schema(
+            ...     collection_name="my_docs",
+            ...     vector_dim=384
+            ... )
+            >>> client.create_collection(
+            ...     collection_name="my_docs",
+            ...     schema=schema,
+            ...     index_params=index_params
+            ... )
+            >>>
+            >>> # Now ingest with enable_lexical_search=True
+            >>> # BM25 function auto-generates sparse_vector from text field
+        """
+        from pymilvus import (
+            CollectionSchema,
+            DataType,
+            FieldSchema,
+            Function,
+            FunctionType,
+        )
+
+        fields = [
+            FieldSchema(
+                name="id",
+                dtype=DataType.INT64,
+                is_primary=True,
+                auto_id=True
+            ),
+            FieldSchema(
+                name="text",
+                dtype=DataType.VARCHAR,
+                max_length=65535,
+                enable_analyzer=True  # Required for BM25
+            ),
+            FieldSchema(
+                name="sparse_vector",
+                dtype=DataType.SPARSE_FLOAT_VECTOR
+            ),
+            FieldSchema(
+                name="embedding",
+                dtype=DataType.FLOAT_VECTOR,
+                dim=vector_dim
+            ),
+        ]
+
+        # BM25 function auto-generates sparse_vector from text
+        bm25_function = Function(
+            name="bm25_fn",
+            function_type=FunctionType.BM25,
+            input_field_names=["text"],
+            output_field_names=["sparse_vector"]
+        )
+
+        schema = CollectionSchema(
+            fields=fields,
+            enable_dynamic_field=enable_dynamic_field,
+            functions=[bm25_function]
+        )
+
+        # Index params for both dense and sparse vectors
+        index_params = {
+            "embedding": {"index_type": "AUTOINDEX", "metric_type": "COSINE"},
+            "sparse_vector": {"index_type": "SPARSE_INVERTED_INDEX", "metric_type": "BM25"}
+        }
+
+        return schema, index_params
 
 
 class MilvusUploaderConfig(UploaderConfig):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -2075,6 +2075,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
     { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175, upload-time = "2026-01-23T16:00:56.213Z" },
     { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401, upload-time = "2026-01-23T16:05:26.365Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", size = 601161, upload-time = "2026-01-23T16:15:53.456Z" },
     { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", size = 590272, upload-time = "2026-01-23T15:32:49.411Z" },
     { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", size = 1550729, upload-time = "2026-01-23T16:04:20.867Z" },
     { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", size = 1615552, upload-time = "2026-01-23T15:33:45.743Z" },
@@ -2083,6 +2084,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/c8/9d76a66421d1ae24340dfae7e79c313957f6e3195c144d2c73333b5bfe34/greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975", size = 276443, upload-time = "2026-01-23T15:30:10.066Z" },
     { url = "https://files.pythonhosted.org/packages/81/99/401ff34bb3c032d1f10477d199724f5e5f6fbfb59816ad1455c79c1eb8e7/greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36", size = 597359, upload-time = "2026-01-23T16:00:57.394Z" },
     { url = "https://files.pythonhosted.org/packages/2b/bc/4dcc0871ed557792d304f50be0f7487a14e017952ec689effe2180a6ff35/greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba", size = 607805, upload-time = "2026-01-23T16:05:28.068Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/7a7ca57588dac3389e97f7c9521cb6641fd8b6602faf1eaa4188384757df/greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca", size = 622363, upload-time = "2026-01-23T16:15:54.754Z" },
     { url = "https://files.pythonhosted.org/packages/cf/05/821587cf19e2ce1f2b24945d890b164401e5085f9d09cbd969b0c193cd20/greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336", size = 609947, upload-time = "2026-01-23T15:32:51.004Z" },
     { url = "https://files.pythonhosted.org/packages/a4/52/ee8c46ed9f8babaa93a19e577f26e3d28a519feac6350ed6f25f1afee7e9/greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1", size = 1567487, upload-time = "2026-01-23T16:04:22.125Z" },
     { url = "https://files.pythonhosted.org/packages/8f/7c/456a74f07029597626f3a6db71b273a3632aecb9afafeeca452cfa633197/greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149", size = 1636087, upload-time = "2026-01-23T15:33:47.486Z" },
@@ -2091,6 +2093,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -7250,6 +7253,10 @@ zendesk = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "pymilvus" },
+    { name = "pytest" },
+]
 lint = [
     { name = "ruff" },
 ]
@@ -7424,6 +7431,10 @@ requires-dist = [
 provides-extras = ["airtable", "astradb", "azure", "azure-ai-search", "bedrock", "biomed", "box", "chroma", "clarifai", "confluence", "couchbase", "databricks-delta-tables", "databricks-volumes", "delta-table", "discord", "doc", "docx", "dropbox", "duckdb", "elasticsearch", "epub", "gcs", "github", "gitlab", "google-drive", "hubspot", "huggingface", "ibm-watsonx-s3", "image", "jira", "kafka", "kdbai", "lancedb", "md", "milvus", "mixedbreadai", "mongodb", "neo4j", "notion", "octoai", "odt", "onedrive", "openai", "opensearch", "org", "outlook", "pdf", "pinecone", "postgres", "ppt", "pptx", "qdrant", "reddit", "redis", "remote", "rst", "rtf", "s3", "salesforce", "sftp", "sharepoint", "singlestore", "slack", "snowflake", "teradata", "togetherai", "tsv", "vastdb", "vectara", "vertexai", "voyageai", "weaviate", "wikipedia", "xlsx", "zendesk"]
 
 [package.metadata.requires-dev]
+dev = [
+    { name = "pymilvus", specifier = ">=2.6.9" },
+    { name = "pytest", specifier = ">=9.0.2" },
+]
 lint = [{ name = "ruff" }]
 release = [
     { name = "build" },


### PR DESCRIPTION
## Summary
- Add `enable_lexical_search` configuration flag to Milvus destination connector
- Add `create_bm25_schema()` helper method for creating BM25-enabled collection schemas
- Add unit tests for new configuration and schema generation

## Details

This PR adds support for BM25 lexical (full-text) search in Milvus destinations using Milvus 2.5+ built-in BM25 Function API.

**Key Changes:**

1. **Configuration Flag**: Added `enable_lexical_search` boolean field to `MilvusUploadStagerConfig`
   - Defaults to `False` for backward compatibility
   - Requires Milvus 2.5+ and BM25-enabled collection schema

2. **Schema Helper**: Added `create_bm25_schema()` static method to `MilvusUploadStager`
   - Creates collection schema with BM25 Function that auto-generates sparse vectors
   - Includes proper field configuration: `text` field with `enable_analyzer=True`, `sparse_vector` field, dense `embedding` field
   - Returns schema and index params ready for `MilvusClient.create_collection()`

3. **Tests**: Added comprehensive unit tests
   - Test configuration flag default and custom values
   - Test schema structure and field types
   - Test BM25 function configuration
   - Test index parameters

**Usage Pattern:**

Collection schema must be created BEFORE ingestion using the helper:

```python
from pymilvus import MilvusClient
from unstructured_ingest.processes.connectors.milvus import MilvusUploadStager

client = MilvusClient(uri="http://localhost:19530")
schema, index_params = MilvusUploadStager.create_bm25_schema(
    collection_name="my_docs",
    vector_dim=384
)
client.create_collection(
    collection_name="my_docs",
    schema=schema,
    index_params=index_params
)

# Then ingest with enable_lexical_search=True
# BM25 function auto-generates sparse_vector from text field
```

**Requirements:**
- Milvus 2.5+ (BM25 Function API)
- Manual schema creation before ingestion
- pymilvus dependency

**Related:**
- Paired with platform-api PR that adds `enable_lexical_search` to connector config input model
- Follows AstraDB pattern for lexical search implementation

## Test Plan
- [x] Unit tests pass for new configuration flag
- [x] Unit tests pass for schema helper method
- [x] Schema structure validates correctly (text field with enable_analyzer, sparse_vector field, BM25 function)
- [x] Index params validate correctly