### PR TITLE
fix(fixtures): update SharePoint and Notion integration test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.23b1]
+
+### Fixes
+
+- **fix(fixtures): update SharePoint and Notion integration test fixtures** SharePoint API now returns `isAuthoritative` in `additional_metadata`; Notion page/database HTML content updated to reflect current upstream API output.
+
 ## [1.4.22]
 
 ### Fixes

--- a/test/integration/connectors/expected_results/notion_database/downloads/1722c3765a0a8082b382ebc2c62d3f4c.html
+++ b/test/integration/connectors/expected_results/notion_database/downloads/1722c3765a0a8082b382ebc2c62d3f4c.html
@@ -199,6 +199,77 @@
     </td>
     <td>
       <div>
+        90
+      </div>
+    </td>
+    <td>
+      <div>
+        None-3
+      </div>
+    </td>
+    <td>
+      <div>
+        test-page3-in-database
+      </div>
+    </td>
+    <td>
+      <div>
+        1234567890
+      </div>
+    </td>
+    <td>
+      <div style='color: pink'>
+        Medium
+      </div>
+    </td>
+    <td>
+      <div>
+        2025-01-06
+      </div>
+    </td>
+    <td>
+      <div style='color: orange'>
+        In Review
+      </div>
+    </td>
+    <td>
+      <div>
+        <span style='color: yellow'>
+          V5
+        </span>
+        <span>
+          V6
+        </span>
+      </div>
+    </td>
+    <td>
+      <a href='https://abcde.com'>
+        https://abcde.com
+      </a>
+    </td>
+    <td>
+      <div>
+        45
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <div>
+        <span>
+          <a href='https://lh3.googleusercontent.com/a/AATXAJyU_JkTO5JUkbJ8l_RuIHq4K3KdPghBV0r9U_GU=s100'>
+            Brian Raymond
+          </a>
+        </span>
+      </div>
+    </td>
+    <td>
+      <div>
+        xyz@abc.com
+      </div>
+    </td>
+    <td>
+      <div>
         12
       </div>
     </td>
@@ -253,77 +324,6 @@
     <td>
       <div>
         6
-      </div>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <div>
-        <span>
-          <a href='https://lh3.googleusercontent.com/a/AATXAJyU_JkTO5JUkbJ8l_RuIHq4K3KdPghBV0r9U_GU=s100'>
-            Brian Raymond
-          </a>
-        </span>
-      </div>
-    </td>
-    <td>
-      <div>
-        xyz@abc.com
-      </div>
-    </td>
-    <td>
-      <div>
-        90
-      </div>
-    </td>
-    <td>
-      <div>
-        None-3
-      </div>
-    </td>
-    <td>
-      <div>
-        test-page3-in-database
-      </div>
-    </td>
-    <td>
-      <div>
-        1234567890
-      </div>
-    </td>
-    <td>
-      <div style='color: pink'>
-        Medium
-      </div>
-    </td>
-    <td>
-      <div>
-        2025-01-06
-      </div>
-    </td>
-    <td>
-      <div style='color: orange'>
-        In Review
-      </div>
-    </td>
-    <td>
-      <div>
-        <span style='color: yellow'>
-          V5
-        </span>
-        <span>
-          V6
-        </span>
-      </div>
-    </td>
-    <td>
-      <a href='https://abcde.com'>
-        https://abcde.com
-      </a>
-    </td>
-    <td>
-      <div>
-        45
       </div>
     </td>
   </tr>

--- a/test/integration/connectors/expected_results/notion_database/file_data/1722c3765a0a8082b382ebc2c62d3f4c.json
+++ b/test/integration/connectors/expected_results/notion_database/file_data/1722c3765a0a8082b382ebc2c62d3f4c.json
@@ -14,7 +14,7 @@
     },
     "date_created": "2025-01-05T18:34:00.000Z",
     "date_modified": "2025-04-25T13:45:00.000Z",
-    "date_processed": "1761568832.5411103",
+    "date_processed": "1776015867.182077",
     "permissions_data": null,
     "filesize_bytes": null
   },
@@ -34,6 +34,6 @@
     "url": "https://www.notion.so/1722c3765a0a8082b382ebc2c62d3f4c"
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp1_4nwizo/1722c3765a0a8082b382ebc2c62d3f4c.html",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpnqdhn9hy/1722c3765a0a8082b382ebc2c62d3f4c.html",
   "display_name": "1722c3765a0a8082b382ebc2c62d3f4c.html"
 }

--- a/test/integration/connectors/expected_results/notion_page/downloads/1572c3765a0a806299f0dd6999f9e4c7.html
+++ b/test/integration/connectors/expected_results/notion_page/downloads/1572c3765a0a806299f0dd6999f9e4c7.html
@@ -16,7 +16,7 @@
       <div>
         testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2
       </div>
