### PR TITLE
bug(PLU-332): quote fixer for databricks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.28]
+
+### Fixes
+
+- **fix(databricks): backtick-quote catalog and database in `USE CATALOG` / `USE DATABASE`** Fixes `SQLSTATE 42602 / INVALID_IDENTIFIER` for names with hyphens or other non-word characters.
+
 ## [1.4.27]
 
 ### Fixes

--- a/test/unit/connectors/sql/test_databricks_delta_tables.py
+++ b/test/unit/connectors/sql/test_databricks_delta_tables.py
@@ -43,9 +43,6 @@ def test_quote_identifier_rejects_empty_and_whitespace(bad):
 
 
 def test_quote_identifier_never_uses_single_quotes():
-    # If someone "simplifies" this back to f"'{name}'" the Databricks
-    # parser will reject USE CATALOG 'name-with-dashes' at runtime
-    # (SQLSTATE 42602 / INVALID_IDENTIFIER). This is the original regression.
     out = quote_identifier("utic-dev-tech-fixtures")
     assert not out.startswith("'")
     assert not out.endswith("'")

--- a/test/unit/connectors/sql/test_databricks_delta_tables.py
+++ b/test/unit/connectors/sql/test_databricks_delta_tables.py
@@ -1,9 +1,21 @@
-"""Unit tests for databricks quote_identifier helper."""
+from unittest.mock import MagicMock
 
 import pytest
+from pydantic import Secret
+from pytest_mock import MockerFixture
 
 from unstructured_ingest.error import ValueError as IngestValueError
+from unstructured_ingest.processes.connectors.sql.databricks_delta_tables import (
+    DatabricksDeltaTablesAccessConfig,
+    DatabricksDeltaTablesConnectionConfig,
+    DatabricksDeltaTablesUploader,
+    DatabricksDeltaTablesUploaderConfig,
+)
 from unstructured_ingest.utils.databricks import quote_identifier
