### PR TITLE
fix(teradata): fix off-by-one in split_dataframe that sent empty exec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.26b1]
+
+### Fixes
+
+- **fix(teradata): fix off-by-one in split_dataframe that sent empty executemany batches** The old `num_chunks = len(df) // chunk_size + 1` formula always appended one extra iteration. When a document produced exactly N * batch_size elements, the last chunk was empty, causing teradatasql to send a zero-row parameterized batch to the server which returned Error 3939 (parameter count mismatch). Replace with `range(0, len(df), chunk_size)` which never produces an empty slice. All SQL-based connectors (Teradata, Snowflake, VastDB, Databricks Delta Tables, KDB.AI) share this function and benefit from the fix.
+
 ## [1.4.25]
 
 ### Security

--- a/test/unit/connectors/sql/test_teradata.py
+++ b/test/unit/connectors/sql/test_teradata.py
@@ -1181,3 +1181,33 @@ def test_teradata_uploader_create_destination_preserves_user_table_name_with_das
     uploader.create_destination()
 
     assert uploader.upload_config.table_name == "my-table"
+
+
+# --- Regression tests for Error 3939 (parameter count mismatch) ---
+
+
+def test_split_dataframe_no_empty_chunk_when_length_is_multiple_of_chunk_size():
+    """split_dataframe must not yield an empty trailing chunk when len(df) % chunk_size == 0.
+
+    The old formula (num_chunks = len(df)//chunk_size + 1) always appended one
+    extra iteration, producing an empty df slice that caused teradatasql to send
+    a zero-row parameterized batch to the server (Error 3939).
+    """
+    from unstructured_ingest.utils.data_prep import split_dataframe
+
+    df = pd.DataFrame({"a": range(100)})
+    chunks = list(split_dataframe(df, chunk_size=100))
+    assert len(chunks) == 1, "exactly one chunk expected for len==chunk_size"
+    assert len(chunks[0]) == 100
+    assert all(len(c) > 0 for c in chunks), "no empty chunks allowed"
+
+
+def test_split_dataframe_no_empty_chunk_for_exact_multiples():
+    """Verify no empty chunks for several exact multiples of chunk_size."""
+    from unstructured_ingest.utils.data_prep import split_dataframe
+
+    for n in (50, 100, 150, 200):
+        df = pd.DataFrame({"x": range(n)})
+        chunks = list(split_dataframe(df, chunk_size=50))
+        assert all(len(c) > 0 for c in chunks), f"empty chunk for n={n}"
+        assert sum(len(c) for c in chunks) == n

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.25"  # pragma: no cover
+__version__ = "1.4.26b1"  # pragma: no cover

--- a/unstructured_ingest/utils/data_prep.py
+++ b/unstructured_ingest/utils/data_prep.py
@@ -20,9 +20,15 @@ IterableT = Iterable[T]
 
 
 def split_dataframe(df: "DataFrame", chunk_size: int = 100) -> Generator["DataFrame", None, None]:
-    num_chunks = len(df) // chunk_size + 1
-    for i in range(num_chunks):
-        yield df[i * chunk_size : (i + 1) * chunk_size]
+    # range(0, len(df), chunk_size) never produces an out-of-bounds slice, so
+    # every yielded chunk has at least one row. The previous num_chunks+1
+    # formula yielded a spurious empty trailing chunk whenever len(df) was an
+    # exact multiple of chunk_size, which caused teradatasql to send an empty
+    # executemany batch to the server and receive Error 3939.
+    if len(df) == 0:
+        return
+    for i in range(0, len(df), chunk_size):
+        yield df[i : i + chunk_size]
 
 
 def batch_generator(iterable: IterableT, batch_size: int = 100) -> IterableT:


### PR DESCRIPTION
When a document had exactly N * batch_size elements the last chunk was empty - this causes teradatasql to send a zero-row parameterized batch to the Teradata server which returned Error 3939 (parameter count mismatch).

Replace with range(0, len(df), chunk_size) which never produces an empty slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to a shared batching utility plus targeted unit tests; primary risk is subtle behavior change for callers that (incorrectly) relied on receiving empty chunks.
> 
> **Overview**
> Fixes an off-by-one bug in `split_dataframe` so it no longer yields an empty trailing DataFrame slice when `len(df)` is an exact multiple of `chunk_size`, preventing zero-row `executemany` batches that triggered Teradata Error 3939 (and benefiting all connectors that share this helper).
> 
> Adds Teradata-focused regression tests covering exact-multiple chunking cases, and bumps the package version/changelog entry to `1.4.26b1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4e839f6b7f695941b0ce04460607fe1e81a1763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->