-      <img src='https://prod-files-secure.s3.us-west-2.amazonaws.com/9e97f74a-ce4a-43ae-b704-4b8501948642/902effc2-1280-4e9c-92cc-77d940b24ac0/image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAZI2LB466Y5NGAA4D%2F20250609%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250609T113309Z&X-Amz-Expires=3600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEMv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJHMEUCIQCU6njY2f6rpFJbUuQUwT0YXViaQehjoAOW3FfykIwzhwIgFyeHHczgiH%2FT9UQfgkFvQBoNjJ4GpYKw%2FiSICCVQlLoqiAQIpP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw2Mzc0MjMxODM4MDUiDPDTKxIEADQLUaQU7ircA0dVjnh2u8Qon%2BjyXFKFDYPAVlIhSPwECX6zlrPxRkgR42931KZVtUTgWUG%2B7Qdcegw2t1ApQ9TzUZNM8MJ%2ByrZ9aFkWD6AqzsK%2BqC3v0ZoPZOSeNvM2aps6RdNZxDcRZLxKZxQdH9gqNoM4a0%2FjeJtwzminLuNA2ZnNRVKNsoKC%2FpnOK56Hee37wqYbhrAe0SiO9tzppp6FHinO0E2op4Ag6hrJVqDrRtcwVE6MeFYS83CLMW%2B0A8Jt0rrk9IjyLmabyKANwfdxOUeSYUEIouk3YwZJZWdI9r6F%2BfTJBnt%2FeseC8AYt8XQlAbZgztwJiLywNBAp8YzdROrV%2FdWDe7PQZ3d5jwktxsJyEXmujgZ%2BJoEyMswMaXmMCoqrzTg%2BhpbUKoJKLCB7Snd%2BgzNETJaNxS1vFLKq5R%2FFD07rdsenALiohWZoAY9iV3RkL81EXIubgz79EdmbLJLozruTZpDldfXCJY6TRJ9NCWQdb4t9kq2M%2Fp9H2I89ymZi3z%2F4oAwUM6Oft68xUTQEidLOp45%2BKmudDrTZmUC5tcdPkO9NwL1wXaeo3GphndsLVLmvk0g%2FxsD2ZVjG9376cDzdOmizvHC8UsJSHjcZRZG6wg0gFVDikf6s64sDfRpkMOv%2FmsIGOqUBTV%2FdV%2F8p4A7j9Sb8sUOegVjmsH%2F3TWgXoK9oOu25d%2FfMkw%2FCw%2Fqh1yU7RT4bJFUH6URJoz4Rn3de%2FkkljZgWaMD9UnO%2BvTiq9HtJZ%2F4nAxr%2BfQ7bkB6UG%2BlYHj3RPPMTVPD%2BGkBGBvRmtHDIt2KlBxCW1bU80Ok0MLYzLardJjQHmQT%2BDapp7Kd7YbVghwg6yAFkTLcpNSFJ4eQt6UqhusZKNNWs&X-Amz-Signature=6dffd3e8d69ddc5399e2fb801e23f32bd3c7de5b07042786d1bd14509ca499f1&X-Amz-SignedHeaders=host&x-id=GetObject'/>
+      <img src='https://prod-files-secure.s3.us-west-2.amazonaws.com/9e97f74a-ce4a-43ae-b704-4b8501948642/902effc2-1280-4e9c-92cc-77d940b24ac0/image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAZI2LB466XOEDGVF7%2F20260412%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260412T174430Z&X-Amz-Expires=3600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEJn%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJIMEYCIQDQuREaFdenHLuTHxdhS0d4830f81OJ0F%2B9XrJ3rb9RqwIhAJLAXAFwBXD7dqNxCzT91qEXk8DUfXxOij68YbvFD0LvKv8DCGIQABoMNjM3NDIzMTgzODA1IgxxYvBtc3PpwbzJ16Aq3AOXGdSZLf6fky%2BlXfR5%2FeamHir2%2F2vdvweeMcFA%2FgnoTBm%2F2RAJ06p3uiKn7CgQQtWnmsJBWqJcmqbeLtvbA1YeHCc8WPP%2Fdyjwoi6R7itrgGijZKZaFJRIWU1gXEAOxw%2Fj2%2FWHulnOAqzK2cAoPmbTvKEvOI%2FKMSccL1l1hYDF327F2L5qEFCo2BxxcXu2Mpa1vHCkgG5Y7feuDYuEKMA6hd8U0eIXfkxcoh1dHfQgdszT7gFHovUjMGpUKSH%2F5yec45kE0dQiZrYpDNQIkYynFT9XqZiLkI%2FDICBCCBeV1fCIukhZBt4GYqPsYLdBpJCGaHeI6zORRBLfHXXFJgN48C7HempccNNwsDV%2FLi4L9yDUsaQ1lWhymw9v28H5K1v0ldb5csbw%2FQfKqgK9TMpOGlZpZozDUDtNABVUIlQ3QcRS%2FN8BU83rs2YCzjwk5sM5y1BkJmyCyjoJGDae53sim2RqawFLS0478EtmLsz0m4YpdmDcOYYcX0J5iBuJiwfH4nlJMXiNGLDdMJTAJMQYNZeRjRx8Tvj5CjnbVw5bUB8Pbj8pySwIoYVSV%2BXNeH4NnRbZn4bjoYdxy43NQpb97MpROb69q3hMIAxF1I1bqFy7C7jxBRgGbCioqDCglu%2FOBjqkARInFXNgOasfxF7K%2FXjeKpifNWck%2FlaJWWP3e9961PuyPNbAseCOAwqCGt1HJKQwt%2FD%2FshxjS3FCEuOk4F9L8c63ozA4lkDJ8EhMYSrRJJ524rIm64HJjWvw3V274z7kmU7gaOgyisaWPpwT2pSIFn8%2BA2wbrRWb5nxXR8h0XLD7W2I7E%2BqxJbJob4RHZTucMop%2B2g868W5tMPv076OCMx0iMmAN&X-Amz-Signature=eca653a6f84ea7e3443859dc6bcb5cdc193c0c9f3277232463d6f63b9a9e8ff5&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject'/>
       <div>
         <ol style='margin-left: 0px'>
           <li>
@@ -42,22 +42,12 @@
       </ol>
       <br/>
       <div>
-        <input type='checkbox'/>
-        
-      </div>
-      <div>
         Testdoc2 Checklist Item 1
-      </div>
-      <div>
-        <input type='checkbox'/>
-        
       </div>
       <div>
         Testdoc2 Checklist Item 2 (checked)
       </div>
-      <div>
-        
-      </div>
+      <br/>
       <img src='https://pf-emoji-service--cdn.us-east-1.prod.public.atl-paas.net/standard/caa27a19-fc09-4452-b2b4-a301552fd69c/32x32/1f603.png'/>
       <img src='https://pf-emoji-service--cdn.us-east-1.prod.public.atl-paas.net/standard/caa27a19-fc09-4452-b2b4-a301552fd69c/32x32/1f603.png'/>
       <div>
@@ -137,7 +127,7 @@
           </td>
         </tr>
       </table>
-      <img src='https://prod-files-secure.s3.us-west-2.amazonaws.com/9e97f74a-ce4a-43ae-b704-4b8501948642/bef64626-dfad-4bf2-9486-0fe380e90e4f/image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAZI2LB466Y5NGAA4D%2F20250609%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250609T113309Z&X-Amz-Expires=3600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEMv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJHMEUCIQCU6njY2f6rpFJbUuQUwT0YXViaQehjoAOW3FfykIwzhwIgFyeHHczgiH%2FT9UQfgkFvQBoNjJ4GpYKw%2FiSICCVQlLoqiAQIpP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw2Mzc0MjMxODM4MDUiDPDTKxIEADQLUaQU7ircA0dVjnh2u8Qon%2BjyXFKFDYPAVlIhSPwECX6zlrPxRkgR42931KZVtUTgWUG%2B7Qdcegw2t1ApQ9TzUZNM8MJ%2ByrZ9aFkWD6AqzsK%2BqC3v0ZoPZOSeNvM2aps6RdNZxDcRZLxKZxQdH9gqNoM4a0%2FjeJtwzminLuNA2ZnNRVKNsoKC%2FpnOK56Hee37wqYbhrAe0SiO9tzppp6FHinO0E2op4Ag6hrJVqDrRtcwVE6MeFYS83CLMW%2B0A8Jt0rrk9IjyLmabyKANwfdxOUeSYUEIouk3YwZJZWdI9r6F%2BfTJBnt%2FeseC8AYt8XQlAbZgztwJiLywNBAp8YzdROrV%2FdWDe7PQZ3d5jwktxsJyEXmujgZ%2BJoEyMswMaXmMCoqrzTg%2BhpbUKoJKLCB7Snd%2BgzNETJaNxS1vFLKq5R%2FFD07rdsenALiohWZoAY9iV3RkL81EXIubgz79EdmbLJLozruTZpDldfXCJY6TRJ9NCWQdb4t9kq2M%2Fp9H2I89ymZi3z%2F4oAwUM6Oft68xUTQEidLOp45%2BKmudDrTZmUC5tcdPkO9NwL1wXaeo3GphndsLVLmvk0g%2FxsD2ZVjG9376cDzdOmizvHC8UsJSHjcZRZG6wg0gFVDikf6s64sDfRpkMOv%2FmsIGOqUBTV%2FdV%2F8p4A7j9Sb8sUOegVjmsH%2F3TWgXoK9oOu25d%2FfMkw%2FCw%2Fqh1yU7RT4bJFUH6URJoz4Rn3de%2FkkljZgWaMD9UnO%2BvTiq9HtJZ%2F4nAxr%2BfQ7bkB6UG%2BlYHj3RPPMTVPD%2BGkBGBvRmtHDIt2KlBxCW1bU80Ok0MLYzLardJjQHmQT%2BDapp7Kd7YbVghwg6yAFkTLcpNSFJ4eQt6UqhusZKNNWs&X-Amz-Signature=bec66864f82b4c369657c2ac155aca4523ca4e5f12d66648be0fd3dd15663b19&X-Amz-SignedHeaders=host&x-id=GetObject'/>
+      <img src='https://prod-files-secure.s3.us-west-2.amazonaws.com/9e97f74a-ce4a-43ae-b704-4b8501948642/bef64626-dfad-4bf2-9486-0fe380e90e4f/image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAZI2LB466XOEDGVF7%2F20260412%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260412T174430Z&X-Amz-Expires=3600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEJn%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJIMEYCIQDQuREaFdenHLuTHxdhS0d4830f81OJ0F%2B9XrJ3rb9RqwIhAJLAXAFwBXD7dqNxCzT91qEXk8DUfXxOij68YbvFD0LvKv8DCGIQABoMNjM3NDIzMTgzODA1IgxxYvBtc3PpwbzJ16Aq3AOXGdSZLf6fky%2BlXfR5%2FeamHir2%2F2vdvweeMcFA%2FgnoTBm%2F2RAJ06p3uiKn7CgQQtWnmsJBWqJcmqbeLtvbA1YeHCc8WPP%2Fdyjwoi6R7itrgGijZKZaFJRIWU1gXEAOxw%2Fj2%2FWHulnOAqzK2cAoPmbTvKEvOI%2FKMSccL1l1hYDF327F2L5qEFCo2BxxcXu2Mpa1vHCkgG5Y7feuDYuEKMA6hd8U0eIXfkxcoh1dHfQgdszT7gFHovUjMGpUKSH%2F5yec45kE0dQiZrYpDNQIkYynFT9XqZiLkI%2FDICBCCBeV1fCIukhZBt4GYqPsYLdBpJCGaHeI6zORRBLfHXXFJgN48C7HempccNNwsDV%2FLi4L9yDUsaQ1lWhymw9v28H5K1v0ldb5csbw%2FQfKqgK9TMpOGlZpZozDUDtNABVUIlQ3QcRS%2FN8BU83rs2YCzjwk5sM5y1BkJmyCyjoJGDae53sim2RqawFLS0478EtmLsz0m4YpdmDcOYYcX0J5iBuJiwfH4nlJMXiNGLDdMJTAJMQYNZeRjRx8Tvj5CjnbVw5bUB8Pbj8pySwIoYVSV%2BXNeH4NnRbZn4bjoYdxy43NQpb97MpROb69q3hMIAxF1I1bqFy7C7jxBRgGbCioqDCglu%2FOBjqkARInFXNgOasfxF7K%2FXjeKpifNWck%2FlaJWWP3e9961PuyPNbAseCOAwqCGt1HJKQwt%2FD%2FshxjS3FCEuOk4F9L8c63ozA4lkDJ8EhMYSrRJJ524rIm64HJjWvw3V274z7kmU7gaOgyisaWPpwT2pSIFn8%2BA2wbrRWb5nxXR8h0XLD7W2I7E%2BqxJbJob4RHZTucMop%2B2g868W5tMPv076OCMx0iMmAN&X-Amz-Signature=55765fac5e58fa151013f83fed98e576373918768a00d3d3355a46dffce842eb&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject'/>
       <div>
         2 Columns in ColumnList
       </div>