+
+HYPHENATED_CATALOG = "utic-dev-tech-fixtures"
+HYPHENATED_DATABASE = "my-db"
+TABLE_NAME = "elements"
 
 
 @pytest.mark.parametrize(
@@ -39,6 +51,76 @@ def test_quote_identifier_rejects_empty_and_whitespace(bad):
 
 def test_quote_identifier_never_uses_single_quotes():
     out = quote_identifier("utic-dev-tech-fixtures")
-    assert not out.startswith("'")
-    assert not out.endswith("'")
     assert out.startswith("`") and out.endswith("`")
+    assert "'" not in out
+
+
+@pytest.fixture
+def databricks_uploader():
+    return DatabricksDeltaTablesUploader(
+        connection_config=DatabricksDeltaTablesConnectionConfig(
+            access_config=Secret(DatabricksDeltaTablesAccessConfig(token="tok")),
+            server_hostname="example.databricks.com",
+            http_path="/sql/1.0/warehouses/xxx",
+        ),
+        upload_config=DatabricksDeltaTablesUploaderConfig(
+            catalog=HYPHENATED_CATALOG,
+            database=HYPHENATED_DATABASE,
+            table_name=TABLE_NAME,
+        ),
+    )
+
+
+@pytest.fixture
+def mock_cursor(mocker: MockerFixture):
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def mock_get_cursor(mocker: MockerFixture, mock_cursor: MagicMock):
+    mock = mocker.patch(
+        "unstructured_ingest.processes.connectors.sql.databricks_delta_tables"
+        ".DatabricksDeltaTablesConnectionConfig.get_cursor",
+        autospec=True,
+    )
+    mock.return_value.__enter__.return_value = mock_cursor
+    return mock
+
+
+def test_get_cursor_quotes_catalog_and_database(
+    mock_cursor: MagicMock,
+    mock_get_cursor: MagicMock,
+    databricks_uploader: DatabricksDeltaTablesUploader,
+):
+    """Test that get_cursor emits backtick-quoted USE CATALOG/USE DATABASE (PLU-332)."""
+    with databricks_uploader.get_cursor():
+        pass
+
+    executed = [c.args[0] for c in mock_cursor.execute.call_args_list]
+    assert f"USE CATALOG `{HYPHENATED_CATALOG}`" in executed
+    assert f"USE DATABASE `{HYPHENATED_DATABASE}`" in executed
+    for sql in executed:
+        if sql.startswith("USE "):
+            assert "'" not in sql
+
+
+def test_precheck_quotes_catalog_and_database(
+    mock_cursor: MagicMock,
+    mock_get_cursor: MagicMock,
+    databricks_uploader: DatabricksDeltaTablesUploader,
+):
+    """Test that precheck emits backtick-quoted USE CATALOG/USE DATABASE (PLU-332)."""
+    mock_cursor.fetchall.side_effect = [
+        [(HYPHENATED_CATALOG,)],
+        [(HYPHENATED_DATABASE,)],
+        [("col1", TABLE_NAME)],
+    ]
+
+    databricks_uploader.precheck()
+
+    executed = [c.args[0] for c in mock_cursor.execute.call_args_list]
+    assert f"USE CATALOG `{HYPHENATED_CATALOG}`" in executed
+    assert f"USE DATABASE `{HYPHENATED_DATABASE}`" in executed
+    for sql in executed:
+        if sql.startswith("USE "):
+            assert "'" not in sql

--- a/test/unit/connectors/sql/test_databricks_delta_tables.py
+++ b/test/unit/connectors/sql/test_databricks_delta_tables.py
@@ -1,9 +1,4 @@
-"""Unit tests for databricks quote_identifier helper.
-
-Pure-function tests: no Databricks client, no network, no mocks.
-See CHANGELOG 1.4.28 for the regression these guard against
-(USE CATALOG rejecting single-quoted string literals on DBSQL warehouses).
-"""
+"""Unit tests for databricks quote_identifier helper."""
 
 import pytest
 

--- a/test/unit/connectors/sql/test_databricks_delta_tables.py
+++ b/test/unit/connectors/sql/test_databricks_delta_tables.py
@@ -1,0 +1,52 @@
+"""Unit tests for databricks quote_identifier helper.
+
+Pure-function tests: no Databricks client, no network, no mocks.
+See CHANGELOG 1.4.28 for the regression these guard against
+(USE CATALOG rejecting single-quoted string literals on DBSQL warehouses).
+"""
+
+import pytest
+
+from unstructured_ingest.error import ValueError as IngestValueError
+from unstructured_ingest.utils.databricks import quote_identifier
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("default", "`default`"),
+        ("utic-dev-tech-fixtures", "`utic-dev-tech-fixtures`"),
+        ("select", "`select`"),
+        ("table", "`table`"),
+        ("from", "`from`"),
+        ("1name", "`1name`"),
+        ("my schema", "`my schema`"),
+        ("café", "`café`"),
+        ("foo`bar", "`foo``bar`"),
+        ("a``b", "`a````b`"),
+        ("`", "````"),
+        ("`leading", "```leading`"),
+        ("trailing`", "`trailing```"),
+    ],
+)
+def test_quote_identifier_happy_and_escaping(raw, expected):
+    assert quote_identifier(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [None, "", " ", "  ", "\t", "\n", "\t \n"],
+)
+def test_quote_identifier_rejects_empty_and_whitespace(bad):
+    with pytest.raises(IngestValueError):
+        quote_identifier(bad)
+
+
+def test_quote_identifier_never_uses_single_quotes():
+    # If someone "simplifies" this back to f"'{name}'" the Databricks
+    # parser will reject USE CATALOG 'name-with-dashes' at runtime
+    # (SQLSTATE 42602 / INVALID_IDENTIFIER). This is the original regression.
+    out = quote_identifier("utic-dev-tech-fixtures")
+    assert not out.startswith("'")
+    assert not out.endswith("'")
+    assert out.startswith("`") and out.endswith("`")

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.27"  # pragma: no cover
+__version__ = "1.4.28"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/databricks/volumes_table.py
+++ b/unstructured_ingest/processes/connectors/databricks/volumes_table.py
@@ -23,10 +23,10 @@ from unstructured_ingest.processes.connectors.databricks.volumes import Databric
 from unstructured_ingest.processes.connectors.sql.databricks_delta_tables import (
     DatabricksDeltaTablesConnectionConfig,
     DatabricksDeltaTablesUploadStagerConfig,
-    _quote_identifier,
 )
 from unstructured_ingest.utils.constants import RECORD_ID_LABEL
 from unstructured_ingest.utils.data_prep import get_enhanced_element_id, get_json_data, write_data
