### PR TITLE
chore(UNTRACKED): skip confluence test until account reactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.29]
+
+### Chores
+
+- **chore(tests): temporarily skip Confluence integration test pending account reactivation.**
+
 ## [1.4.28]
 
 ### Fixes

--- a/test/integration/connectors/test_confluence.py
+++ b/test/integration/connectors/test_confluence.py
@@ -19,6 +19,10 @@ from unstructured_ingest.processes.connectors.confluence import (
 )
 
 
+@pytest.mark.skip(
+    reason="Temporarily disabled: Confluence test account is inactive. "
+    "Re-enable once credentials are restored."
+)
 @pytest.mark.asyncio
 @pytest.mark.tags(CONNECTOR_TYPE, SOURCE_TAG, UNCATEGORIZED_TAG)
 @requires_env("CONFLUENCE_USER_EMAIL", "CONFLUENCE_API_TOKEN")

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.28"  # pragma: no cover
+__version__ = "1.4.29"  # pragma: no cover


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only affects test execution and version/changelog metadata, with no production code changes.
> 
> **Overview**
> Temporarily skips the Confluence integration test (`test_confluence_source_param`) via `@pytest.mark.skip` due to inactive credentials, preventing CI failures until the account is reactivated.
> 
> Bumps the package version to `1.4.29` and records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b16d19bef1719b22590204e4572cb9043e93cc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->