--- a/test/integration/connectors/expected_results/notion_page/file_data/1572c3765a0a806299f0dd6999f9e4c7.json
+++ b/test/integration/connectors/expected_results/notion_page/file_data/1572c3765a0a806299f0dd6999f9e4c7.json
@@ -14,7 +14,7 @@
     },
     "date_created": "2024-12-09T18:13:00.000Z",
     "date_modified": "2025-01-07T19:24:00.000Z",
-    "date_processed": "1749468789.0419436",
+    "date_processed": "1776015869.7829351",
     "permissions_data": null,
     "filesize_bytes": null
   },
@@ -34,6 +34,6 @@
     "url": "https://www.notion.so/test-doc1-1572c3765a0a806299f0dd6999f9e4c7"
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmpb91_pd05/1572c3765a0a806299f0dd6999f9e4c7.html",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpbzr2c5l6/1572c3765a0a806299f0dd6999f9e4c7.html",
   "display_name": "1572c3765a0a806299f0dd6999f9e4c7.html"
 }

--- a/test/integration/connectors/expected_results/onedrive/file_data/01FKMPQP5P3IF7RTMOW5EZPDJGEBVUREKR.json
+++ b/test/integration/connectors/expected_results/onedrive/file_data/01FKMPQP5P3IF7RTMOW5EZPDJGEBVUREKR.json
@@ -26,7 +26,8 @@
     "name": "fake-email.txt",
     "webUrl": "https://unstructuredio-my.sharepoint.com/personal/devops_unstructuredio_onmicrosoft_com/Documents/eml/fake-email.txt",
     "cTag": "\"c:{F80BDAAF-8ECD-49B7-978D-26206B489151},1\"",
-    "size": 830
+    "size": 830,
+    "isAuthoritative": false
   },
   "reprocess": false,
   "local_download_path": "/tmp/tmppx_cse9y/fake-email.txt",

--- a/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ.json
+++ b/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "/list-item-example.pdf"
     },
-    "date_created": "1738335995.0",
-    "date_modified": "1738335995.0",
-    "date_processed": "1749467391.2725604",
+    "date_created": "1738353995.0",
+    "date_modified": "1738353995.0",
+    "date_processed": "1776016101.8820329",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=94bc1801-87a2-4b52-a177-25324bb17ae9&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzA5ODYifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCI7T39CF1JM-EAUaDjIwLjE5MC4xMzIuMTA1KixvVXhtbnUzZnVXVktNd2VlNVdQU3BKYklaU2h0MmF5L2tMYXBMblh2QkVzPTCdATgBQhChpmjqlOAAkCgd4Pb3I0_eShBoYXNoZWRwcm9vZnRva2VuegExugEuYWxsc2l0ZXMud3JpdGUgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.WpdGtklq6SElEwOfC7bQIHPhpJqwbIz-cwa0HSAh86o&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=94bc1801-87a2-4b52-a177-25324bb17ae9&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk2OTMifQ.CkAKDGVudHJhX2NsYWltcxIwQ0xHejc4NEdFQUFhRm1GdWNscEhRamRWWkdzMlRrZG5jMDUyYkRSYVFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJ7B1L62sYw_EAUaDTQwLjEyNi4yNC4xNTMqLG9VeG1udTNmdVdWS013ZWU1V1BTcEpiSVpTaHQyYXkva0xhcExuWHZCRXM9MJ0BOAFCEKIJT7ynIADAawoFve2fulNKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.ij9zgUefn-gdAsABwdKw5GzKX4-ZkCC9a0RbopHEP88&ApiVersion=2.0",
     "eTag": "\"{94BC1801-87A2-4B52-A177-25324BB17AE9},1\"",
     "id": "0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ",
     "name": "list-item-example.pdf",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/list-item-example.pdf",
     "cTag": "\"c:{94BC1801-87A2-4B52-A177-25324BB17AE9},1\"",
+    "isAuthoritative": false,
     "size": 48981
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp65_re12k/list-item-example.pdf",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpqzyeoyg8/list-item-example.pdf",
   "display_name": "/list-item-example.pdf"
 }

--- a/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG.json
+++ b/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "/book-war-and-peace-1p.txt"
     },
-    "date_created": "1738856878.0",
-    "date_modified": "1738856878.0",
-    "date_processed": "1749467387.5502467",
+    "date_created": "1738874878.0",
+    "date_modified": "1738874878.0",
+    "date_processed": "1776016095.9818702",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=77650b15-a8aa-450e-bc8f-bb511a86d4c6&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzA5ODYifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCI7T39CF1JM-EAUaDjIwLjE5MC4xMzIuMTA1Kix6ZU1CSS9yOUVBVXF4eDVBNnRJUWZKN0VjSVQrbG8vbmw2aEg1VDdTRmxVPTCdATgBQhChpmjqlOAAkCgd4Pb3I0_eShBoYXNoZWRwcm9vZnRva2VuegExugEuYWxsc2l0ZXMud3JpdGUgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.0VmYsWKB_wb2ukuGY5DI3Dgxw4sjQdv3lpGYnlt-6II&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=77650b15-a8aa-450e-bc8f-bb511a86d4c6&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk2OTMifQ.CkAKDGVudHJhX2NsYWltcxIwQ0xHejc4NEdFQUFhRm1GdWNscEhRamRWWkdzMlRrZG5jMDUyYkRSYVFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJ7B1L62sYw_EAUaDTQwLjEyNi4yNC4xNTMqLHplTUJJL3I5RUFVcXh4NUE2dElRZko3RWNJVCtsby9ubDZoSDVUN1NGbFU9MJ0BOAFCEKIJT7ynIADAawoFve2fulNKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.1OOIxtbHEQlKp9IxbOmX-AAREsgHhrYJfOVyKWjoioc&ApiVersion=2.0",
     "eTag": "\"{77650B15-A8AA-450E-BC8F-BB511A86D4C6},1\"",
     "id": "0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG",
     "name": "book-war-and-peace-1p.txt",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/book-war-and-peace-1p.txt",
     "cTag": "\"c:{77650B15-A8AA-450E-BC8F-BB511A86D4C6},1\"",