+from unstructured_ingest.utils.databricks import quote_identifier
 
 CONNECTOR_TYPE = "databricks_volume_delta_tables"
 
@@ -111,7 +111,7 @@ class DatabricksVolumeDeltaTableUploader(Uploader):
                         self.upload_config.catalog, ", ".join(catalogs)
                     )
                 )
-            cursor.execute(f"USE CATALOG {_quote_identifier(self.upload_config.catalog)}")
+            cursor.execute(f"USE CATALOG {quote_identifier(self.upload_config.catalog)}")
             cursor.execute("SHOW DATABASES")
             databases = [r[0] for r in cursor.fetchall()]
             if self.upload_config.database not in databases:
@@ -129,8 +129,8 @@ class DatabricksVolumeDeltaTableUploader(Uploader):
     @contextmanager
     def get_cursor(self, **connect_kwargs) -> Generator[Any, None, None]:
         with self.connection_config.get_cursor(**connect_kwargs) as cursor:
-            catalog_identifier = _quote_identifier(self.upload_config.catalog)
-            database_identifier = _quote_identifier(self.upload_config.database)
+            catalog_identifier = quote_identifier(self.upload_config.catalog)
+            database_identifier = quote_identifier(self.upload_config.database)
             logger.debug(f"executing: USE CATALOG {catalog_identifier}")
             cursor.execute(f"USE CATALOG {catalog_identifier}")
             logger.debug(f"executing: USE DATABASE {database_identifier}")

--- a/unstructured_ingest/processes/connectors/databricks/volumes_table.py
+++ b/unstructured_ingest/processes/connectors/databricks/volumes_table.py
@@ -23,6 +23,7 @@ from unstructured_ingest.processes.connectors.databricks.volumes import Databric
 from unstructured_ingest.processes.connectors.sql.databricks_delta_tables import (
     DatabricksDeltaTablesConnectionConfig,
     DatabricksDeltaTablesUploadStagerConfig,
+    _quote_identifier,
 )
 from unstructured_ingest.utils.constants import RECORD_ID_LABEL
 from unstructured_ingest.utils.data_prep import get_enhanced_element_id, get_json_data, write_data
@@ -110,7 +111,7 @@ class DatabricksVolumeDeltaTableUploader(Uploader):
                         self.upload_config.catalog, ", ".join(catalogs)
                     )
                 )
-            cursor.execute(f"USE CATALOG '{self.upload_config.catalog}'")
+            cursor.execute(f"USE CATALOG {_quote_identifier(self.upload_config.catalog)}")
             cursor.execute("SHOW DATABASES")
             databases = [r[0] for r in cursor.fetchall()]
             if self.upload_config.database not in databases:
@@ -128,10 +129,12 @@ class DatabricksVolumeDeltaTableUploader(Uploader):
     @contextmanager
     def get_cursor(self, **connect_kwargs) -> Generator[Any, None, None]:
         with self.connection_config.get_cursor(**connect_kwargs) as cursor:
-            logger.debug(f"executing: USE CATALOG: '{self.upload_config.catalog}'")
-            cursor.execute(f"USE CATALOG '{self.upload_config.catalog}'")
-            logger.debug(f"executing: USE DATABASE: {self.upload_config.database}")
-            cursor.execute(f"USE DATABASE {self.upload_config.database}")
+            catalog_identifier = _quote_identifier(self.upload_config.catalog)
+            database_identifier = _quote_identifier(self.upload_config.database)
+            logger.debug(f"executing: USE CATALOG {catalog_identifier}")
+            cursor.execute(f"USE CATALOG {catalog_identifier}")
+            logger.debug(f"executing: USE DATABASE {database_identifier}")
+            cursor.execute(f"USE DATABASE {database_identifier}")
             yield cursor
 
     def get_table_columns(self) -> dict[str, str]:

--- a/unstructured_ingest/processes/connectors/sql/databricks_delta_tables.py
+++ b/unstructured_ingest/processes/connectors/sql/databricks_delta_tables.py
@@ -146,6 +146,7 @@ class DatabricksDeltaTablesUploader(SQLUploader):
     def get_cursor(self) -> Generator[Any, None, None]:
         with self.connection_config.get_cursor() as cursor:
             cursor.execute(f"USE CATALOG {_quote_identifier(self.upload_config.catalog)}")
+            cursor.execute(f"USE DATABASE {_quote_identifier(self.upload_config.database)}")
             yield cursor
 
     def precheck(self) -> None:
@@ -167,6 +168,7 @@ class DatabricksDeltaTablesUploader(SQLUploader):
                         self.upload_config.database, ", ".join(databases)
                     )
                 )
+            cursor.execute(f"USE DATABASE {_quote_identifier(self.upload_config.database)}")
             cursor.execute("SHOW TABLES")
             table_names = [r[1] for r in cursor.fetchall()]
             if self.upload_config.table_name not in table_names:

--- a/unstructured_ingest/processes/connectors/sql/databricks_delta_tables.py
+++ b/unstructured_ingest/processes/connectors/sql/databricks_delta_tables.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
 CONNECTOR_TYPE = "databricks_delta_tables"
 
 
+def _quote_identifier(name: str) -> str:
+    if name is None:
+        raise ValueError("identifier is required")
+    return "`" + name.replace("`", "``") + "`"
+
+
 class DatabricksDeltaTablesAccessConfig(SQLAccessConfig):
     token: Optional[str] = Field(default=None, description="Databricks Personal Access Token")
     client_id: Optional[str] = Field(default=None, description="Client ID of the OAuth app.")
@@ -137,7 +143,7 @@ class DatabricksDeltaTablesUploader(SQLUploader):
     @contextmanager
     def get_cursor(self) -> Generator[Any, None, None]:
         with self.connection_config.get_cursor() as cursor:
-            cursor.execute(f"USE CATALOG '{self.upload_config.catalog}'")
+            cursor.execute(f"USE CATALOG {_quote_identifier(self.upload_config.catalog)}")
             yield cursor
 
     def precheck(self) -> None:
@@ -150,7 +156,7 @@ class DatabricksDeltaTablesUploader(SQLUploader):
                         self.upload_config.catalog, ", ".join(catalogs)
                     )
                 )
-            cursor.execute(f"USE CATALOG '{self.upload_config.catalog}'")
+            cursor.execute(f"USE CATALOG {_quote_identifier(self.upload_config.catalog)}")
             cursor.execute("SHOW DATABASES")
             databases = [r[0] for r in cursor.fetchall()]
             if self.upload_config.database not in databases:

--- a/unstructured_ingest/processes/connectors/sql/databricks_delta_tables.py
+++ b/unstructured_ingest/processes/connectors/sql/databricks_delta_tables.py
@@ -22,6 +22,7 @@ from unstructured_ingest.processes.connectors.sql.sql import (
     SQLUploadStagerConfig,
 )
 from unstructured_ingest.utils.data_prep import split_dataframe
+from unstructured_ingest.utils.databricks import quote_identifier
 from unstructured_ingest.utils.dep_check import requires_dependencies
 
 if TYPE_CHECKING:
@@ -31,14 +32,6 @@ if TYPE_CHECKING:
     from pandas import DataFrame
 
 CONNECTOR_TYPE = "databricks_delta_tables"
