### PR TITLE
fix: reinstate the confluence page limit

### DIFF
--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -193,12 +193,9 @@ class ConfluenceIndexer(Indexer):
                 expand=None,
                 content_type="page",  # blogpost and comment types not currently supported
                 status=None,
+                limit=self.index_config.max_num_of_docs_from_each_space,
             )
-        # Limit the number of documents to max_num_of_docs_from_each_space
-        # Note: this is needed because the limit field in client.get_all_pages_from_space does
-        # not seem to work as expected
-        limited_pages = pages[: self.index_config.max_num_of_docs_from_each_space]
-        doc_ids = [{"space_id": space_key, "doc_id": page["id"]} for page in limited_pages]
+        doc_ids = [{"space_id": space_key, "doc_id": page["id"]} for page in pages]
         return doc_ids
 
     def run(self) -> Generator[FileData, None, None]:


### PR DESCRIPTION
Fixes Issue: Confluence page limits not working #645

Otherwise one can only get a maximum of 50 pages as this is the default of the atlassian confluence package.
The limit now seems to work as expected for client.get_all_pages_from_space.