+    "isAuthoritative": false,
     "size": 3045
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp65_re12k/book-war-and-peace-1p.txt",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpqzyeoyg8/book-war-and-peace-1p.txt",
   "display_name": "/book-war-and-peace-1p.txt"
 }

--- a/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
+++ b/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "Folder1/fake-memo.pdf"
     },
-    "date_created": "1738335979.0",
-    "date_modified": "1738335979.0",
-    "date_processed": "1749467394.9487815",
+    "date_created": "1738353979.0",
+    "date_modified": "1738353979.0",
+    "date_processed": "1776016107.091462",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=dacdc697-3d6c-4b30-8fcf-2a0635bf5c0b&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzA5ODYifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJ7t4taF1JM-EAUaDjIwLjE5MC4xMzIuMTA1KixBZHFxaGhSYzUzQnhvSVJMYzVxRThQbVo4aXE3V1VPWEpqS08wMUNHTjlrPTCdATgBQhChpmjqu2AAkCgd5SEOCnGpShBoYXNoZWRwcm9vZnRva2VuegExugEuYWxsc2l0ZXMud3JpdGUgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.9YqPzr1GejE5DVW631CrLrIEmHMQGYQIM1dnmn_cBPM&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=dacdc697-3d6c-4b30-8fcf-2a0635bf5c0b&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk2OTQifQ.CkAKDGVudHJhX2NsYWltcxIwQ0xLejc4NEdFQUFhRmpKMlExWkRhMnBIVFVWVFdFRnhhMk5wWmpCQlFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCKjamMm2sYw_EAUaDTQwLjEyNi4yNC4xNTMqLEFkcXFoaFJjNTNCeG9JUkxjNXFFOFBtWjhpcTdXVU9YSmpLTzAxQ0dOOWs9MJ0BOAFCEKIJT7zrMADAWCrgJjLyJQVKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.WhAcMFJrQhJoNrDUHyjB6WnztGHwYF4_VJuPZxKH0oA&ApiVersion=2.0",
     "eTag": "\"{DACDC697-3D6C-4B30-8FCF-2A0635BF5C0B},1\"",
     "id": "0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL",
     "name": "fake-memo.pdf",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/Folder1/fake-memo.pdf",
     "cTag": "\"c:{DACDC697-3D6C-4B30-8FCF-2A0635BF5C0B},1\"",
+    "isAuthoritative": false,
     "size": 13374
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp65_re12k/Folder1/fake-memo.pdf",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpqzyeoyg8/Folder1/fake-memo.pdf",
   "display_name": "Folder1/fake-memo.pdf"
 }

--- a/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
+++ b/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "Folder1/Folder2/fake-email.txt"
     },
-    "date_created": "1738335577.0",
-    "date_modified": "1738335577.0",
-    "date_processed": "1749467398.3832765",
+    "date_created": "1738353577.0",
+    "date_modified": "1738353577.0",
+    "date_processed": "1776016113.034531",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=bbb9ada5-a64e-4bee-8ed9-7fc9f66a38d3&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzA5ODcifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCKyevdyF1JM-EAUaDjIwLjE5MC4xMzIuMTA1KixRWjVXSklra3A5TjdFR1AyZFp3SEpvTFZiNXlqNmFPMkZ3UW93WUdiR08wPTCdATgBQhChpmjq4cAAkCgd5tmf3s7BShBoYXNoZWRwcm9vZnRva2VuegExugEuYWxsc2l0ZXMud3JpdGUgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.2XNTRnwFsz0IFsGATsF3wwJ9j0X7tKyIkV6lG1229TI&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=bbb9ada5-a64e-4bee-8ed9-7fc9f66a38d3&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk2OTUifQ.CkAKDGVudHJhX2NsYWltcxIwQ0xPejc4NEdFQUFhRmpOalVVaGhMVXhNVkVWNWRGODRPR05YY3pRNVFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCMrKxNK2sYw_EAUaDjIwLjE5MC4xNTIuMTUzKixRWjVXSklra3A5TjdFR1AyZFp3SEpvTFZiNXlqNmFPMkZ3UW93WUdiR08wPTCdATgBQhCiCU-9KWAAwGsKDnvlOLMTShBoYXNoZWRwcm9vZnRva2VuegExugFlc2hhcmVwb2ludHRlbmFudHNldHRpbmdzLnJlYWR3cml0ZS5hbGwgYWxsc2l0ZXMud3JpdGUgYWxsc2l0ZXMubWFuYWdlIGFsbGZpbGVzLndyaXRlIGFsbHByb2ZpbGVzLnJlYWTIAQE.9ZoPYJ_5EU21UiTxUnWOaSWYhu_bIz1py4w0poJRx8A&ApiVersion=2.0",
     "eTag": "\"{BBB9ADA5-A64E-4BEE-8ED9-7FC9F66A38D3},1\"",
     "id": "0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT",
     "name": "fake-email.txt",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/Folder1/Folder2/fake-email.txt",
     "cTag": "\"c:{BBB9ADA5-A64E-4BEE-8ED9-7FC9F66A38D3},1\"",
+    "isAuthoritative": false,
     "size": 836
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp65_re12k/Folder1/Folder2/fake-email.txt",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpqzyeoyg8/Folder1/Folder2/fake-email.txt",
   "display_name": "Folder1/Folder2/fake-email.txt"
 }

--- a/test/integration/connectors/expected_results/sharepoint2/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
+++ b/test/integration/connectors/expected_results/sharepoint2/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "Folder1/fake-memo.pdf"
     },
-    "date_created": "1738335979.0",
-    "date_modified": "1738335979.0",
-    "date_processed": "1749467406.3806903",
+    "date_created": "1738353979.0",
+    "date_modified": "1738353979.0",
+    "date_processed": "1776016128.162882",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=dacdc697-3d6c-4b30-8fcf-2a0635bf5c0b&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwMDUifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCLCMmYmH1JM-EAUaCzQwLjEyNi40LjQwKixBZHFxaGhSYzUzQnhvSVJMYzVxRThQbVo4aXE3V1VPWEpqS08wMUNHTjlrPTCdATgBQhChpmjvTLAAkA8oyepOYlkBShBoYXNoZWRwcm9vZnRva2VuegExugEuYWxsc2l0ZXMud3JpdGUgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.X6BwCghYvaVZi6cu5ZdUBE5I1CZdzGl1axiepsTznh0&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=dacdc697-3d6c-4b30-8fcf-2a0635bf5c0b&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3MjcifQ.CkAKDGVudHJhX2NsYWltcxIwQ05Lejc4NEdFQUFhRmt4RlNVSk5kMDR4UkVWWFRXRnRPV2REZFZWMVFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCOKBg_24sYw_EAUaDTIwLjE5MC4xNTIuODgqLEFkcXFoaFJjNTNCeG9JUkxjNXFFOFBtWjhpcTdXVU9YSmpLTzAxQ0dOOWs9MJ0BOAFCEKIJT8TMkADAWCrhmQ7_Y4tKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.f6VsH9eh3MqnsXxJy2_5ke0pqf39GxWE1sX-Ej1jS48&ApiVersion=2.0",
     "eTag": "\"{DACDC697-3D6C-4B30-8FCF-2A0635BF5C0B},1\"",
     "id": "0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL",
     "name": "fake-memo.pdf",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/Folder1/fake-memo.pdf",
     "cTag": "\"c:{DACDC697-3D6C-4B30-8FCF-2A0635BF5C0B},1\"",