-
-
-def _quote_identifier(name: str) -> str:
-    """Wrap ``name`` as a Databricks backtick-quoted identifier so hyphens,
-    reserved words, etc. are legal; embedded backticks are doubled."""
-    if name is None:
-        raise ValueError("identifier is required")
-    return "`" + name.replace("`", "``") + "`"
 
 
 class DatabricksDeltaTablesAccessConfig(SQLAccessConfig):
@@ -145,8 +138,8 @@ class DatabricksDeltaTablesUploader(SQLUploader):
     @contextmanager
     def get_cursor(self) -> Generator[Any, None, None]:
         with self.connection_config.get_cursor() as cursor:
-            cursor.execute(f"USE CATALOG {_quote_identifier(self.upload_config.catalog)}")
-            cursor.execute(f"USE DATABASE {_quote_identifier(self.upload_config.database)}")
+            cursor.execute(f"USE CATALOG {quote_identifier(self.upload_config.catalog)}")
+            cursor.execute(f"USE DATABASE {quote_identifier(self.upload_config.database)}")
             yield cursor
 
     def precheck(self) -> None:
@@ -159,7 +152,7 @@ class DatabricksDeltaTablesUploader(SQLUploader):
                         self.upload_config.catalog, ", ".join(catalogs)
                     )
                 )
-            cursor.execute(f"USE CATALOG {_quote_identifier(self.upload_config.catalog)}")
+            cursor.execute(f"USE CATALOG {quote_identifier(self.upload_config.catalog)}")
             cursor.execute("SHOW DATABASES")
             databases = [r[0] for r in cursor.fetchall()]
             if self.upload_config.database not in databases:
@@ -168,7 +161,7 @@ class DatabricksDeltaTablesUploader(SQLUploader):
                         self.upload_config.database, ", ".join(databases)
                     )
                 )
-            cursor.execute(f"USE DATABASE {_quote_identifier(self.upload_config.database)}")
+            cursor.execute(f"USE DATABASE {quote_identifier(self.upload_config.database)}")
             cursor.execute("SHOW TABLES")
             table_names = [r[1] for r in cursor.fetchall()]
             if self.upload_config.table_name not in table_names:

--- a/unstructured_ingest/processes/connectors/sql/databricks_delta_tables.py
+++ b/unstructured_ingest/processes/connectors/sql/databricks_delta_tables.py
@@ -34,6 +34,8 @@ CONNECTOR_TYPE = "databricks_delta_tables"
 
 
 def _quote_identifier(name: str) -> str:
+    """Wrap ``name`` as a Databricks backtick-quoted identifier so hyphens,
+    reserved words, etc. are legal; embedded backticks are doubled."""
     if name is None:
         raise ValueError("identifier is required")
     return "`" + name.replace("`", "``") + "`"

--- a/unstructured_ingest/utils/databricks.py
+++ b/unstructured_ingest/utils/databricks.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from unstructured_ingest.error import ValueError
+
+
+def quote_identifier(name: Optional[str]) -> str:
+    """Wrap ``name`` as a Databricks backtick-quoted identifier so hyphens,
+    reserved words, etc. are legal; embedded backticks are doubled."""
+    if not name or not name.strip():
+        raise ValueError("identifier is required and cannot be empty")
+    return "`" + name.replace("`", "``") + "`"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk bugfix limited to Databricks connectors’ session setup SQL; main risk is any behavioral change for unusual identifier names or quoting expectations.
> 
> **Overview**
> Fixes Databricks Delta Tables and Databricks Volumes Delta Tables connectors to **backtick-quote** `catalog` and `database` when issuing `USE CATALOG` / `USE DATABASE`, preventing `INVALID_IDENTIFIER` errors for names containing hyphens, spaces, reserved words, or backticks.
> 
> Introduces a shared `quote_identifier()` helper (with escaping and empty-value validation), adds unit tests covering quoting/escaping and emitted SQL, and bumps the package version + changelog to `1.4.28`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c1b7e60bf94c49f2786d6df6a2de76e30c0457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->