### PR TITLE
fix(notion): accept app.notion.com URLs after Notion domain migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.1]
+
+### Fixes
+
+- **fix(notion): accept app.notion.com URLs after Notion domain migration.** `is_page_url()` and `is_database_url()` now accept both `www.notion.so` and `app.notion.com` domains.
+
 ## [1.5.0]
 
 ### Enhancements

--- a/test/integration/connectors/expected_results/notion_database/file_data/1722c3765a0a8082b382ebc2c62d3f4c.json
+++ b/test/integration/connectors/expected_results/notion_database/file_data/1722c3765a0a8082b382ebc2c62d3f4c.json
@@ -31,7 +31,7 @@
       "type": "workspace",
       "workspace": true
     },
-    "url": "https://www.notion.so/1722c3765a0a8082b382ebc2c62d3f4c"
+    "url": "https://app.notion.com/p/1722c3765a0a8082b382ebc2c62d3f4c"
   },
   "reprocess": false,
   "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpnqdhn9hy/1722c3765a0a8082b382ebc2c62d3f4c.html",

--- a/test/integration/connectors/expected_results/notion_page/downloads/1572c3765a0a806299f0dd6999f9e4c7.html
+++ b/test/integration/connectors/expected_results/notion_page/downloads/1572c3765a0a806299f0dd6999f9e4c7.html
@@ -221,8 +221,8 @@
         </code>
       </div>
       <div>
-        <a href='https://www.notion.so/test-doc1-1572c3765a0a806299f0dd6999f9e4c7'>
-          https://www.notion.so/test-doc1-1572c3765a0a806299f0dd6999f9e4c7
+        <a href='https://app.notion.com/p/test-doc1-1572c3765a0a806299f0dd6999f9e4c7'>
+          https://app.notion.com/p/test-doc1-1572c3765a0a806299f0dd6999f9e4c7
         </a>
       </div>
       <div>

--- a/test/integration/connectors/expected_results/notion_page/file_data/1572c3765a0a806299f0dd6999f9e4c7.json
+++ b/test/integration/connectors/expected_results/notion_page/file_data/1572c3765a0a806299f0dd6999f9e4c7.json
@@ -31,7 +31,7 @@
       "page_id": "1182c376-5a0a-8042-9a2a-fb003e00d57b",
       "type": "page_id"
     },
-    "url": "https://www.notion.so/test-doc1-1572c3765a0a806299f0dd6999f9e4c7"
+    "url": "https://app.notion.com/p/test-doc1-1572c3765a0a806299f0dd6999f9e4c7"
   },
   "reprocess": false,
   "local_download_path": "/private/var/folders/5k/frv076q97yl0ywybmzydhbsr0000gn/T/tmpbzr2c5l6/1572c3765a0a806299f0dd6999f9e4c7.html",

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.5.0"  # pragma: no cover
+__version__ = "1.5.1"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/notion/helpers.py
+++ b/unstructured_ingest/processes/connectors/notion/helpers.py
@@ -424,10 +424,13 @@ def get_uuid_from_url(path: str) -> Optional[str]:
     return None
 
 
+_NOTION_DOMAINS = ("www.notion.so", "app.notion.com")
+
+
 def is_page_url(client: Client, url: str):
     parsed_url = urlparse(url)
     path = parsed_url.path.split("/")[-1]
-    if parsed_url.netloc != "www.notion.so":
+    if parsed_url.netloc not in _NOTION_DOMAINS:
         return False
     page_uuid = get_uuid_from_url(path=path)
     if not page_uuid:
@@ -439,7 +442,7 @@ def is_page_url(client: Client, url: str):
 def is_database_url(client: Client, url: str):
     parsed_url = urlparse(url)
     path = parsed_url.path.split("/")[-1]
-    if parsed_url.netloc != "www.notion.so":
+    if parsed_url.netloc not in _NOTION_DOMAINS:
         return False
     database_uuid = get_uuid_from_url(path=path)
     if not database_uuid:


### PR DESCRIPTION
## Summary
- Accept both `www.notion.so` and `app.notion.com` in `is_page_url()` and `is_database_url()` after Notion's domain migration.
- Update integration test fixtures to match the new URL format returned by the Notion API.

## Details
- Notion migrated from `www.notion.so` to `app.notion.com/p/` URLs. The URL validation helpers in `helpers.py` hardcoded the old domain, rejecting URLs in the new format.
- Added `_NOTION_DOMAINS` tuple to centralize accepted domains and support both old and new formats for backwards compatibility.
- Updated 3 fixture files (`notion_page` and `notion_database` expected results) to reflect the new URL format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to Notion URL validation plus fixture/version bumps; main risk is misclassifying unusual Notion URL variants by domain parsing.
> 
> **Overview**
> Updates the Notion connector URL validators (`is_page_url()`/`is_database_url()`) to accept both `www.notion.so` and the new `app.notion.com` domains via a shared `_NOTION_DOMAINS` allowlist.
> 
> Bumps the package version to `1.5.1`, adds a changelog entry, and refreshes Notion integration test fixtures/expected outputs to the new `app.notion.com/p/...` URL format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae509e0a24bf3a2635a4eecd00e8ed40ecca229e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->