+    "isAuthoritative": false,
     "size": 13374
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmpnq4szkz0/fake-memo.pdf",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmp03j32qjk/fake-memo.pdf",
   "display_name": "Folder1/fake-memo.pdf"
 }

--- a/test/integration/connectors/expected_results/sharepoint2/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
+++ b/test/integration/connectors/expected_results/sharepoint2/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "Folder1/Folder2/fake-email.txt"
     },
-    "date_created": "1738335577.0",
-    "date_modified": "1738335577.0",
-    "date_processed": "1749467409.6202116",
+    "date_created": "1738353577.0",
+    "date_modified": "1738353577.0",
+    "date_processed": "1776016133.377137",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=bbb9ada5-a64e-4bee-8ed9-7fc9f66a38d3&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwMDYifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCOb_1o-H1JM-EAUaDTIwLjE5MC4xNTMuMzcqLFFaNVdKSWtrcDlON0VHUDJkWndISm9MVmI1eWo2YU8yRndRb3dZR2JHTzA9MJ0BOAFCEKGmaO91QACQPy4R7BVFqOtKEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.HGrM78x6kurCcRr5wC5tLUHSUEJBMr4Q2vpcYKIjMSM&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=bbb9ada5-a64e-4bee-8ed9-7fc9f66a38d3&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3MjgifQ.CkAKDGVudHJhX2NsYWltcxIwQ05Pejc4NEdFQUFhRm05VVVWZFNVMlZ4VkVWaFlWbFRiMVoyU0RSaVFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCP7rvoW5sYw_EAUaDTIwLjE5MC4xNTIuODgqLFFaNVdKSWtrcDlON0VHUDJkWndISm9MVmI1eWo2YU8yRndRb3dZR2JHTzA9MJ0BOAFCEKIJT8UFEADAtWFsXD2Cj2NKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ._k0OC5YoTLUVbZDOkb-MGvt0P7hSDa0-AXYic11IC9g&ApiVersion=2.0",
     "eTag": "\"{BBB9ADA5-A64E-4BEE-8ED9-7FC9F66A38D3},1\"",
     "id": "0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT",
     "name": "fake-email.txt",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/Folder1/Folder2/fake-email.txt",
     "cTag": "\"c:{BBB9ADA5-A64E-4BEE-8ED9-7FC9F66A38D3},1\"",
+    "isAuthoritative": false,
     "size": 836
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmpnq4szkz0/Folder2/fake-email.txt",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmp03j32qjk/Folder2/fake-email.txt",
   "display_name": "Folder1/Folder2/fake-email.txt"
 }

--- a/test/integration/connectors/expected_results/sharepoint3/file_data/01QKP26Q7PST2HZ7PAXFBYQ5G2QF2NLSPN.json
+++ b/test/integration/connectors/expected_results/sharepoint3/file_data/01QKP26Q7PST2HZ7PAXFBYQ5G2QF2NLSPN.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "e2e-test-folder/book-war-and-peace-1225p.txt"
     },
-    "date_created": "1738250742.0",
-    "date_modified": "1738250742.0",
-    "date_processed": "1749467417.2292135",
+    "date_created": "1738268742.0",
+    "date_modified": "1738268742.0",
+    "date_processed": "1776016147.6252959",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/_layouts/15/download.aspx?UniqueId=7cf494ef-e0fd-43b9-8874-da8174d5c9ed&Translate=false&tempauth=v1.eyJzaXRlaWQiOiIxMmQ1NzBlMC01ZTAwLTRlYjQtOTUyYS0xY2YwNzkwMjU0N2UiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwMTcifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCNq0yPeH1JM-EAUaDjIwLjE5MC4xMzIuMTA2Kiw5OEdjOEFFd0orVlBVUHFlam5vRUpzMmI3NWN4cS9uT0F3WDZ6aEV6cnkwPTB9OAFCEKGmaPIfEACQPy4exOW-NqxKEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.2reOqgplLWBXwFMAngGiodjGlLlVMnUVCDFZgniqun8&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/_layouts/15/download.aspx?UniqueId=7cf494ef-e0fd-43b9-8874-da8174d5c9ed&Translate=false&tempauth=v1.eyJzaXRlaWQiOiIxMmQ1NzBlMC01ZTAwLTRlYjQtOTUyYS0xY2YwNzkwMjU0N2UiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3NDcifQ.CkAKDGVudHJhX2NsYWltcxIwQ09lejc4NEdFQUFhRmtaQlZWVnBTSG8yYjFWaGFsbHRkRGhTZW5ORFFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJy89L66sYw_EAUaDTIwLjE5MC4xNTIuODgqLDk4R2M4QUV3SitWUFVQcWVqbm9FSnMyYjc1Y3hxL25PQXdYNnpoRXpyeTA9MH04AUIQoglPycJAAMBrCgC0-oDirUoQaGFzaGVkcHJvb2Z0b2tlbnoBMboBZXNoYXJlcG9pbnR0ZW5hbnRzZXR0aW5ncy5yZWFkd3JpdGUuYWxsIGFsbHNpdGVzLndyaXRlIGFsbHNpdGVzLm1hbmFnZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.YUQIGIINvMqCbfOIagAtStjOU3nJcFRA1aWUq2JybgQ&ApiVersion=2.0",
     "eTag": "\"{7CF494EF-E0FD-43B9-8874-DA8174D5C9ED},4\"",
     "id": "01QKP26Q7PST2HZ7PAXFBYQ5G2QF2NLSPN",
     "name": "book-war-and-peace-1225p.txt",
     "webUrl": "https://unstructuredio.sharepoint.com/Shared%20Documents/e2e-test-folder/book-war-and-peace-1225p.txt",
     "cTag": "\"c:{7CF494EF-E0FD-43B9-8874-DA8174D5C9ED},1\"",
+    "isAuthoritative": false,
     "size": 3202320
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmpsqp6881k/book-war-and-peace-1225p.txt",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmp2eoz5bdm/book-war-and-peace-1225p.txt",
   "display_name": "e2e-test-folder/book-war-and-peace-1225p.txt"
 }

--- a/test/integration/connectors/expected_results/sharepoint3/file_data/01QKP26QZL5KBVQTQ3IRDYF72MRH2QKKR3.json
+++ b/test/integration/connectors/expected_results/sharepoint3/file_data/01QKP26QZL5KBVQTQ3IRDYF72MRH2QKKR3.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "e2e-test-folder/fake-memo.pdf"
     },
