### PR TITLE
[PLU-121]: fix Teradata connector case sensitivity for Enterprise databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.6]
+
+* **fix: normalize teradata column names to lowercase for Enterprise compatibility**
+
 ## [1.4.5]
 
 * **fix: add capability to use opensearch serverless**

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.5"  # pragma: no cover
+__version__ = "1.4.6"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/sql/teradata.py
+++ b/unstructured_ingest/processes/connectors/sql/teradata.py
@@ -154,7 +154,7 @@ class TeradataDownloader(SQLDownloader):
             logger.debug(f"running query: {query}\nwith values: {ids}")
             cursor.execute(query, ids)
             rows = cursor.fetchall()
-            columns = [col[0] for col in cursor.description]
+            columns = [col[0].lower() for col in cursor.description]
             return rows, columns
 
 
@@ -202,7 +202,7 @@ class TeradataUploader(SQLUploader):
         if self._columns is None:
             with self.get_cursor() as cursor:
                 cursor.execute(f'SELECT TOP 1 * FROM "{self.upload_config.table_name}"')
-                self._columns = [desc[0] for desc in cursor.description]
+                self._columns = [desc[0].lower() for desc in cursor.description]
         return self._columns
 
     def delete_by_record_id(self, file_data: FileData) -> None:


### PR DESCRIPTION
## Summary
- Enterprise Teradata uppercases all column names in `cursor.description`, while ClearScape Analytics preserves the original case
- This causes a `KeyError` in the downloader when it tries to look up the user-configured `id_column` (lowercase) against uppercase DataFrame columns
- Normalize column names to lowercase in `TeradataDownloader.query_db` (line 157) and `TeradataUploader.get_table_columns` (line 205)

## Root Cause
Standard Enterprise Teradata folds unquoted identifiers to uppercase per the ANSI SQL spec. The existing connector was only tested against ClearScape Analytics (Teradata's developer edition), which preserves case as-typed. When a customer pointed the connector at Enterprise Teradata, `cursor.description` returned `ID` instead of `id`, causing the downstream `result.iloc[0][id_column]` lookup to fail with `KeyError: 'id'`.

## Changes
- `TeradataDownloader.query_db`: `columns = [col[0].lower() for col in cursor.description]`
- `TeradataUploader.get_table_columns`: `self._columns = [desc[0].lower() for desc in cursor.description]`

## Test plan
- [x] Verified against patched image (`teradata-case-fix`) on SND with ClearScape source — no regression
- [ ] Customer to verify against Enterprise Teradata once deployed