### PR TITLE
fix(mongodb): add pymongo error handling to classify user vs platform errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.3]
+
+### Fixes
+
+- **fix(mongodb): map pymongo exceptions to correct error types.** `MongoDBUploader` now classifies `OperationFailure` (quota / authorization) as `QuotaError`, `ServerSelectionTimeoutError` as `TimeoutError`, `BulkWriteError` as `WriteError`, and `AutoReconnect` as `DestinationConnectionError`. Previously these all surfaced as generic `DestinationConnectionError`, which the platform controller classified as `error_type=platform` and counted against the platform-error SLO denominator. Exception ordering is preserved so subclasses are caught before their parents (`BulkWriteError` before `OperationFailure`; `ServerSelectionTimeoutError` before `AutoReconnect`).
+
 ## [1.6.2]
 
 ### Fixes

--- a/test/unit/connectors/test_mongodb_errors.py
+++ b/test/unit/connectors/test_mongodb_errors.py
@@ -1,0 +1,128 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pymongo.errors import (
+    AutoReconnect,
+    BulkWriteError,
+    OperationFailure,
+    ServerSelectionTimeoutError,
+)
+
+from unstructured_ingest.error import (
+    DestinationConnectionError,
+    QuotaError,
+    TimeoutError,
+    WriteError,
+)
+from unstructured_ingest.processes.connectors.mongodb import (
+    MongoDBConnectionConfig,
+    MongoDBUploader,
+    MongoDBUploaderConfig,
+)
+
+
+def _make_uploader():
+    connection_config = MagicMock(spec=MongoDBConnectionConfig)
+    connection_config.host = "test_host"
+    upload_config = MagicMock(spec=MongoDBUploaderConfig)
+    upload_config.record_id_key = "record_id"
+    upload_config.database = "test_db"
+    upload_config.collection = "test_collection"
+    upload_config.batch_size = 100
+    return MongoDBUploader(
+        connection_config=connection_config,
+        upload_config=upload_config,
+    )
+
+
+def _mock_client(uploader, collection_side_effect=None):
+    mock_client = MagicMock()
+    uploader.connection_config.get_client.return_value.__enter__ = MagicMock(
+        return_value=mock_client
+    )
+    uploader.connection_config.get_client.return_value.__exit__ = MagicMock(return_value=False)
+    mock_collection = mock_client.__getitem__("test_db").__getitem__("test_collection")
+    # Make can_delete return False so we skip delete_by_record_id and go straight to insert
+    mock_collection.list_indexes.return_value = []
+    if collection_side_effect:
+        mock_collection.insert_many.side_effect = collection_side_effect
+    return mock_collection
+
+
+class TestRunDataErrorHandling:
+    def test_operation_failure_quota_raises_quota_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        _mock_client(uploader, OperationFailure("quota exceeded for writes"))
+
+        with pytest.raises(QuotaError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
+    def test_operation_failure_other_raises_destination_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        _mock_client(uploader, OperationFailure("some other failure"))
+
+        with pytest.raises(DestinationConnectionError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
+    def test_server_selection_timeout_raises_timeout_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        _mock_client(uploader, ServerSelectionTimeoutError("timeout"))
+
+        with pytest.raises(TimeoutError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
+    def test_bulk_write_error_raises_write_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        _mock_client(uploader, BulkWriteError({"writeErrors": [{"errmsg": "fail"}]}))
+
+        with pytest.raises(WriteError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
+    def test_auto_reconnect_raises_destination_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        _mock_client(uploader, AutoReconnect("connection lost"))
+
+        with pytest.raises(DestinationConnectionError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
+
+class TestDeleteByRecordIdErrorHandling:
+    def test_operation_failure_quota_raises_quota_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        collection = MagicMock()
+        collection.delete_many.side_effect = OperationFailure("quota exceeded")
+
+        with pytest.raises(QuotaError):
+            uploader.delete_by_record_id(collection=collection, file_data=file_data)
+
+    def test_server_selection_timeout_raises_timeout_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        collection = MagicMock()
+        collection.delete_many.side_effect = ServerSelectionTimeoutError("timeout")
+
+        with pytest.raises(TimeoutError):
+            uploader.delete_by_record_id(collection=collection, file_data=file_data)
+
+    def test_auto_reconnect_raises_destination_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        collection = MagicMock()
+        collection.delete_many.side_effect = AutoReconnect("connection lost")
+
+        with pytest.raises(DestinationConnectionError):
+            uploader.delete_by_record_id(collection=collection, file_data=file_data)

--- a/test/unit/connectors/test_mongodb_errors.py
+++ b/test/unit/connectors/test_mongodb_errors.py
@@ -145,6 +145,19 @@ class TestRunDataErrorHandling:
         with pytest.raises(QuotaError):
             uploader.run_data(data=[{"key": "value"}], file_data=file_data)
 
+    def test_non_pymongo_exception_propagates_unchanged(self):
+        # KeyError/TypeError/ValueError from config or input-shape problems
+        # should not be relabeled as DestinationConnectionError. The narrowed
+        # `except PyMongoError` lets them propagate so they're classified by
+        # whatever caller-side logic exists upstream.
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        _mock_client(uploader, KeyError("missing config key"))
+
+        with pytest.raises(KeyError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
     def test_delete_quota_error_not_relabeled_by_run_data_catch_all(self):
         # When can_delete() is True, run_data calls delete_by_record_id inside
         # its try block. If delete raises QuotaError, run_data's catch-all

--- a/test/unit/connectors/test_mongodb_errors.py
+++ b/test/unit/connectors/test_mongodb_errors.py
@@ -1,7 +1,10 @@
 from unittest.mock import MagicMock
 
 import pytest
-from pymongo.errors import (
+
+pytest.importorskip("pymongo")
+
+from pymongo.errors import (  # noqa: E402 - import after importorskip is intentional
     AutoReconnect,
     BulkWriteError,
     OperationFailure,

--- a/test/unit/connectors/test_mongodb_errors.py
+++ b/test/unit/connectors/test_mongodb_errors.py
@@ -7,6 +7,7 @@ pytest.importorskip("pymongo")
 from pymongo.errors import (  # noqa: E402 - import after importorskip is intentional
     AutoReconnect,
     BulkWriteError,
+    NetworkTimeout,
     OperationFailure,
     ServerSelectionTimeoutError,
 )
@@ -98,6 +99,77 @@ class TestRunDataErrorHandling:
         with pytest.raises(DestinationConnectionError):
             uploader.run_data(data=[{"key": "value"}], file_data=file_data)
 
+    def test_network_timeout_raises_timeout_error(self):
+        # NetworkTimeout is a subclass of AutoReconnect; must be caught first.
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        _mock_client(uploader, NetworkTimeout("socket timeout during insert"))
+
+        with pytest.raises(TimeoutError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
+    def test_operation_failure_uses_structured_errmsg_for_quota(self):
+        # Quota detection should match the server's errmsg field, not str(e).
+        # An auth failure mentioning a database named 'quota_db' must NOT
+        # be misclassified as QuotaError.
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        false_positive = OperationFailure(
+            "auth failed",
+            code=18,
+            details={
+                "errmsg": "authentication failed",
+                "code": 18,
+                "codeName": "AuthenticationFailed",
+                "ns": "quota_db.records",
+            },
+        )
+        _mock_client(uploader, false_positive)
+
+        with pytest.raises(DestinationConnectionError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
+    def test_operation_failure_structured_quota_errmsg_raises_quota_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        structured_quota = OperationFailure(
+            "user is over quota",
+            code=8000,
+            details={"errmsg": "user is over quota", "code": 8000, "codeName": "AtlasError"},
+        )
+        _mock_client(uploader, structured_quota)
+
+        with pytest.raises(QuotaError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
+    def test_delete_quota_error_not_relabeled_by_run_data_catch_all(self):
+        # When can_delete() is True, run_data calls delete_by_record_id inside
+        # its try block. If delete raises QuotaError, run_data's catch-all
+        # must NOT relabel it as DestinationConnectionError.
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        mock_client = MagicMock()
+        uploader.connection_config.get_client.return_value.__enter__ = MagicMock(
+            return_value=mock_client
+        )
+        uploader.connection_config.get_client.return_value.__exit__ = MagicMock(return_value=False)
+        mock_collection = mock_client.__getitem__("test_db").__getitem__("test_collection")
+        # can_delete() returns True
+        mock_collection.list_indexes.return_value = [{"key": {"record_id": 1}}]
+        # delete_many raises a quota OperationFailure
+        mock_collection.delete_many.side_effect = OperationFailure(
+            "over quota",
+            code=8000,
+            details={"errmsg": "user is over quota", "code": 8000, "codeName": "AtlasError"},
+        )
+
+        with pytest.raises(QuotaError):
+            uploader.run_data(data=[{"key": "value"}], file_data=file_data)
+
 
 class TestDeleteByRecordIdErrorHandling:
     def test_operation_failure_quota_raises_quota_error(self):
@@ -126,6 +198,35 @@ class TestDeleteByRecordIdErrorHandling:
         file_data.identifier = "test_id"
         collection = MagicMock()
         collection.delete_many.side_effect = AutoReconnect("connection lost")
+
+        with pytest.raises(DestinationConnectionError):
+            uploader.delete_by_record_id(collection=collection, file_data=file_data)
+
+    def test_network_timeout_raises_timeout_error(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        collection = MagicMock()
+        collection.delete_many.side_effect = NetworkTimeout("socket timeout during delete")
+
+        with pytest.raises(TimeoutError):
+            uploader.delete_by_record_id(collection=collection, file_data=file_data)
+
+    def test_operation_failure_uses_structured_errmsg_for_quota(self):
+        uploader = _make_uploader()
+        file_data = MagicMock()
+        file_data.identifier = "test_id"
+        collection = MagicMock()
+        collection.delete_many.side_effect = OperationFailure(
+            "auth failed",
+            code=18,
+            details={
+                "errmsg": "authentication failed",
+                "code": 18,
+                "codeName": "AuthenticationFailed",
+                "ns": "quota_db.records",
+            },
+        )
 
         with pytest.raises(DestinationConnectionError):
             uploader.delete_by_record_id(collection=collection, file_data=file_data)

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.2"  # pragma: no cover
+__version__ = "1.6.3"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/mongodb.py
+++ b/unstructured_ingest/processes/connectors/mongodb.py
@@ -17,8 +17,11 @@ from unstructured_ingest.data_types.file_data import (
 from unstructured_ingest.error import (
     ConnectionError,
     DestinationConnectionError,
+    QuotaError,
     SourceConnectionError,
+    TimeoutError,
     ValueError,
+    WriteError,
 )
 from unstructured_ingest.interfaces import (
     AccessConfig,
@@ -341,18 +344,40 @@ class MongoDBUploader(Uploader):
         return self.upload_config.record_id_key in indexed_keys
 
     def delete_by_record_id(self, collection: "Collection", file_data: FileData) -> None:
+        from pymongo.errors import (
+            AutoReconnect,
+            OperationFailure,
+            ServerSelectionTimeoutError,
+        )
+
         logger.debug(
             f"deleting any content with metadata "
             f"{self.upload_config.record_id_key}={file_data.identifier} "
             f"from collection: {collection.name}"
         )
         query = {self.upload_config.record_id_key: file_data.identifier}
-        delete_results = collection.delete_many(filter=query)
+        try:
+            delete_results = collection.delete_many(filter=query)
+        except OperationFailure as e:
+            if "quota" in str(e).lower():
+                raise QuotaError(f"MongoDB quota exceeded: {e}") from e
+            raise DestinationConnectionError(f"MongoDB operation failed: {e}") from e
+        except ServerSelectionTimeoutError as e:
+            raise TimeoutError(f"MongoDB server unreachable: {e}") from e
+        except AutoReconnect as e:
+            raise DestinationConnectionError(f"MongoDB connection lost: {e}") from e
         logger.info(
             f"deleted {delete_results.deleted_count} records from collection {collection.name}"
         )
 
     def run_data(self, data: list[dict], file_data: FileData, **kwargs: Any) -> None:
+        from pymongo.errors import (
+            AutoReconnect,
+            BulkWriteError,
+            OperationFailure,
+            ServerSelectionTimeoutError,
+        )
+
         logger.info(
             f"writing {len(data)} objects to destination "
             f"db, {self.upload_config.database}, "
@@ -363,15 +388,28 @@ class MongoDBUploader(Uploader):
         # is done, setting the record id field in the uploader
         for element in data:
             element[self.upload_config.record_id_key] = file_data.identifier
-        with self.connection_config.get_client() as client:
-            db = client[self.upload_config.database]
-            collection = db[self.upload_config.collection]
-            if self.can_delete(collection=collection):
-                self.delete_by_record_id(file_data=file_data, collection=collection)
-            else:
-                logger.warning("criteria for deleting previous content not met, skipping")
-            for chunk in batch_generator(data, self.upload_config.batch_size):
-                collection.insert_many(chunk)
+        try:
+            with self.connection_config.get_client() as client:
+                db = client[self.upload_config.database]
+                collection = db[self.upload_config.collection]
+                if self.can_delete(collection=collection):
+                    self.delete_by_record_id(file_data=file_data, collection=collection)
+                else:
+                    logger.warning("criteria for deleting previous content not met, skipping")
+                for chunk in batch_generator(data, self.upload_config.batch_size):
+                    collection.insert_many(chunk)
+        except BulkWriteError as e:
+            raise WriteError(f"MongoDB bulk write failed: {e}") from e
+        except OperationFailure as e:
+            if "quota" in str(e).lower():
+                raise QuotaError(f"MongoDB quota exceeded: {e}") from e
+            raise DestinationConnectionError(f"MongoDB operation failed: {e}") from e
+        except ServerSelectionTimeoutError as e:
+            raise TimeoutError(f"MongoDB server unreachable: {e}") from e
+        except AutoReconnect as e:
+            raise DestinationConnectionError(f"MongoDB connection lost: {e}") from e
+        except Exception as e:
+            raise DestinationConnectionError(f"MongoDB error: {e}") from e
 
 
 mongodb_destination_entry = DestinationRegistryEntry(

--- a/unstructured_ingest/processes/connectors/mongodb.py
+++ b/unstructured_ingest/processes/connectors/mongodb.py
@@ -343,9 +343,21 @@ class MongoDBUploader(Uploader):
             indexed_keys.extend(key_bson.keys())
         return self.upload_config.record_id_key in indexed_keys
 
+    @staticmethod
+    def _is_quota_error(e: Exception) -> bool:
+        # Check the server's structured errmsg field (in OperationFailure.details)
+        # rather than str(e), which often includes the namespace and produced
+        # false positives like "auth failure on database 'quota_db'".
+        details = getattr(e, "details", None) or {}
+        errmsg = str(details.get("errmsg") or "").lower()
+        if not errmsg:
+            errmsg = str(getattr(e, "_message", "") or "").lower()
+        return "quota" in errmsg
+
     def delete_by_record_id(self, collection: "Collection", file_data: FileData) -> None:
         from pymongo.errors import (
             AutoReconnect,
+            NetworkTimeout,
             OperationFailure,
             ServerSelectionTimeoutError,
         )
@@ -359,11 +371,14 @@ class MongoDBUploader(Uploader):
         try:
             delete_results = collection.delete_many(filter=query)
         except OperationFailure as e:
-            if "quota" in str(e).lower():
+            if self._is_quota_error(e):
                 raise QuotaError(f"MongoDB quota exceeded: {e}") from e
             raise DestinationConnectionError(f"MongoDB operation failed: {e}") from e
         except ServerSelectionTimeoutError as e:
             raise TimeoutError(f"MongoDB server unreachable: {e}") from e
+        except NetworkTimeout as e:
+            # Must come before AutoReconnect: NetworkTimeout is a subclass.
+            raise TimeoutError(f"MongoDB network timeout: {e}") from e
         except AutoReconnect as e:
             raise DestinationConnectionError(f"MongoDB connection lost: {e}") from e
         logger.info(
@@ -374,6 +389,7 @@ class MongoDBUploader(Uploader):
         from pymongo.errors import (
             AutoReconnect,
             BulkWriteError,
+            NetworkTimeout,
             OperationFailure,
             ServerSelectionTimeoutError,
         )
@@ -398,14 +414,21 @@ class MongoDBUploader(Uploader):
                     logger.warning("criteria for deleting previous content not met, skipping")
                 for chunk in batch_generator(data, self.upload_config.batch_size):
                     collection.insert_many(chunk)
+        except (QuotaError, TimeoutError, WriteError, DestinationConnectionError):
+            # Internal types raised by delete_by_record_id (or future helpers).
+            # Must come before the broad except blocks so they aren't relabeled.
+            raise
         except BulkWriteError as e:
             raise WriteError(f"MongoDB bulk write failed: {e}") from e
         except OperationFailure as e:
-            if "quota" in str(e).lower():
+            if self._is_quota_error(e):
                 raise QuotaError(f"MongoDB quota exceeded: {e}") from e
             raise DestinationConnectionError(f"MongoDB operation failed: {e}") from e
         except ServerSelectionTimeoutError as e:
             raise TimeoutError(f"MongoDB server unreachable: {e}") from e
+        except NetworkTimeout as e:
+            # Must come before AutoReconnect: NetworkTimeout is a subclass.
+            raise TimeoutError(f"MongoDB network timeout: {e}") from e
         except AutoReconnect as e:
             raise DestinationConnectionError(f"MongoDB connection lost: {e}") from e
         except Exception as e:

--- a/unstructured_ingest/processes/connectors/mongodb.py
+++ b/unstructured_ingest/processes/connectors/mongodb.py
@@ -20,6 +20,7 @@ from unstructured_ingest.error import (
     QuotaError,
     SourceConnectionError,
     TimeoutError,
+    UnstructuredIngestError,
     ValueError,
     WriteError,
 )
@@ -414,9 +415,10 @@ class MongoDBUploader(Uploader):
                     logger.warning("criteria for deleting previous content not met, skipping")
                 for chunk in batch_generator(data, self.upload_config.batch_size):
                     collection.insert_many(chunk)
-        except (QuotaError, TimeoutError, WriteError, DestinationConnectionError):
-            # Internal types raised by delete_by_record_id (or future helpers).
-            # Must come before the broad except blocks so they aren't relabeled.
+        except UnstructuredIngestError:
+            # Internal types raised by delete_by_record_id (or future helpers)
+            # propagate unchanged. Placed before the pymongo handlers and the
+            # broad `except Exception` so they aren't reclassified.
             raise
         except BulkWriteError as e:
             raise WriteError(f"MongoDB bulk write failed: {e}") from e

--- a/unstructured_ingest/processes/connectors/mongodb.py
+++ b/unstructured_ingest/processes/connectors/mongodb.py
@@ -392,6 +392,7 @@ class MongoDBUploader(Uploader):
             BulkWriteError,
             NetworkTimeout,
             OperationFailure,
+            PyMongoError,
             ServerSelectionTimeoutError,
         )
 
@@ -417,8 +418,7 @@ class MongoDBUploader(Uploader):
                     collection.insert_many(chunk)
         except UnstructuredIngestError:
             # Internal types raised by delete_by_record_id (or future helpers)
-            # propagate unchanged. Placed before the pymongo handlers and the
-            # broad `except Exception` so they aren't reclassified.
+            # propagate unchanged.
             raise
         except BulkWriteError as e:
             raise WriteError(f"MongoDB bulk write failed: {e}") from e
@@ -433,7 +433,11 @@ class MongoDBUploader(Uploader):
             raise TimeoutError(f"MongoDB network timeout: {e}") from e
         except AutoReconnect as e:
             raise DestinationConnectionError(f"MongoDB connection lost: {e}") from e
-        except Exception as e:
+        except PyMongoError as e:
+            # Any other pymongo exception we haven't enumerated. Non-pymongo
+            # exceptions (KeyError, TypeError, ValueError from config/input
+            # validation) deliberately propagate unchanged - those are not
+            # destination connection problems and shouldn't be relabeled.
             raise DestinationConnectionError(f"MongoDB error: {e}") from e
 
 


### PR DESCRIPTION
## Summary

- Add explicit pymongo exception handling to `run_data()` and `delete_by_record_id()` in the MongoDB uploader
- Pymongo exceptions were falling through to the generic `Exception` catch in `api_generator.py`, defaulting to HTTP 500 and being classified as "platform" errors — this was the largest source of SLI misattribution for the DAG Job Completions SLO (933 errors in 7 days)
- Map pymongo exceptions to appropriate error types: `OperationFailure` with quota → `QuotaError` (401), `ServerSelectionTimeoutError` → `TimeoutError` (408), `BulkWriteError` → `WriteError` (400), `AutoReconnect` → `DestinationConnectionError` (400)

## Test plan

- [x] 8 new unit tests covering all exception mappings for both `run_data()` and `delete_by_record_id()`
- [x] Ruff lint and format pass
- [ ] After deploy: query Elasticsearch to confirm MongoDB uploader errors shift from `error_type: "platform"` to `error_type: "user"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how MongoDB write/delete failures are surfaced (error type/status code), which may affect downstream error handling and retries. Logic is straightforward and covered by new unit tests, but impacts runtime classification of production failures.
> 
> **Overview**
> **MongoDB uploader errors are now explicitly classified.** `MongoDBUploader.run_data()` and `delete_by_record_id()` catch key `pymongo` exceptions and re-raise them as typed ingest errors (`QuotaError`, `TimeoutError`, `WriteError`, `DestinationConnectionError`) instead of falling through as generic failures.
> 
> Adds a focused unit test suite (`test_mongodb_errors.py`) to assert the exception-to-error mapping for both insert and delete paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75eb74098bd118d7c239fb5d827f89fe69bf54ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->