-    "date_created": "1738100496.0",
-    "date_modified": "1738100496.0",
-    "date_processed": "1749467421.358538",
+    "date_created": "1738118496.0",
+    "date_modified": "1738118496.0",
+    "date_processed": "1776016154.007283",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/_layouts/15/download.aspx?UniqueId=5883ea2b-1b4e-4744-82ff-4c89f5052a3b&Translate=false&tempauth=v1.eyJzaXRlaWQiOiIxMmQ1NzBlMC01ZTAwLTRlYjQtOTUyYS0xY2YwNzkwMjU0N2UiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwMTcifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCNq0yPeH1JM-EAUaDjIwLjE5MC4xMzIuMTA2KixlL2RBNWN2Qk5UdnowN0p4YmFxL256Tm5qTmljRWNEclhOczNkZ2hGTWt3PTB9OAFCEKGmaPIfEACQPy4exOW-NqxKEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.Uljl--Ld64Mg7RaL95mDLy8eMoLX1_Xl9kQcFWMz4gU&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/_layouts/15/download.aspx?UniqueId=5883ea2b-1b4e-4744-82ff-4c89f5052a3b&Translate=false&tempauth=v1.eyJzaXRlaWQiOiIxMmQ1NzBlMC01ZTAwLTRlYjQtOTUyYS0xY2YwNzkwMjU0N2UiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3NDcifQ.CkAKDGVudHJhX2NsYWltcxIwQ09lejc4NEdFQUFhRmtaQlZWVnBTSG8yYjFWaGFsbHRkRGhTZW5ORFFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJy89L66sYw_EAUaDTIwLjE5MC4xNTIuODgqLGUvZEE1Y3ZCTlR2ejA3SnhiYXEvbnpObmpOaWNFY0RyWE5zM2RnaEZNa3c9MH04AUIQoglPycJAAMBrCgC0-oDirUoQaGFzaGVkcHJvb2Z0b2tlbnoBMboBZXNoYXJlcG9pbnR0ZW5hbnRzZXR0aW5ncy5yZWFkd3JpdGUuYWxsIGFsbHNpdGVzLndyaXRlIGFsbHNpdGVzLm1hbmFnZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.m60-UtPGhSQ9DNWZvc6bgMs0tx72uZCeXXHrCdXDkig&ApiVersion=2.0",
     "eTag": "\"{5883EA2B-1B4E-4744-82FF-4C89F5052A3B},1\"",
     "id": "01QKP26QZL5KBVQTQ3IRDYF72MRH2QKKR3",
     "name": "fake-memo.pdf",
     "webUrl": "https://unstructuredio.sharepoint.com/Shared%20Documents/e2e-test-folder/fake-memo.pdf",
     "cTag": "\"c:{5883EA2B-1B4E-4744-82FF-4C89F5052A3B},1\"",
+    "isAuthoritative": false,
     "size": 13374
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmpsqp6881k/fake-memo.pdf",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmp2eoz5bdm/fake-memo.pdf",
   "display_name": "e2e-test-folder/fake-memo.pdf"
 }

--- a/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ.json
+++ b/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "/list-item-example.pdf"
     },
-    "date_created": "1738335995.0",
-    "date_modified": "1738335995.0",
-    "date_processed": "1749467432.9591458",
+    "date_created": "1738353995.0",
+    "date_modified": "1738353995.0",
+    "date_processed": "1776016175.370295",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=94bc1801-87a2-4b52-a177-25324bb17ae9&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwMjgifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCLyf49-I1JM-EAUaDTIwLjE5MC4xMzIuNDAqLG9VeG1udTNmdVdWS013ZWU1V1BTcEpiSVpTaHQyYXkva0xhcExuWHZCRXM9MJ0BOAFCEKGmaPTKAACQDyjHMC1JU-NKEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.NOXNZU_AfsScEWhgPCy1RmE2AdlcP611tOTfSlYp8Os&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=94bc1801-87a2-4b52-a177-25324bb17ae9&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3NjgifQ.CkAKDGVudHJhX2NsYWltcxIwQ1B1ejc4NEdFQUFhRmxad2FGTnVWRjlqYm10bE5USmZUbWhuUjNab1FVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCOqJ2oS8sYw_EAUaDTIwLjE5MC4xNTIuODgqLG9VeG1udTNmdVdWS013ZWU1V1BTcEpiSVpTaHQyYXkva0xhcExuWHZCRXM9MJ0BOAFCEKIJT87TgADAawoJWD-B3lZKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.ymQBO-J2Lohp_HE_ZwIRnjxvHLg0iXbMg4wpklGo8I0&ApiVersion=2.0",
     "eTag": "\"{94BC1801-87A2-4B52-A177-25324BB17AE9},1\"",
     "id": "0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ",
     "name": "list-item-example.pdf",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/list-item-example.pdf",
     "cTag": "\"c:{94BC1801-87A2-4B52-A177-25324BB17AE9},1\"",
+    "isAuthoritative": false,
     "size": 48981
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp0egjbysg/list-item-example.pdf",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpbvtr4eg4/list-item-example.pdf",
   "display_name": "/list-item-example.pdf"
 }

--- a/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG.json
+++ b/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "/book-war-and-peace-1p.txt"
     },
-    "date_created": "1738856878.0",
-    "date_modified": "1738856878.0",
-    "date_processed": "1749467429.61241",
+    "date_created": "1738874878.0",
+    "date_modified": "1738874878.0",
+    "date_processed": "1776016170.523031",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=77650b15-a8aa-450e-bc8f-bb511a86d4c6&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwMjgifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCOiW0N-I1JM-EAUaDTIwLjE5MC4xMzIuNDAqLHplTUJJL3I5RUFVcXh4NUE2dElRZko3RWNJVCtsby9ubDZoSDVUN1NGbFU9MJ0BOAFCEKGmaPTKAACQDyjHMC1JU-NKEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.75oZyQwJjFDJWj7zOR6QTgE5cJTEvHuL_K-lAmb9l2E&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=77650b15-a8aa-450e-bc8f-bb511a86d4c6&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3NjgifQ.CkAKDGVudHJhX2NsYWltcxIwQ1B1ejc4NEdFQUFhRmxad2FGTnVWRjlqYm10bE5USmZUbWhuUjNab1FVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCOqJ2oS8sYw_EAUaDTIwLjE5MC4xNTIuODgqLHplTUJJL3I5RUFVcXh4NUE2dElRZko3RWNJVCtsby9ubDZoSDVUN1NGbFU9MJ0BOAFCEKIJT87TgADAawoJWD-B3lZKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.j0QoVgeeOtVVrMo8S4N8xYuMa2EfdFyw6--vqoIrE9U&ApiVersion=2.0",
     "eTag": "\"{77650B15-A8AA-450E-BC8F-BB511A86D4C6},1\"",
     "id": "0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG",
     "name": "book-war-and-peace-1p.txt",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/book-war-and-peace-1p.txt",
     "cTag": "\"c:{77650B15-A8AA-450E-BC8F-BB511A86D4C6},1\"",
+    "isAuthoritative": false,
     "size": 3045
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp0egjbysg/book-war-and-peace-1p.txt",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpbvtr4eg4/book-war-and-peace-1p.txt",
   "display_name": "/book-war-and-peace-1p.txt"
 }

--- a/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
+++ b/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "Folder1/fake-memo.pdf"
     },
-    "date_created": "1738335979.0",
-    "date_modified": "1738335979.0",
-    "date_processed": "1749467436.1380186",
+    "date_created": "1738353979.0",
+    "date_modified": "1738353979.0",
+    "date_processed": "1776016180.197994",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=dacdc697-3d6c-4b30-8fcf-2a0635bf5c0b&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwMjgifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCMzzx-WI1JM-EAUaDTIwLjE5MC4xNTMuMzcqLEFkcXFoaFJjNTNCeG9JUkxjNXFFOFBtWjhpcTdXVU9YSmpLTzAxQ0dOOWs9MJ0BOAFCEKGmaPTv8ACA9ujdp2fOJRdKEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.A_fvTnmwVcPGaNj4EyuLWdWF5LXAylz7ZaaDqP--aY8&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=dacdc697-3d6c-4b30-8fcf-2a0635bf5c0b&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3NjkifQ.CkAKDGVudHJhX2NsYWltcxIwQ1B5ejc4NEdFQUFhRm1OdllsVTJNR2RRVEdzeWNsbHZTWEV4Y0RGeVFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCKibiI-8sYw_EAUaDTIwLjE5MC4xNTIuODgqLEFkcXFoaFJjNTNCeG9JUkxjNXFFOFBtWjhpcTdXVU9YSmpLTzAxQ0dOOWs9MJ0BOAFCEKIJT88YYADAawoGuIsA-sBKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.IWNN8wY4P9cikiT3R8RymWsHM9zdvh8uLDVNlYRZw5Q&ApiVersion=2.0",
     "eTag": "\"{DACDC697-3D6C-4B30-8FCF-2A0635BF5C0B},1\"",
     "id": "0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL",
     "name": "fake-memo.pdf",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/Folder1/fake-memo.pdf",
     "cTag": "\"c:{DACDC697-3D6C-4B30-8FCF-2A0635BF5C0B},1\"",
