### PR TITLE
fix: make Azure anonymous access explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.21]
+
+### Fixes
+
+- **fix(azure): make anonymous access explicit for public containers** Set `anon=True` when Azure source config omits credentials and `anon=False` when explicit credentials are provided, so public-container access no longer depends on the `adlfs` default that changed in `2026.4.0`.
+
 ## [1.4.20]
 
 ### Fixes

--- a/test/unit/connectors/fsspec/test_azure.py
+++ b/test/unit/connectors/fsspec/test_azure.py
@@ -1,0 +1,56 @@
+from pydantic import Secret
+
+from unstructured_ingest.processes.connectors.fsspec.azure import (
+    AzureAccessConfig,
+    AzureConnectionConfig,
+)
+
+
+class TestAzureConnectionConfig:
+    def test_get_access_config_defaults_to_anonymous_without_credentials(self):
+        connection_config = AzureConnectionConfig(
+            access_config=Secret(AzureAccessConfig(account_name="azureunstructured1"))
+        )
+
+        assert connection_config.get_access_config() == {
+            "account_name": "azureunstructured1",
+            "anon": True,
+        }
+
+    def test_get_access_config_uses_non_anonymous_mode_with_account_key(self):
+        connection_config = AzureConnectionConfig(
+            access_config=Secret(
+                AzureAccessConfig(account_name="azureunstructured1", account_key="secret-key")
+            )
+        )
+
+        assert connection_config.get_access_config() == {
+            "account_name": "azureunstructured1",
+            "account_key": "secret-key",
+            "anon": False,
+        }
+
+    def test_get_access_config_uses_non_anonymous_mode_with_sas_token(self):
+        connection_config = AzureConnectionConfig(
+            access_config=Secret(
+                AzureAccessConfig(account_name="azureunstructured1", sas_token="secret-sas")
+            )
+        )
+
+        assert connection_config.get_access_config() == {
+            "account_name": "azureunstructured1",
+            "sas_token": "secret-sas",
+            "anon": False,
+        }
+
+    def test_get_access_config_uses_non_anonymous_mode_with_connection_string(self):
+        connection_config = AzureConnectionConfig(
+            access_config=Secret(
+                AzureAccessConfig(connection_string="UseDevelopmentStorage=true")
+            )
+        )
+
+        assert connection_config.get_access_config() == {
+            "connection_string": "UseDevelopmentStorage=true",
+            "anon": False,
+        }

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.20"  # pragma: no cover
+__version__ = "1.4.21"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/fsspec/azure.py
+++ b/unstructured_ingest/processes/connectors/fsspec/azure.py
@@ -92,10 +92,18 @@ class AzureConnectionConfig(FsspecConnectionConfig):
     connector_type: str = Field(default=CONNECTOR_TYPE, init=False)
 
     def get_access_config(self) -> dict[str, Any]:
-        # Avoid injecting None by filtering out k,v pairs where the value is None
-        access_configs: dict[str, Any] = {
-            k: v for k, v in self.access_config.get_secret_value().model_dump().items() if v
-        }
+        access_config = self.access_config.get_secret_value()
+
+        # adlfs 2026.4.0 changed anonymous access defaults. Make our intended
+        # behavior explicit instead of relying on the library default.
+        has_explicit_credentials = bool(
+            access_config.connection_string or access_config.account_key or access_config.sas_token
+        )
+
+        access_configs: dict[str, Any] = (
+            {"anon": False} if has_explicit_credentials else {"anon": True}
+        )
+        access_configs.update({k: v for k, v in access_config.model_dump().items() if v is not None})
         return access_configs
 
     @requires_dependencies(["adlfs", "fsspec"], extras="azure")

--- a/unstructured_ingest/processes/connectors/fsspec/azure.py
+++ b/unstructured_ingest/processes/connectors/fsspec/azure.py
@@ -94,8 +94,9 @@ class AzureConnectionConfig(FsspecConnectionConfig):
     def get_access_config(self) -> dict[str, Any]:
         access_config = self.access_config.get_secret_value()
 
-        # adlfs 2026.4.0 changed anonymous access defaults. Make our intended
-        # behavior explicit instead of relying on the library default.
+        # adlfs 2026.4.0 changed anonymous access defaults:
+        # https://github.com/fsspec/adlfs/releases/tag/2026.4.0
+        # Make our intended behavior explicit instead of relying on the library default.
         has_explicit_credentials = bool(
             access_config.connection_string or access_config.account_key or access_config.sas_token
         )
@@ -103,7 +104,9 @@ class AzureConnectionConfig(FsspecConnectionConfig):
         access_configs: dict[str, Any] = (
             {"anon": False} if has_explicit_credentials else {"anon": True}
         )
-        access_configs.update({k: v for k, v in access_config.model_dump().items() if v is not None})
+        access_configs.update(
+            {k: v for k, v in access_config.model_dump().items() if v is not None}
+        )
         return access_configs
 
     @requires_dependencies(["adlfs", "fsspec"], extras="azure")


### PR DESCRIPTION
## Summary
- make Azure fsspec auth behavior explicit instead of relying on `adlfs` defaults
- keep public-container access anonymous when no account key, SAS token, or connection string is provided
- add unit coverage for Azure auth config resolution
- bump release metadata for the connector fix

# Why this matters
`adlfs` changed its Azure auth default in `2026.4.0`, flipping anonymous access behavior and causing public-container reads to start attempting `DefaultAzureCredential` unless `anon=True` is set explicitly.

Release note:
https://github.com/fsspec/adlfs/releases/tag/2026.4.0

This connector already documented anonymous fallback when auth fields are omitted, but the implementation was relying on the old `adlfs` default instead of enforcing that behavior itself. This change makes the connector behavior match its documented contract.

## Testing
- `uv run --group test pytest test/unit/connectors/fsspec/test_azure.py`
- `uv run --group test --extra azure python - <<'PY'`
  verified `{'anon': True, 'account_name': 'azureunstructured1'}` can list the public fixture container with `AzureBlobFileSystem`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Azure connector authentication behavior by explicitly setting `anon` based on provided credentials; misclassification could break access to private or public containers. Adds unit tests to reduce regression risk.
> 
> **Overview**
> **Azure Blob Storage auth behavior is now explicit.** `AzureConnectionConfig.get_access_config()` sets `anon=True` when no `connection_string`, `account_key`, or `sas_token` is provided, and `anon=False` when any of those credentials are present, avoiding reliance on the `adlfs` default.
> 
> Adds unit tests covering the four credential/no-credential permutations, and bumps the package version/changelog to `1.4.21` for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b409cfba5225732f5bd5eac4cd71317ce4c8b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->