### PR TITLE
Teradata connector support for http proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.22]
+
+### Fixes
+
+- **fix(teradata): honour HTTP_PROXY/HTTPS_PROXY for proxy-restricted environments** The teradatasql Go driver does not automatically read standard proxy environment variables. Added `_build_proxy_params()` which reads `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` at connection time and forwards them as native teradatasql parameters (`https_proxy`, `http_proxy`, `proxy_bypass_hosts`), enabling Teradata connections in environments that require an egress proxy.
+
 ## [1.4.21]
 
 ### Fixes

--- a/test/unit/connectors/sql/test_teradata.py
+++ b/test/unit/connectors/sql/test_teradata.py
@@ -19,6 +19,7 @@ from unstructured_ingest.processes.connectors.sql.teradata import (
     TeradataUploaderConfig,
     TeradataUploadStager,
     TeradataUploadStagerConfig,
+    _build_proxy_params,
     _resolve_db_column_case,
     _summarize_error,
 )
@@ -407,6 +408,58 @@ def test_summarize_error_context_overrides_regex():
     assert not result.startswith("Failed to connect")
     assert "myhost" in result
     assert "table 'password_reset_log' not found or not accessible" in result
+
+
+def test_build_proxy_params_empty(monkeypatch):
+    """No proxy env vars → empty dict."""
+    for var in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(var, raising=False)
+    assert _build_proxy_params() == {}
+
+
+def test_build_proxy_params_https_only(monkeypatch):
+    """HTTPS_PROXY alone is forwarded as https_proxy."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+    for var in ("https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(var, raising=False)
+    params = _build_proxy_params()
+    assert params["https_proxy"] == "http://proxy.example.com:8080"
+    assert "http_proxy" not in params
+    assert "proxy_bypass_hosts" not in params
+
+
+def test_build_proxy_params_lowercase_wins(monkeypatch):
+    """Lowercase env var is used when uppercase is absent."""
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.setenv("https_proxy", "http://lower.proxy:9000")
+    for var in ("HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(var, raising=False)
+    params = _build_proxy_params()
+    assert params["https_proxy"] == "http://lower.proxy:9000"
+
+
+def test_build_proxy_params_no_proxy_conversion(monkeypatch):
+    """NO_PROXY is converted: commas→pipes, leading dots→wildcards, CIDRs skipped."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy:912")
+    monkeypatch.setenv(
+        "NO_PROXY",
+        "localhost,127.0.0.1,10.0.0.0/8,.svc,.svc.cluster.local,kubernetes.default",
+    )
+    for var in ("https_proxy", "HTTP_PROXY", "http_proxy", "no_proxy"):
+        monkeypatch.delenv(var, raising=False)
+    params = _build_proxy_params()
+    bypass = params["proxy_bypass_hosts"]
+    assert "localhost" in bypass
+    assert "127.0.0.1" in bypass
+    assert "*.svc" in bypass
+    assert "*.svc.cluster.local" in bypass
+    assert "kubernetes.default" in bypass
+    # CIDR entry must be dropped
+    assert "10.0.0.0/8" not in bypass
+    assert "10.0.0.0" not in bypass
+    # Separator must be pipe
+    assert "|" in bypass
+    assert "," not in bypass
 
 
 def test_teradata_indexer_precheck_success(

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.21"  # pragma: no cover
+__version__ = "1.4.22"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/sql/teradata.py
+++ b/unstructured_ingest/processes/connectors/sql/teradata.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -69,6 +70,39 @@ def _summarize_error(host: str, raw: Exception, context: str = "") -> str:
     return prefix
 
 
+def _build_proxy_params() -> dict:
+    """Read standard proxy env vars and translate to teradatasql connection parameters.
+
+    The teradatasql Go driver does not honour HTTP_PROXY/HTTPS_PROXY automatically;
+    they must be passed explicitly as connection-string parameters.
+    NO_PROXY entries that use CIDR notation are skipped (not supported by the driver).
+    """
+    params: dict = {}
+    https_proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+    http_proxy = os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy")
+    no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+
+    if https_proxy:
+        params["https_proxy"] = https_proxy
+    if http_proxy:
+        params["http_proxy"] = http_proxy
+    if no_proxy:
+        # Convert comma-separated NO_PROXY to pipe-separated proxy_bypass_hosts.
+        # Leading dots become wildcard prefixes (.svc → *.svc).
+        # CIDR ranges (10.0.0.0/8) are skipped — not supported by teradatasql.
+        entries = [e.strip() for e in no_proxy.split(",") if e.strip()]
+        converted = []
+        for entry in entries:
+            if "/" in entry:
+                continue
+            if entry.startswith("."):
+                entry = "*" + entry
+            converted.append(entry)
+        if converted:
+            params["proxy_bypass_hosts"] = "|".join(converted)
+    return params
+
+
 def _resolve_db_column_case(
     get_cursor, table_name: str, column_name: str, cache: dict[str, dict[str, str]]
 ) -> str:
@@ -117,6 +151,7 @@ class TeradataConnectionConfig(SQLConnectionConfig):
         }
         if self.database:
             conn_params["database"] = self.database
+        conn_params.update(_build_proxy_params())
 
         connection = connect(**conn_params)
         try:


### PR DESCRIPTION
In environments with egress restrictions (e.g., air-gapped k8s clusters with a mandatory proxy), the Teradata connector's connection check fails with TCP/HTTPS timeouts. The pod has HTTPS_PROXY / HTTP_PROXY env vars set correctly, and the network path works when tested with a generic netshoot container using those same env vars.

The root cause is that the teradatasql Python library wraps a Go-based binary driver (gosqldriver/teradatasql). Go programs do not automatically honor standard HTTP_PROXY/HTTPS_PROXY environment variables unless the code explicitly reads and applies them. The Python side of teradatasql similarly does not auto-propagate these env vars into the Go driver's connection configuration.

The fix is to read the standard proxy env vars in Python and pass them explicitly as teradatasql connection parameters.