+    "isAuthoritative": false,
     "size": 13374
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp0egjbysg/Folder1/fake-memo.pdf",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpbvtr4eg4/Folder1/fake-memo.pdf",
   "display_name": "Folder1/fake-memo.pdf"
 }

--- a/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
+++ b/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "Folder1/Folder2/fake-email.txt"
     },
-    "date_created": "1738335577.0",
-    "date_modified": "1738335577.0",
-    "date_processed": "1749467439.4021304",
+    "date_created": "1738353577.0",
+    "date_modified": "1738353577.0",
+    "date_processed": "1776016185.12759",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=bbb9ada5-a64e-4bee-8ed9-7fc9f66a38d3&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwMjkifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCPSd0-2I1JM-EAUaDjIwLjE5MC4xMzIuMTA1KixRWjVXSklra3A5TjdFR1AyZFp3SEpvTFZiNXlqNmFPMkZ3UW93WUdiR08wPTCdATgBQhChpmj1JuAAgPbo2FSfQuvPShBoYXNoZWRwcm9vZnRva2VuegExugEuYWxsc2l0ZXMud3JpdGUgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.5cPjS4qKkQ6mAlHFwG9TigIlT5HclYjrv83cSDdZfq4&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=bbb9ada5-a64e-4bee-8ed9-7fc9f66a38d3&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3NzAifQ.CkAKDGVudHJhX2NsYWltcxIwQ1A2ejc4NEdFQUFhRmxCNmVHaElOSFpyU0RCTE5qaFNSMTk1VFVVdFFWRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCPqLwZm8sYw_EAUaDTIwLjE5MC4xNTIuODgqLFFaNVdKSWtrcDlON0VHUDJkWndISm9MVmI1eWo2YU8yRndRb3dZR2JHTzA9MJ0BOAFCEKIJT89c0ADAWCrl1Vi8WP9KEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.jBgmo5pCQyMOV4KK55WmyjUudm2Xo53e7h0odaQpRu8&ApiVersion=2.0",
     "eTag": "\"{BBB9ADA5-A64E-4BEE-8ED9-7FC9F66A38D3},1\"",
     "id": "0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT",
     "name": "fake-email.txt",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Shared%20Documents/Folder1/Folder2/fake-email.txt",
     "cTag": "\"c:{BBB9ADA5-A64E-4BEE-8ED9-7FC9F66A38D3},1\"",
+    "isAuthoritative": false,
     "size": 836
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp0egjbysg/Folder1/Folder2/fake-email.txt",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpbvtr4eg4/Folder1/Folder2/fake-email.txt",
   "display_name": "Folder1/Folder2/fake-email.txt"
 }

--- a/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSBCDXFGQVNK6NCZOQZY3CZ2CCI2.json
+++ b/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSBCDXFGQVNK6NCZOQZY3CZ2CCI2.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "/fake-doc.rtf"
     },
-    "date_created": "1749069607.0",
-    "date_modified": "1749069607.0",
-    "date_processed": "1749467447.9553537",
+    "date_created": "1749084007.0",
+    "date_modified": "1749084007.0",
+    "date_processed": "1776016200.275014",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=68ca1d22-aa55-45f3-9743-38d8b3a1091a&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwNDcifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCM6SipWK1JM-EAUaDTIwLjE5MC4xMzIuNDIqLEd0a2pBRGhQc3R6bXNvc1ducUZDVUpQT0pJUjEyU05VMVYxbDJRNllBM2c9MJ0BOAFCEKGmaPlvMACQKB3mQp8Tw49KEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.UgY7_XmQSMQ-t_E3Fb3yO0jwcV959GZK9zrBTJb2d2A&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=68ca1d22-aa55-45f3-9743-38d8b3a1091a&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3OTkifQ.CkAKDGVudHJhX2NsYWltcxIwQ0pxMDc4NEdFQUFhRmpJMWFubFVjREY1VVRCcGVsZG5WbXR3WHkxQ1FVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJrrtKu-sYw_EAUaDTIwLjE5MC4xNTIuODgqLEd0a2pBRGhQc3R6bXNvc1ducUZDVUpQT0pJUjEyU05VMVYxbDJRNllBM2c9MJ0BOAFCEKIJT9Zf4ADAO40xz-GPTsFKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.I1IYxXoqA1X_d4__1KQWIWutUCwIant2ezUDSQoJx04&ApiVersion=2.0",
     "eTag": "\"{68CA1D22-AA55-45F3-9743-38D8B3A1091A},1\"",
     "id": "0153RHRSBCDXFGQVNK6NCZOQZY3CZ2CCI2",
     "name": "fake-doc.rtf",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/Doc.aspx?sourcedoc=%7B68CA1D22-AA55-45F3-9743-38D8B3A1091A%7D&file=fake-doc.rtf&action=default",
     "cTag": "\"c:{68CA1D22-AA55-45F3-9743-38D8B3A1091A},1\"",
+    "isAuthoritative": false,
     "size": 408
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmphxsidw1k/fake-doc.rtf",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpi5wpdvve/fake-doc.rtf",
   "display_name": "/fake-doc.rtf"
 }

--- a/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C.json
+++ b/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "e2e-library-folder/book-war-and-peace-1p.txt"
     },
-    "date_created": "1749099715.0",
-    "date_modified": "1749099715.0",
-    "date_processed": "1749467467.6507068",
+    "date_created": "1749114115.0",
+    "date_modified": "1749114115.0",
+    "date_processed": "1776016211.807793",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=5d0b5c7c-d0d6-458e-8d93-fae5a66e9bc2&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwNDcifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCOymxpyK1JM-EAUaDTIwLjE5MC4xMzIuNDAqLHlOY2lzRklNQU5Ja1AyKysvbUhwbVJMSVZ0a3phNklzN1hjMXJlYTM0Zlk9MJ0BOAFCEKGmaPmgIACQPy4Ums9b_4FKEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.zQoIccWBND-kmUIRzahnC5M5PkJr_-u29lnCwfHDcLA&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=5d0b5c7c-d0d6-458e-8d93-fae5a66e9bc2&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk4MDAifQ.CkAKDGVudHJhX2NsYWltcxIwQ0p1MDc4NEdFQUFhRm5wTVNYUnBNbnB4YkZWbGRsWkxiRXRCWlRCdFFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJ64hbW-sYw_EAUaDTIwLjE5MC4xNTIuODgqLHlOY2lzRklNQU5Ja1AyKysvbUhwbVJMSVZ0a3phNklzN1hjMXJlYTM0Zlk9MJ0BOAFCEKIJT9aeAADAkWK20WPzDuVKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.KekxESePTIbleeHkn8uAkqba_HlyJ4r57ROHSHNOSp8&ApiVersion=2.0",
     "eTag": "\"{5D0B5C7C-D0D6-458E-8D93-FAE5A66E9BC2},1\"",
     "id": "0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C",
     "name": "book-war-and-peace-1p.txt",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Documents2/e2e-library-folder/book-war-and-peace-1p.txt",
     "cTag": "\"c:{5D0B5C7C-D0D6-458E-8D93-FAE5A66E9BC2},1\"",
+    "isAuthoritative": false,
     "size": 3045
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmphxsidw1k/e2e-library-folder/book-war-and-peace-1p.txt",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpi5wpdvve/e2e-library-folder/book-war-and-peace-1p.txt",
   "display_name": "e2e-library-folder/book-war-and-peace-1p.txt"
 }

--- a/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSFPJTHUKBK7AFEJO3WOAEA3RC7D.json
+++ b/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSFPJTHUKBK7AFEJO3WOAEA3RC7D.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "/fake-html.html"
     },
