### PR TITLE
fix(teradata): auto-create table when table_name is None at upload time

### DIFF
--- a/test/unit/connectors/sql/test_teradata.py
+++ b/test/unit/connectors/sql/test_teradata.py
@@ -1173,6 +1173,54 @@ def test_teradata_uploader_precheck_schema_check_case_insensitive(
     teradata_uploader.precheck()
 
 
+def test_teradata_uploader_upload_dataframe_auto_creates_table_when_name_is_none(
+    mock_cursor: MagicMock,
+    teradata_uploader_auto_create: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """upload_dataframe calls create_destination when table_name is None."""
+    assert teradata_uploader_auto_create.upload_config.table_name is None
+
+    # create_destination: SELECT DATABASE, DBC.TablesV check (table missing), CREATE TABLE
+    # get_table_columns: SELECT TOP 1 (returns all required columns)
+    # delete_by_record_id: DELETE
+    # upload: INSERT
+    mock_cursor.fetchone.side_effect = [
+        ("test_db",),  # SELECT DATABASE
+        None,  # DBC.TablesV -> table doesn't exist
+        None,  # delete rowcount
+    ]
+    mock_cursor.description = [
+        ("id",), ("record_id",), ("element_id",),
+        ("text",), ("type",), ("metadata",),
+    ]
+    mock_cursor.rowcount = 0
+
+    df = pd.DataFrame(
+        {
+            "id": ["1"],
+            "record_id": ["r1"],
+            "element_id": ["e1"],
+            "text": ["hello"],
+            "type": ["NarrativeText"],
+            "metadata": ["{}"],
+        }
+    )
+    file_data = FileData(
+        identifier="test",
+        connector_type="teradata",
+        source_identifiers=SourceIdentifiers(filename="test.txt", fullpath="test.txt"),
+    )
+
+    teradata_uploader_auto_create.upload_dataframe(df=df, file_data=file_data)
+
+    assert teradata_uploader_auto_create.upload_config.table_name == DEFAULT_TABLE_NAME
+    calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
+    assert any("CREATE MULTISET TABLE" in c for c in calls)
+    insert_calls = [call[0][0] for call in mock_cursor.executemany.call_args_list]
+    assert any("INSERT INTO" in c for c in insert_calls)
+
+
 def test_teradata_uploader_upload_dataframe_rejects_missing_columns(
     mock_cursor: MagicMock,
     teradata_uploader: TeradataUploader,

--- a/test/unit/connectors/sql/test_teradata.py
+++ b/test/unit/connectors/sql/test_teradata.py
@@ -9,6 +9,7 @@ from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
 from unstructured_ingest.error import DestinationConnectionError, SourceConnectionError
 from unstructured_ingest.processes.connectors.sql.teradata import (
     DEFAULT_TABLE_NAME,
+    REQUIRED_DESTINATION_COLUMNS,
     TeradataAccessConfig,
     TeradataConnectionConfig,
     TeradataDownloader,
@@ -340,10 +341,11 @@ def test_teradata_uploader_upload_dataframe_quotes_column_names(
             "text": ["text1", "text2"],
             "type": ["Title", "NarrativeText"],
             "record_id": ["file1", "file1"],
+            "element_id": ["e1", "e2"],
         }
     )
 
-    teradata_uploader._columns = ["id", "text", "type", "record_id"]
+    teradata_uploader._columns = ["id", "text", "type", "record_id", "element_id"]
     mocker.patch.object(teradata_uploader, "_fit_to_schema", return_value=df)
     mocker.patch.object(teradata_uploader, "can_delete", return_value=False)
 
@@ -529,11 +531,16 @@ def test_teradata_uploader_precheck_success(
     teradata_uploader: TeradataUploader,
     mock_get_cursor: MagicMock,
 ):
-    """Test that uploader precheck only validates connection, not table existence."""
+    """Test that uploader precheck validates connection and schema."""
+    # Table exists with all required columns
+    mock_cursor.fetchone.return_value = (1,)
+    mock_cursor.fetchall.return_value = [
+        (col,) for col in ["id", "record_id", "element_id", "text", "type", "metadata"]
+    ]
     teradata_uploader.precheck()
 
-    assert mock_cursor.execute.call_count == 1
-    assert mock_cursor.execute.call_args[0][0] == "SELECT 1"
+    calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
+    assert "SELECT 1" in calls
 
 
 def test_teradata_uploader_precheck_connection_failure(
@@ -552,17 +559,21 @@ def test_teradata_uploader_precheck_connection_failure(
     assert mock_cursor.execute.call_count == 1
 
 
-def test_teradata_uploader_precheck_does_not_check_table(
+def test_teradata_uploader_precheck_skips_schema_check_when_table_missing(
     mock_cursor: MagicMock,
     teradata_uploader: TeradataUploader,
     mock_get_cursor: MagicMock,
 ):
-    """Precheck never checks table existence; create_destination handles missing tables."""
+    """Precheck skips schema validation when the table doesn't exist yet."""
+    # DBC.ColumnsV returns no rows — table doesn't exist
+    mock_cursor.fetchone.return_value = None
     teradata_uploader.precheck()
 
     calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
-    assert calls == ["SELECT 1"]
-    assert not any("SELECT TOP" in c for c in calls)
+    assert "SELECT 1" in calls
+    assert any("DBC.ColumnsV" in c for c in calls)
+    # Should not query for column names since table doesn't exist
+    assert not any("SELECT ColumnName" in c for c in calls)
 
 
 def test_teradata_uploader_precheck_rejects_dashes_in_table_name(
@@ -697,10 +708,11 @@ def test_teradata_uploader_upload_dataframe_uses_db_case_in_sql(
             "text": ["text1", "text2"],
             "type": ["Title", "NarrativeText"],
             "record_id": ["file1", "file1"],
+            "element_id": ["e1", "e2"],
         }
     )
 
-    teradata_uploader._columns = ["ID", "TEXT", "TYPE", "RECORD_ID"]
+    teradata_uploader._columns = ["ID", "TEXT", "TYPE", "RECORD_ID", "ELEMENT_ID"]
     mocker.patch.object(teradata_uploader, "_fit_to_schema", return_value=df)
     mocker.patch.object(teradata_uploader, "can_delete", return_value=False)
 
@@ -1103,3 +1115,89 @@ def test_teradata_uploader_create_destination_rejects_dashes_in_destination_name
     """create_destination raises when destination_name contains dashes."""
     with pytest.raises(DestinationConnectionError, match="cannot contain dashes"):
         teradata_uploader_auto_create.create_destination(destination_name="my-bad-table")
+
+
+def test_teradata_uploader_precheck_rejects_missing_columns(
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """Precheck raises DestinationConnectionError when table is missing required columns."""
+    # Table exists but only has id and text
+    mock_cursor.fetchone.return_value = (1,)
+    mock_cursor.fetchall.return_value = [("id",), ("text",)]
+
+    with pytest.raises(DestinationConnectionError, match="missing required columns"):
+        teradata_uploader.precheck()
+
+
+def test_teradata_uploader_precheck_schema_check_skipped_when_table_name_none(
+    mock_cursor: MagicMock,
+    teradata_uploader_auto_create: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """Precheck skips schema validation when table_name is None (auto-create mode)."""
+    teradata_uploader_auto_create.precheck()
+
+    calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
+    assert calls == ["SELECT 1"]
+
+
+def test_teradata_uploader_precheck_schema_check_tolerates_extra_columns(
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """Precheck passes when table has all required columns plus extras."""
+    mock_cursor.fetchone.return_value = (1,)
+    mock_cursor.fetchall.return_value = [
+        (col,)
+        for col in ["id", "record_id", "element_id", "text", "type", "metadata", "custom_col"]
+    ]
+    # Should not raise
+    teradata_uploader.precheck()
+
+
+def test_teradata_uploader_precheck_schema_check_case_insensitive(
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """Precheck schema validation is case-insensitive (Teradata may store uppercase)."""
+    mock_cursor.fetchone.return_value = (1,)
+    mock_cursor.fetchall.return_value = [
+        (col,)
+        for col in ["ID", "RECORD_ID", "ELEMENT_ID", "TEXT", "TYPE", "METADATA"]
+    ]
+    # Should not raise
+    teradata_uploader.precheck()
+
+
+def test_teradata_uploader_upload_dataframe_rejects_missing_columns(
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """upload_dataframe raises DestinationConnectionError when table schema is incomplete."""
+    # Table only has id and text columns
+    mock_cursor.description = [("id",), ("text",)]
+    mock_cursor.fetchall.return_value = []
+
+    df = pd.DataFrame(
+        {
+            "id": ["1"],
+            "record_id": ["r1"],
+            "element_id": ["e1"],
+            "text": ["hello"],
+            "type": ["NarrativeText"],
+            "metadata": ["{}"],
+        }
+    )
+    file_data = FileData(
+        identifier="test",
+        connector_type="teradata",
+        source_identifiers=SourceIdentifiers(filename="test.txt", fullpath="test.txt"),
+    )
+
+    with pytest.raises(DestinationConnectionError, match="missing required columns"):
+        teradata_uploader.upload_dataframe(df=df, file_data=file_data)

--- a/unstructured_ingest/processes/connectors/sql/teradata.py
+++ b/unstructured_ingest/processes/connectors/sql/teradata.py
@@ -451,6 +451,9 @@ class TeradataUploader(SQLUploader):
     def upload_dataframe(self, df: "DataFrame", file_data: FileData) -> None:
         import numpy as np
 
+        if not self.upload_config.table_name:
+            self.create_destination()
+
         table_name = self.upload_config.table_name
 
         # Validate schema before attempting any writes.

--- a/unstructured_ingest/processes/connectors/sql/teradata.py
+++ b/unstructured_ingest/processes/connectors/sql/teradata.py
@@ -37,6 +37,10 @@ if TYPE_CHECKING:
 
 CONNECTOR_TYPE = "teradata"
 DEFAULT_TABLE_NAME = "unstructuredautocreated"
+# Columns that must exist in the destination table for uploads to succeed.
+# record_id is needed for delete-before-upsert; element_id, text, and type
+# carry the core document content.
+REQUIRED_DESTINATION_COLUMNS = {"id", "record_id", "element_id", "text", "type"}
 
 
 def _summarize_error(host: str, raw: Exception, context: str = "") -> str:
@@ -378,6 +382,41 @@ class TeradataUploader(SQLUploader):
             logger.error(f"failed to validate connection: {e}", exc_info=True)
             raise DestinationConnectionError(_summarize_error(self.connection_config.host, e))
 
+        if table_name:
+            self._validate_table_schema(table_name)
+
+    def _validate_table_schema(self, table_name: str) -> None:
+        """Check that an existing table has the required columns for uploads."""
+        try:
+            with self.get_cursor() as cursor:
+                cursor.execute(
+                    "SELECT 1 FROM DBC.ColumnsV WHERE TableName = ? LIMIT 1",
+                    [table_name],
+                )
+                if not cursor.fetchone():
+                    # Table doesn't exist yet — create_destination will handle it.
+                    return
+
+                cursor.execute(
+                    "SELECT ColumnName FROM DBC.ColumnsV WHERE TableName = ?",
+                    [table_name],
+                )
+                existing = {row[0].strip().lower() for row in cursor.fetchall()}
+        except Exception:
+            # If we can't query DBC metadata, skip validation — the upload
+            # will fail with its own error if the schema is truly wrong.
+            return
+
+        missing = REQUIRED_DESTINATION_COLUMNS - existing
+        if missing:
+            raise DestinationConnectionError(
+                f"Table '{table_name}' is missing required columns: "
+                f"{', '.join(sorted(missing))}. "
+                f"Expected columns: {', '.join(sorted(REQUIRED_DESTINATION_COLUMNS))}. "
+                "Drop the table and let the connector recreate it, or "
+                "add the missing columns."
+            )
+
     def get_table_columns(self) -> list[str]:
         if self._columns is None:
             with self.get_cursor() as cursor:
@@ -412,6 +451,20 @@ class TeradataUploader(SQLUploader):
     def upload_dataframe(self, df: "DataFrame", file_data: FileData) -> None:
         import numpy as np
 
+        table_name = self.upload_config.table_name
+
+        # Validate schema before attempting any writes.
+        table_columns_lower = {col.lower() for col in self.get_table_columns()}
+        missing = REQUIRED_DESTINATION_COLUMNS - table_columns_lower
+        if missing:
+            raise DestinationConnectionError(
+                f"Table '{table_name}' is missing required columns: "
+                f"{', '.join(sorted(missing))}. "
+                f"Expected columns: {', '.join(sorted(REQUIRED_DESTINATION_COLUMNS))}. "
+                "Drop the table and let the connector recreate it, or "
+                "add the missing columns."
+            )
+
         if self.can_delete():
             self.delete_by_record_id(file_data=file_data)
         else:
@@ -429,14 +482,14 @@ class TeradataUploader(SQLUploader):
         quoted_columns = [f'"{col}"' for col in db_columns]
 
         stmt = "INSERT INTO {table_name} ({columns}) VALUES({values})".format(
-            table_name=f'"{self.upload_config.table_name}"',
+            table_name=f'"{table_name}"',
             columns=",".join(quoted_columns),
             values=",".join([self.values_delimiter for _ in columns]),
         )
         logger.info(
             f"writing a total of {len(df)} elements via"
             f" document batches to destination"
-            f" table named {self.upload_config.table_name}"
+            f" table named {table_name}"
             f" with batch size {self.upload_config.batch_size}"
         )
         for rows in split_dataframe(df=df, chunk_size=self.upload_config.batch_size):


### PR DESCRIPTION
## Summary
- When a Teradata connection is created without specifying a table name, `upload_dataframe()` now lazily calls `create_destination()` to auto-create the default table (`unstructuredautocreated`)
- Previously this caused `SELECT TOP 1 * FROM "None"` → Teradata error 3807, surfaced to users as the generic "Unexpected job failure after 3 retries"
- Added test `test_teradata_uploader_upload_dataframe_auto_creates_table_when_name_is_none`

## Test plan
- [ ] All 67 Teradata unit tests pass (`pytest test/unit/connectors/sql/test_teradata.py`)
- [ ] Create a Teradata connection with no table name, run a workflow, verify table is auto-created

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Teradata upload behavior by auto-creating the destination table when `table_name` is unset and by enforcing required-column checks before writes, which could surface new errors for existing non-conforming tables.
> 
> **Overview**
> Fixes Teradata uploads when `upload_config.table_name` is `None` by lazily calling `create_destination()` inside `upload_dataframe()` before column discovery/inserts.
> 
> Adds required-schema enforcement via `REQUIRED_DESTINATION_COLUMNS` and a new `_validate_table_schema()` used in `precheck()` (when a table name is provided) and in `upload_dataframe()` (always), raising a clearer `DestinationConnectionError` when required columns are missing while tolerating extra columns and case differences.
> 
> Updates/expands unit tests to cover the new auto-create path, schema validation behavior (missing/extra/case-insensitive), and adjusts INSERT quoting tests to include `element_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95abe53e15031315d393fdf6646dfd151f866625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->