### PR TITLE
feat: add additional_metadata_fields to Pinecone upload stager config

### DIFF
--- a/unstructured_ingest/processes/connectors/pinecone.py
+++ b/unstructured_ingest/processes/connectors/pinecone.py
@@ -108,6 +108,14 @@ class PineconeUploadStagerConfig(UploadStagerConfig):
             "Pinecone."
         ),
     )
+    additional_metadata_fields: list[str] = Field(
+        default=[],
+        description=(
+            "Additional metadata fields to include beyond the default allowed list. "
+            "Useful for custom enricher-generated keys. "
+            "List values are preserved as-is for native Pinecone $in filtering."
+        ),
+    )
 
 
 class PineconeUploaderConfig(UploaderConfig):
@@ -140,12 +148,15 @@ class PineconeUploadStager(UploadStager):
         data_source = metadata.pop("data_source", {})
         coordinates = metadata.pop("coordinates", {})
         pinecone_metadata = {}
+        allowed = set(self.upload_stager_config.metadata_fields) | set(
+            self.upload_stager_config.additional_metadata_fields
+        )
         for possible_meta in [element_dict, metadata, data_source, coordinates]:
             pinecone_metadata.update(
                 {
                     k: v
                     for k, v in possible_meta.items()
-                    if k in self.upload_stager_config.metadata_fields
+                    if k in allowed
                 }
             )
 
@@ -154,10 +165,16 @@ class PineconeUploadStager(UploadStager):
             separator="-",
             flatten_lists=True,
             remove_none=True,
+            keys_to_omit=list(self.upload_stager_config.additional_metadata_fields),
         )
         metadata_size_bytes = len(json.dumps(metadata).encode())
+        if metadata_size_bytes > MAX_METADATA_BYTES * 0.75:
+            logger.warning(
+                f"Metadata size is {metadata_size_bytes} bytes, approaching the "
+                f"{MAX_METADATA_BYTES} byte limit per vector."
+            )
         if metadata_size_bytes > MAX_METADATA_BYTES:
-            logger.info(
+            logger.error(
                 f"Metadata size is {metadata_size_bytes} bytes, which exceeds the limit of"
                 f" {MAX_METADATA_BYTES} bytes per vector. Dropping the metadata."
             )


### PR DESCRIPTION
## Summary

Adds `additional_metadata_fields` to `PineconeUploadStagerConfig`, allowing users to include custom enricher-generated metadata keys in Pinecone vector payloads beyond the hardcoded `ALLOWED_FIELDS` allowlist.

## Problem

The Pinecone stager uses a hardcoded `ALLOWED_FIELDS` tuple to filter which metadata keys are written to each vector. Any key not in this list is silently dropped. Users running enricher nodes that produce custom metadata keys have no way to surface those keys in Pinecone.

## Solution

- Add `additional_metadata_fields: list[str] = []` to `PineconeUploadStagerConfig`
- Keys in this list are unioned with `metadata_fields` in the allowlist filter
- Keys are also passed as `keys_to_omit` to `flatten_dict`, preserving `list[str]` values for native Pinecone `$in` filtering (without this, `flatten_lists=True` converts `["a", "b"]` to indexed keys `field-0`, `field-1`)
- Add 40KB warning at 75% threshold; upgrade metadata drop log from INFO to ERROR

## Precedent

Similar to Milvus connector's `fields_to_include` added in platform 3.5.0.