-    "date_created": "1749069607.0",
-    "date_modified": "1749069607.0",
-    "date_processed": "1749467451.8023508",
+    "date_created": "1749084007.0",
+    "date_modified": "1749084007.0",
+    "date_processed": "1776016205.8976462",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=45cf4caf-5f05-4801-976e-ce0101b88be3&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwNDcifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCM6SipWK1JM-EAUaDTIwLjE5MC4xMzIuNDIqLEF0SkxkRkZUVVZZaktjRm9vdEFvQW1Qa1lPdFpzQ2VLWjdNVEwrNFJqM0k9MJ0BOAFCEKGmaPlvMACQKB3mQp8Tw49KEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.j-fQZAKWxXRBi5oPjUrifPjftx3q5NwywXdi2ibL1u4&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=45cf4caf-5f05-4801-976e-ce0101b88be3&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk3OTkifQ.CkAKDGVudHJhX2NsYWltcxIwQ0pxMDc4NEdFQUFhRmpJMWFubFVjREY1VVRCcGVsZG5WbXR3WHkxQ1FVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJrrtKu-sYw_EAUaDTIwLjE5MC4xNTIuODgqLEF0SkxkRkZUVVZZaktjRm9vdEFvQW1Qa1lPdFpzQ2VLWjdNVEwrNFJqM0k9MJ0BOAFCEKIJT9Zf4ADAO40xz-GPTsFKEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.skMT1z_6e9pLFv7nWka8Mt2mB9knhAFHzLXL0qLYWXM&ApiVersion=2.0",
     "eTag": "\"{45CF4CAF-5F05-4801-976E-CE0101B88BE3},1\"",
     "id": "0153RHRSFPJTHUKBK7AFEJO3WOAEA3RC7D",
     "name": "fake-html.html",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Documents2/fake-html.html",
     "cTag": "\"c:{45CF4CAF-5F05-4801-976E-CE0101B88BE3},1\"",
+    "isAuthoritative": false,
     "size": 665
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmphxsidw1k/fake-html.html",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpi5wpdvve/fake-html.html",
   "display_name": "/fake-html.html"
 }

--- a/test/integration/connectors/expected_results/sharepoint6/file_data/0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C.json
+++ b/test/integration/connectors/expected_results/sharepoint6/file_data/0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C.json
@@ -13,22 +13,23 @@
       "user_pname": null,
       "server_relative_path": "e2e-library-folder/book-war-and-peace-1p.txt"
     },
-    "date_created": "1749099715.0",
-    "date_modified": "1749099715.0",
-    "date_processed": "1749467476.2606735",
+    "date_created": "1749114115.0",
+    "date_modified": "1749114115.0",
+    "date_processed": "1776016245.748956",
     "permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {
-    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=5d0b5c7c-d0d6-458e-8d93-fae5a66e9bc2&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJteS1vbmVkcml2ZS1hcHAiLCJuYW1laWQiOiI4MTMyZTAwYS0xYmU0LTRiYTUtYTNjYy1mNmI4MjU0YzkwZjJAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NDk0NzEwNzYifQ.CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCJK4xKqM1JM-EAUaDTIwLjE5MC4xNTMuMjUqLHlOY2lzRklNQU5Ja1AyKysvbUhwbVJMSVZ0a3phNklzN1hjMXJlYTM0Zlk9MJ0BOAFCEKGmaQCJgACQDyjGAVkbAU5KEGhhc2hlZHByb29mdG9rZW56ATG6AS5hbGxzaXRlcy53cml0ZSBhbGxmaWxlcy53cml0ZSBhbGxwcm9maWxlcy5yZWFkyAEB.9eJ0sunZhUgbMxyku7XuFSVR05jg0VP0jfD4h6bIY20&ApiVersion=2.0",
+    "@microsoft.graph.downloadUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/_layouts/15/download.aspx?UniqueId=5d0b5c7c-d0d6-458e-8d93-fae5a66e9bc2&Translate=false&tempauth=v1.eyJzaXRlaWQiOiJhNmY1NjcwNS1hZjI5LTQ2YzctOTBiYS05YTBkNWE3YTFlZWMiLCJhcHBfZGlzcGxheW5hbWUiOiJzaGFyZXBvaW50LWFwcC1yZWdpc3RyYXRpb24iLCJuYW1laWQiOiI2YzE2MDc1My05YjYzLTQ3MDktYTE0MC0xN2EyN2QzMDg3YTZAM2Q2MGE3ZTUtMWUzMi00MTRlLTgzOWItMWM2ZTY3ODI2MTNkIiwiYXVkIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwL3Vuc3RydWN0dXJlZGlvLnNoYXJlcG9pbnQuY29tQDNkNjBhN2U1LTFlMzItNDE0ZS04MzliLTFjNmU2NzgyNjEzZCIsImV4cCI6IjE3NzYwMTk4NDUifQ.CkAKDGVudHJhX2NsYWltcxIwQ01tMDc4NEdFQUFhRm1KSVdub3dkVnB3Vkd0TFZGOWxjMnBoWm1OUFFVRXFBQT09CjIKCmFjdG9yYXBwaWQSJDAwMDAwMDAzLTAwMDAtMDAwMC1jMDAwLTAwMDAwMDAwMDAwMAoKCgRzbmlkEgI2NBILCK687-bBsYw_EAUaDTQwLjEyNi4yNC4xNTMqLHlOY2lzRklNQU5Ja1AyKysvbUhwbVJMSVZ0a3phNklzN1hjMXJlYTM0Zlk9MJ0BOAFCEKIJT-G6IADAWCrrheAXPY9KEGhhc2hlZHByb29mdG9rZW56ATG6AWVzaGFyZXBvaW50dGVuYW50c2V0dGluZ3MucmVhZHdyaXRlLmFsbCBhbGxzaXRlcy53cml0ZSBhbGxzaXRlcy5tYW5hZ2UgYWxsZmlsZXMud3JpdGUgYWxscHJvZmlsZXMucmVhZMgBAQ.lSWmwA_mZdLF70L9ghtQqqu2JB1bJIxaJSFbJKaUcwU&ApiVersion=2.0",
     "eTag": "\"{5D0B5C7C-D0D6-458E-8D93-FAE5A66E9BC2},1\"",
     "id": "0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C",
     "name": "book-war-and-peace-1p.txt",
     "webUrl": "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source/Documents2/e2e-library-folder/book-war-and-peace-1p.txt",
     "cTag": "\"c:{5D0B5C7C-D0D6-458E-8D93-FAE5A66E9BC2},1\"",
+    "isAuthoritative": false,
     "size": 3045
   },
   "reprocess": false,
-  "local_download_path": "/tmp/tmp7lbmryi2/book-war-and-peace-1p.txt",
+  "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmp90ta0s1c/book-war-and-peace-1p.txt",
   "display_name": "e2e-library-folder/book-war-and-peace-1p.txt"
 }

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.22"  # pragma: no cover
+__version__ = "1.4.23b1"  # pragma: no cover


### PR DESCRIPTION
## Summary
- SharePoint fixtures updated to include new `isAuthoritative` field in `additional_metadata` (upstream API change)
- Notion `notion_page` and `notion_database` HTML download fixtures updated to reflect current API output

## Test plan
- [ ] `blob_storage_connectors_int_test` SharePoint tests pass
- [ ] `uncategorized_connectors_int_test` Notion tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to test expected outputs and version/changelog bumps, with no production logic changes.
> 
> **Overview**
> Updates integration test expected results for SharePoint/OneDrive to include the new `additional_metadata.isAuthoritative` field and refreshes various timestamp/token/path values to match current Graph API responses.
> 
> Refreshes Notion `notion_page` and `notion_database` HTML/JSON fixtures to match current upstream rendering/output, and bumps `CHANGELOG.md` + `unstructured_ingest/__version__.py` to `1.4.23b1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 538ce348e65e250b7d77d68a2e3f3af04812c193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->