### PR TITLE
fix(PLU-348): azure ai search improvement dropping fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.1]
+
+### Fixes
+
+- **fix(azure_ai_search): drop unknown fields at every nesting level of the index schema.** The existing "drop unknown fields" filter only inspected top-level keys, so new nested metadata fields from `unstructured` (e.g. `metadata.table_extraction_method`) reached the service and were rejected with HTTP 400. The filter now recursively walks `index.fields` and prunes any sub-field not declared by the destination schema.
+
 ## [1.5.0]
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **fix(azure_ai_search): drop unknown fields at every nesting level of the index schema.** The existing "drop unknown fields" filter only inspected top-level keys, so new nested metadata fields from `unstructured` (e.g. `metadata.table_extraction_method`) reached the service and were rejected with HTTP 400. The filter now recursively walks `index.fields` and prunes any sub-field not declared by the destination schema.
+- **fix(azure_ai_search): recursively drop unknown fields against the index schema.** New nested fields from `unstructured` (e.g. `metadata.table_extraction_method`) were reaching the service and causing HTTP 400s; the filter now recurses through `index.fields`.
 
 ## [1.5.0]
 

--- a/test/integration/connectors/test_azure_ai_search.py
+++ b/test/integration/connectors/test_azure_ai_search.py
@@ -237,6 +237,62 @@ async def test_azure_ai_search_destination(
         validate_count(search_client=search_client, expected_count=expected_count)
 
 
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+@requires_env("AZURE_SEARCH_API_KEY")
+async def test_azure_ai_search_destination_drops_unknown_nested_fields(
+    upload_file: Path,
+    index: str,
+    tmp_path: Path,
+):
+    """Regression test for the 400 reported on 2026-05-01: the new ``unstructured`` field
+    ``metadata.table_extraction_method`` was rejected by Azure's strict ComplexType validation.
+
+    Stages real elements, injects an unknown nested field and a stray top-level field, and
+    runs the uploader against a real Azure index. The upload succeeding is itself the
+    assertion: without the recursive filter, ``run_data`` would raise on Azure's 400 long
+    before the document-count check; with the filter in place the unknown fields are pruned
+    pre-upload and every staged element is indexed. Round-tripping a doc to assert the
+    injected fields are absent would not add signal — Azure projects responses over the
+    declared schema, so unknown fields are invisible on read regardless of who dropped them.
+    """
+    file_data = FileData(
+        source_identifiers=SourceIdentifiers(fullpath=upload_file.name, filename=upload_file.name),
+        connector_type=CONNECTOR_TYPE,
+        identifier="mock file data nested filter",
+    )
+    stager = AzureAISearchUploadStager(upload_stager_config=AzureAISearchUploadStagerConfig())
+
+    uploader = AzureAISearchUploader(
+        connection_config=AzureAISearchConnectionConfig(
+            access_config=AzureAISearchAccessConfig(key=get_api_key()),
+            endpoint=ENDPOINT,
+            index=index,
+        ),
+        upload_config=AzureAISearchUploaderConfig(),
+    )
+    staged_filepath = stager.run(
+        elements_filepath=upload_file,
+        file_data=file_data,
+        output_dir=tmp_path,
+        output_filename=upload_file.name,
+    )
+
+    with staged_filepath.open() as f:
+        staged_elements = json.load(f)
+    assert staged_elements, "expected staged elements for the regression test"
+    for element in staged_elements:
+        element.setdefault("metadata", {})["table_extraction_method"] = "auto"
+        element["future_undeclared_top_level_field"] = "drop me"
+
+    uploader.precheck()
+    uploader.run_data(data=staged_elements, file_data=file_data)
+
+    expected_count = len(staged_elements)
+    with uploader.connection_config.get_search_client() as search_client:
+        validate_count(search_client=search_client, expected_count=expected_count)
+
+
 @pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
 @pytest.mark.parametrize("upload_file_str", ["upload_file_ndjson", "upload_file"])
 def test_azure_ai_search_stager(

--- a/test/unit/processes/connectors/test_azure_ai_search.py
+++ b/test/unit/processes/connectors/test_azure_ai_search.py
@@ -4,24 +4,116 @@ from unittest.mock import MagicMock
 import pytest
 
 from unstructured_ingest.error import ValueError as IngestValueError
+from unstructured_ingest.processes.connectors import azure_ai_search as aas_module
 from unstructured_ingest.processes.connectors.azure_ai_search import (
     AzureAISearchUploader,
     AzureAISearchUploaderConfig,
 )
 
 
+def make_field(name: str, *, sub_fields=None, key: bool = False, filterable: bool = False):
+    """Build a mock SearchField. ``sub_fields`` should be ``None`` for primitive
+    fields (Edm.String, Collection(Edm.String), etc.) and a list of mock fields
+    for ComplexType / Collection(ComplexType) fields.
+    """
+    f = MagicMock()
+    f.name = name
+    f.fields = sub_fields
+    f.key = key
+    f.filterable = filterable
+    return f
+
+
 def make_index(field_specs: list[tuple[str, bool, bool]]):
-    """Build a mock index with fields defined by (name, key, filterable) tuples."""
-    fields = []
-    for name, key, filterable in field_specs:
-        f = MagicMock()
-        f.name = name
-        f.key = key
-        f.filterable = filterable
-        fields.append(f)
+    """Build a mock index with top-level-only fields defined by (name, key, filterable)."""
+    fields = [
+        make_field(name, key=key, filterable=filterable) for name, key, filterable in field_specs
+    ]
     index = MagicMock()
     index.fields = fields
     return index
+
+
+def make_nested_index(fields_spec):
+    """Build a mock index from a possibly-nested spec.
+
+    ``fields_spec`` is a list of dicts: ``{"name": str, "fields": list | None,
+    "key": bool, "filterable": bool}``. ``fields`` is a child spec list for
+    complex types or ``None`` for primitives. ``key`` and ``filterable`` are
+    optional and default to False.
+    """
+
+    def build(spec):
+        out = []
+        for entry in spec:
+            sub = entry.get("fields")
+            sub_fields = build(sub) if sub is not None else None
+            out.append(
+                make_field(
+                    entry["name"],
+                    sub_fields=sub_fields,
+                    key=entry.get("key", False),
+                    filterable=entry.get("filterable", False),
+                )
+            )
+        return out
+
+    index = MagicMock()
+    index.fields = build(fields_spec)
+    return index
+
+
+def canonical_schema_index():
+    """A mock of the canonical Azure AI Search index schema used by this connector.
+
+    Mirrors the integration-test fixture: top-level (id, record_id, element_id,
+    text, type, metadata, embeddings) with ``metadata`` as a ComplexType whose
+    sub-fields include two further ComplexTypes (``coordinates``, ``data_source``).
+    """
+    return make_nested_index(
+        [
+            {"name": "id", "key": True},
+            {"name": "record_id", "filterable": True},
+            {"name": "element_id"},
+            {"name": "text"},
+            {"name": "type"},
+            {
+                "name": "metadata",
+                "fields": [
+                    {"name": "filename"},
+                    {"name": "filetype"},
+                    {"name": "last_modified"},
+                    {"name": "languages"},
+                    {"name": "page_number"},
+                    {"name": "links"},
+                    {"name": "regex_metadata"},
+                    {"name": "orig_elements"},
+                    {
+                        "name": "coordinates",
+                        "fields": [
+                            {"name": "system"},
+                            {"name": "layout_width"},
+                            {"name": "layout_height"},
+                            {"name": "points"},
+                        ],
+                    },
+                    {
+                        "name": "data_source",
+                        "fields": [
+                            {"name": "url"},
+                            {"name": "version"},
+                            {"name": "date_created"},
+                            {"name": "date_modified"},
+                            {"name": "date_processed"},
+                            {"name": "permissions_data"},
+                            {"name": "record_locator"},
+                        ],
+                    },
+                ],
+            },
+            {"name": "embeddings"},
+        ]
+    )
 
 
 def make_uploader(**kwargs) -> AzureAISearchUploader:
@@ -163,3 +255,439 @@ def test_run_data_no_log_when_no_dropped_fields(caplog):
         uploader.run_data(data=data, file_data=file_data)
 
     assert not any("will be dropped" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# get_index_field_tree
+# ---------------------------------------------------------------------------
+
+
+def test_get_index_field_tree_top_level_only_marks_all_leaves():
+    uploader = make_uploader()
+    index = make_nested_index(
+        [{"name": "id"}, {"name": "text"}, {"name": "record_id"}, {"name": "embeddings"}]
+    )
+    assert uploader.get_index_field_tree(index) == {
+        "id": None,
+        "text": None,
+        "record_id": None,
+        "embeddings": None,
+    }
+
+
+def test_get_index_field_tree_canonical_schema_mirrors_nesting():
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+
+    assert set(tree.keys()) == {
+        "id",
+        "record_id",
+        "element_id",
+        "text",
+        "type",
+        "metadata",
+        "embeddings",
+    }
+    assert tree["id"] is None
+    assert tree["embeddings"] is None
+    assert isinstance(tree["metadata"], dict)
+    assert tree["metadata"]["filename"] is None
+    assert tree["metadata"]["languages"] is None
+    assert isinstance(tree["metadata"]["coordinates"], dict)
+    assert tree["metadata"]["coordinates"]["points"] is None
+    assert isinstance(tree["metadata"]["data_source"], dict)
+    assert tree["metadata"]["data_source"]["record_locator"] is None
+    assert tree["metadata"]["data_source"]["url"] is None
+
+
+def test_get_index_field_tree_collection_of_complex_treated_as_complex():
+    """Collection(ComplexType) fields populate ``.fields`` just like ComplexType,
+    so the tree builder treats them identically (the recursive filter then
+    walks per-item)."""
+    uploader = make_uploader()
+    index = make_nested_index(
+        [
+            {"name": "id"},
+            {
+                "name": "key_value_pairs",
+                "fields": [{"name": "key"}, {"name": "value"}, {"name": "confidence"}],
+            },
+        ]
+    )
+    tree = uploader.get_index_field_tree(index)
+    assert tree["id"] is None
+    assert tree["key_value_pairs"] == {"key": None, "value": None, "confidence": None}
+
+
+def test_get_index_field_tree_empty_index():
+    uploader = make_uploader()
+    index = make_nested_index([])
+    assert uploader.get_index_field_tree(index) == {}
+
+
+def test_get_index_field_tree_caps_at_max_depth(monkeypatch):
+    """Defensive cap: don't recurse past Azure's 10-level limit. With the cap
+    monkeypatched to 3, four nested complex levels collapse such that the
+    deepest declared sub-tree is clipped to ``{}`` and anything beyond is
+    treated as unknown by the filter."""
+    monkeypatch.setattr(aas_module, "_MAX_INDEX_FIELD_DEPTH", 3)
+    uploader = make_uploader()
+    index = make_nested_index(
+        [
+            {
+                "name": "lvl0",
+                "fields": [
+                    {
+                        "name": "lvl1",
+                        "fields": [
+                            {
+                                "name": "lvl2",
+                                "fields": [{"name": "lvl3_should_be_clipped"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+    tree = uploader.get_index_field_tree(index)
+    assert tree == {"lvl0": {"lvl1": {"lvl2": {}}}}
+
+
+# ---------------------------------------------------------------------------
+# filter_doc_against_tree
+# ---------------------------------------------------------------------------
+
+
+def test_filter_doc_against_tree_no_op_when_doc_matches_schema():
+    uploader = make_uploader()
+    tree = {"id": None, "text": None, "metadata": {"filename": None, "page_number": None}}
+    doc = {"id": "1", "text": "hello", "metadata": {"filename": "f.pdf", "page_number": "1"}}
+    assert uploader.filter_doc_against_tree(doc, tree) == doc
+
+
+def test_filter_doc_against_tree_drops_unknown_top_level_key():
+    uploader = make_uploader()
+    tree = {"id": None, "text": None}
+    doc = {"id": "1", "text": "hello", "extra": "drop me"}
+    assert uploader.filter_doc_against_tree(doc, tree) == {"id": "1", "text": "hello"}
+
+
+def test_filter_doc_against_tree_drops_unknown_nested_key_regression_table_extraction_method():
+    """Regression: the bug reported on 2026-05-01. New ``unstructured`` field
+    ``metadata.table_extraction_method`` was being shipped to Azure AI Search
+    even though the index schema doesn't declare it, causing 400 rejections.
+    The recursive filter must drop it before upload.
+    """
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    doc = {
+        "id": "abc",
+        "record_id": "rec-1",
+        "text": "some text",
+        "metadata": {
+            "filename": "doc.pdf",
+            "filetype": "application/pdf",
+            "table_extraction_method": "tatr",
+        },
+    }
+    filtered = uploader.filter_doc_against_tree(doc, tree)
+    assert "table_extraction_method" not in filtered["metadata"]
+    assert filtered["metadata"] == {"filename": "doc.pdf", "filetype": "application/pdf"}
+    assert filtered["id"] == "abc"
+    assert filtered["record_id"] == "rec-1"
+    assert filtered["text"] == "some text"
+
+
+def test_filter_doc_against_tree_drops_unknown_deeply_nested_key():
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    doc = {
+        "id": "abc",
+        "metadata": {
+            "data_source": {
+                "url": "s3://bucket/x.pdf",
+                "future_undeclared_field": "hello",
+            },
+        },
+    }
+    filtered = uploader.filter_doc_against_tree(doc, tree)
+    assert filtered["metadata"]["data_source"] == {"url": "s3://bucket/x.pdf"}
+
+
+def test_filter_doc_against_tree_preserves_string_leaves_modeled_as_edm_string():
+    """Sub-trees the stager has json.dumps'd into a string (e.g. record_locator,
+    points) are modeled as Edm.String in the schema, so ``tree[key] is None``.
+    The recursion should pass them through unchanged regardless of value shape.
+    """
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    doc = {
+        "metadata": {
+            "data_source": {
+                "record_locator": '{"protocol": "s3", "remote_file_path": "s3://x"}',
+                "permissions_data": '[{"permission": "read"}]',
+            },
+            "coordinates": {"points": "[[0, 0], [1, 1]]"},
+            "regex_metadata": '{"foo": "bar"}',
+        }
+    }
+    filtered = uploader.filter_doc_against_tree(doc, tree)
+    assert filtered["metadata"]["data_source"]["record_locator"] == doc["metadata"][
+        "data_source"
+    ]["record_locator"]
+    assert (
+        filtered["metadata"]["data_source"]["permissions_data"]
+        == doc["metadata"]["data_source"]["permissions_data"]
+    )
+    assert filtered["metadata"]["coordinates"]["points"] == doc["metadata"]["coordinates"]["points"]
+    assert filtered["metadata"]["regex_metadata"] == doc["metadata"]["regex_metadata"]
+
+
+def test_filter_doc_against_tree_passes_primitive_collection_through():
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    doc = {
+        "embeddings": [0.1, 0.2, 0.3],
+        "metadata": {"languages": ["eng", "fra"], "links": ["{...}", "{...}"]},
+    }
+    filtered = uploader.filter_doc_against_tree(doc, tree)
+    assert filtered["embeddings"] == [0.1, 0.2, 0.3]
+    assert filtered["metadata"]["languages"] == ["eng", "fra"]
+    assert filtered["metadata"]["links"] == ["{...}", "{...}"]
+
+
+def test_filter_doc_against_tree_recurses_into_collection_of_complex():
+    uploader = make_uploader()
+    index = make_nested_index(
+        [
+            {"name": "id"},
+            {
+                "name": "key_value_pairs",
+                "fields": [{"name": "key"}, {"name": "value"}, {"name": "confidence"}],
+            },
+        ]
+    )
+    tree = uploader.get_index_field_tree(index)
+    doc = {
+        "id": "1",
+        "key_value_pairs": [
+            {"key": "k1", "value": "v1", "confidence": 0.9, "extra_pair_field": "drop"},
+            {"key": "k2", "value": "v2", "confidence": 0.8},
+        ],
+    }
+    filtered = uploader.filter_doc_against_tree(doc, tree)
+    assert filtered == {
+        "id": "1",
+        "key_value_pairs": [
+            {"key": "k1", "value": "v1", "confidence": 0.9},
+            {"key": "k2", "value": "v2", "confidence": 0.8},
+        ],
+    }
+
+
+def test_filter_doc_against_tree_sparse_doc_no_fabrication():
+    """Missing optional schema keys should not be invented in the output."""
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    doc = {"id": "abc", "metadata": {"filename": "f.pdf"}}
+    filtered = uploader.filter_doc_against_tree(doc, tree)
+    assert filtered == {"id": "abc", "metadata": {"filename": "f.pdf"}}
+
+
+def test_filter_doc_against_tree_empty_doc():
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    assert uploader.filter_doc_against_tree({}, tree) == {}
+
+
+def test_filter_doc_against_tree_handles_metadata_modeled_as_edm_string():
+    """Customer schemas that model ``metadata`` as a flat Edm.String column
+    (i.e. JSON blob) end up with ``tree["metadata"] is None``. The recursion
+    must pass the metadata value through verbatim regardless of shape."""
+    uploader = make_uploader()
+    tree = {"id": None, "metadata": None}
+    doc = {"id": "1", "metadata": {"any": "shape", "nested": {"a": 1}}}
+    filtered = uploader.filter_doc_against_tree(doc, tree)
+    assert filtered == doc
+
+
+# ---------------------------------------------------------------------------
+# collect_dropped_paths
+# ---------------------------------------------------------------------------
+
+
+def test_collect_dropped_paths_empty_when_no_drops():
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    doc = {"id": "1", "metadata": {"filename": "f.pdf"}}
+    assert uploader.collect_dropped_paths(doc, tree) == []
+
+
+def test_collect_dropped_paths_reports_dotted_nested_path():
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    doc = {"id": "1", "metadata": {"filename": "f.pdf", "table_extraction_method": "tatr"}}
+    assert uploader.collect_dropped_paths(doc, tree) == ["metadata.table_extraction_method"]
+
+
+def test_collect_dropped_paths_mixes_top_level_and_nested():
+    uploader = make_uploader()
+    tree = uploader.get_index_field_tree(canonical_schema_index())
+    doc = {
+        "id": "1",
+        "totally_unknown_top": "x",
+        "metadata": {
+            "filename": "f.pdf",
+            "table_extraction_method": "tatr",
+            "data_source": {"url": "s3://x", "future_field": "y"},
+        },
+    }
+    assert uploader.collect_dropped_paths(doc, tree) == [
+        "metadata.data_source.future_field",
+        "metadata.table_extraction_method",
+        "totally_unknown_top",
+    ]
+
+
+def test_collect_dropped_paths_dedup_and_sort_across_collection_items():
+    """When the same unknown sub-key appears in multiple list items the path is
+    reported only once, sorted with all other paths."""
+    uploader = make_uploader()
+    index = make_nested_index(
+        [
+            {"name": "id"},
+            {
+                "name": "key_value_pairs",
+                "fields": [{"name": "key"}, {"name": "value"}],
+            },
+        ]
+    )
+    tree = uploader.get_index_field_tree(index)
+    doc = {
+        "id": "1",
+        "key_value_pairs": [
+            {"key": "k", "value": "v", "junk": 1},
+            {"key": "k2", "value": "v2", "junk": 2},
+        ],
+    }
+    assert uploader.collect_dropped_paths(doc, tree) == ["key_value_pairs.junk"]
+
+
+# ---------------------------------------------------------------------------
+# run_data: end-to-end with a realistic schema
+# ---------------------------------------------------------------------------
+
+
+def test_run_data_strips_nested_unknown_field_before_upload(caplog):
+    """End-to-end: the canonical-schema customer hits ``unstructured``'s new
+    ``metadata.table_extraction_method`` field. ``run_data`` must:
+    - log the dotted path that will be dropped, and
+    - hand ``write_dict`` a doc with that nested key removed.
+    """
+    uploader = make_uploader()
+    uploader.get_index = MagicMock(return_value=canonical_schema_index())
+    uploader.can_delete = MagicMock(return_value=False)
+    uploader.write_dict = MagicMock()
+
+    search_client_ctx = MagicMock()
+    search_client_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    search_client_ctx.__exit__ = MagicMock(return_value=False)
+    uploader.connection_config.get_search_client.return_value = search_client_ctx
+
+    file_data = MagicMock()
+    data = [
+        {
+            "id": "abc",
+            "record_id": "rec-1",
+            "text": "some text",
+            "metadata": {
+                "filename": "doc.pdf",
+                "table_extraction_method": "tatr",
+                "data_source": {"url": "s3://x.pdf"},
+            },
+        }
+    ]
+
+    with caplog.at_level(logging.INFO):
+        uploader.run_data(data=data, file_data=file_data)
+
+    assert any(
+        "metadata.table_extraction_method" in r.message
+        and "will be dropped" in r.message
+        for r in caplog.records
+    ), "expected the dotted path to appear in the dropped-fields INFO log"
+
+    uploader.write_dict.assert_called_once()
+    sent_chunk = uploader.write_dict.call_args.kwargs["elements_dict"]
+    assert len(sent_chunk) == 1
+    sent_doc = sent_chunk[0]
+    assert "table_extraction_method" not in sent_doc["metadata"]
+    assert sent_doc["metadata"] == {
+        "filename": "doc.pdf",
+        "data_source": {"url": "s3://x.pdf"},
+    }
+    assert sent_doc["id"] == "abc"
+
+
+def test_run_data_no_log_and_passthrough_when_doc_matches_canonical_schema(caplog):
+    uploader = make_uploader()
+    uploader.get_index = MagicMock(return_value=canonical_schema_index())
+    uploader.can_delete = MagicMock(return_value=False)
+    uploader.write_dict = MagicMock()
+
+    search_client_ctx = MagicMock()
+    search_client_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    search_client_ctx.__exit__ = MagicMock(return_value=False)
+    uploader.connection_config.get_search_client.return_value = search_client_ctx
+
+    file_data = MagicMock()
+    doc = {
+        "id": "abc",
+        "record_id": "rec-1",
+        "text": "some text",
+        "metadata": {
+            "filename": "doc.pdf",
+            "page_number": "1",
+            "data_source": {"url": "s3://x.pdf", "version": "1"},
+            "coordinates": {"system": "PixelSpace", "points": "[[0,0],[1,1]]"},
+        },
+        "embeddings": [0.1, 0.2],
+    }
+
+    with caplog.at_level(logging.INFO):
+        uploader.run_data(data=[doc], file_data=file_data)
+
+    assert not any("will be dropped" in r.message for r in caplog.records)
+    sent_chunk = uploader.write_dict.call_args.kwargs["elements_dict"]
+    assert list(sent_chunk) == [doc]
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility: legacy methods still behave exactly as they did.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_filter_doc_still_returns_top_level_only_filter():
+    """``filter_doc`` is the old depth-0 filter. It is no longer called from
+    ``run_data`` but must remain available with its original semantics so any
+    existing subclass override or external caller keeps working."""
+    uploader = make_uploader()
+    doc = {"id": "1", "metadata": {"foo": "bar", "table_extraction_method": "tatr"}, "junk": "x"}
+    result = uploader.filter_doc(doc, {"id", "metadata"})
+    assert result == {"id": "1", "metadata": {"foo": "bar", "table_extraction_method": "tatr"}}
+    assert "junk" not in result
+
+
+def test_legacy_get_index_field_names_still_returns_top_level_set():
+    uploader = make_uploader()
+    tree_index = canonical_schema_index()
+    assert uploader.get_index_field_names(tree_index) == {
+        "id",
+        "record_id",
+        "element_id",
+        "text",
+        "type",
+        "metadata",
+        "embeddings",
+    }

--- a/test/unit/processes/connectors/test_azure_ai_search.py
+++ b/test/unit/processes/connectors/test_azure_ai_search.py
@@ -12,10 +12,8 @@ from unstructured_ingest.processes.connectors.azure_ai_search import (
 
 
 def make_field(name: str, *, sub_fields=None, key: bool = False, filterable: bool = False):
-    """Build a mock SearchField. ``sub_fields`` should be ``None`` for primitive
-    fields (Edm.String, Collection(Edm.String), etc.) and a list of mock fields
-    for ComplexType / Collection(ComplexType) fields.
-    """
+    """Build a mock ``SearchField``; ``sub_fields=None`` for primitives,
+    a list of mock fields for ComplexType."""
     f = MagicMock()
     f.name = name
     f.fields = sub_fields
@@ -35,13 +33,8 @@ def make_index(field_specs: list[tuple[str, bool, bool]]):
 
 
 def make_nested_index(fields_spec):
-    """Build a mock index from a possibly-nested spec.
-
-    ``fields_spec`` is a list of dicts: ``{"name": str, "fields": list | None,
-    "key": bool, "filterable": bool}``. ``fields`` is a child spec list for
-    complex types or ``None`` for primitives. ``key`` and ``filterable`` are
-    optional and default to False.
-    """
+    """Build a mock index from ``[{"name", "fields"?, "key"?, "filterable"?}, ...]``;
+    ``fields`` is a child spec list for complex types or absent/``None`` for primitives."""
 
     def build(spec):
         out = []
@@ -64,12 +57,8 @@ def make_nested_index(fields_spec):
 
 
 def canonical_schema_index():
-    """A mock of the canonical Azure AI Search index schema used by this connector.
-
-    Mirrors the integration-test fixture: top-level (id, record_id, element_id,
-    text, type, metadata, embeddings) with ``metadata`` as a ComplexType whose
-    sub-fields include two further ComplexTypes (``coordinates``, ``data_source``).
-    """
+    """Mock of the canonical Azure AI Search schema used by this connector (mirrors the
+    integration-test fixture, with nested ``metadata.coordinates`` and ``metadata.data_source``)."""
     return make_nested_index(
         [
             {"name": "id", "key": True},
@@ -125,11 +114,6 @@ def make_uploader(**kwargs) -> AzureAISearchUploader:
     )
 
 
-# ---------------------------------------------------------------------------
-# get_index_field_names
-# ---------------------------------------------------------------------------
-
-
 def test_get_index_field_names_returns_set_of_names():
     uploader = make_uploader()
     index = make_index([("id", True, False), ("text", False, False), ("record_id", False, True)])
@@ -140,11 +124,6 @@ def test_get_index_field_names_empty_index():
     uploader = make_uploader()
     index = make_index([])
     assert uploader.get_index_field_names(index) == set()
-
-
-# ---------------------------------------------------------------------------
-# can_delete
-# ---------------------------------------------------------------------------
 
 
 def test_can_delete_true_when_record_id_field_is_filterable():
@@ -165,11 +144,6 @@ def test_can_delete_false_when_record_id_field_missing():
     assert uploader.can_delete(index) is False
 
 
-# ---------------------------------------------------------------------------
-# get_index_key
-# ---------------------------------------------------------------------------
-
-
 def test_get_index_key_returns_key_field_name():
     uploader = make_uploader()
     index = make_index([("id", True, False), ("text", False, False)])
@@ -181,11 +155,6 @@ def test_get_index_key_raises_when_no_key_field():
     index = make_index([("text", False, False)])
     with pytest.raises(IngestValueError):
         uploader.get_index_key(index)
-
-
-# ---------------------------------------------------------------------------
-# filter_doc
-# ---------------------------------------------------------------------------
 
 
 def test_filter_doc_removes_unknown_fields():
@@ -206,11 +175,6 @@ def test_filter_doc_keeps_all_fields_when_all_known():
 def test_filter_doc_empty_doc():
     uploader = make_uploader()
     assert uploader.filter_doc({}, {"id", "text"}) == {}
-
-
-# ---------------------------------------------------------------------------
-# run_data: dropped fields are logged
-# ---------------------------------------------------------------------------
 
 
 def test_run_data_logs_dropped_fields(caplog):
@@ -257,11 +221,6 @@ def test_run_data_no_log_when_no_dropped_fields(caplog):
     assert not any("will be dropped" in record.message for record in caplog.records)
 
 
-# ---------------------------------------------------------------------------
-# get_index_field_tree
-# ---------------------------------------------------------------------------
-
-
 def test_get_index_field_tree_top_level_only_marks_all_leaves():
     uploader = make_uploader()
     index = make_nested_index(
@@ -301,9 +260,8 @@ def test_get_index_field_tree_canonical_schema_mirrors_nesting():
 
 
 def test_get_index_field_tree_collection_of_complex_treated_as_complex():
-    """Collection(ComplexType) fields populate ``.fields`` just like ComplexType,
-    so the tree builder treats them identically (the recursive filter then
-    walks per-item)."""
+    """Collection(ComplexType) populates ``.fields`` like ComplexType;
+    the tree builder treats both identically."""
     uploader = make_uploader()
     index = make_nested_index(
         [
@@ -326,10 +284,8 @@ def test_get_index_field_tree_empty_index():
 
 
 def test_get_index_field_tree_caps_at_max_depth(monkeypatch):
-    """Defensive cap: don't recurse past Azure's 10-level limit. With the cap
-    monkeypatched to 3, four nested complex levels collapse such that the
-    deepest declared sub-tree is clipped to ``{}`` and anything beyond is
-    treated as unknown by the filter."""
+    """Defensive cap: depth ``>= _MAX_INDEX_FIELD_DEPTH`` clips the sub-tree to ``{}``,
+    so anything beyond is treated as unknown by the filter."""
     monkeypatch.setattr(aas_module, "_MAX_INDEX_FIELD_DEPTH", 3)
     uploader = make_uploader()
     index = make_nested_index(
@@ -354,11 +310,6 @@ def test_get_index_field_tree_caps_at_max_depth(monkeypatch):
     assert tree == {"lvl0": {"lvl1": {"lvl2": {}}}}
 
 
-# ---------------------------------------------------------------------------
-# filter_doc_against_tree
-# ---------------------------------------------------------------------------
-
-
 def test_filter_doc_against_tree_no_op_when_doc_matches_schema():
     uploader = make_uploader()
     tree = {"id": None, "text": None, "metadata": {"filename": None, "page_number": None}}
@@ -374,11 +325,8 @@ def test_filter_doc_against_tree_drops_unknown_top_level_key():
 
 
 def test_filter_doc_against_tree_drops_unknown_nested_key_regression_table_extraction_method():
-    """Regression: the bug reported on 2026-05-01. New ``unstructured`` field
-    ``metadata.table_extraction_method`` was being shipped to Azure AI Search
-    even though the index schema doesn't declare it, causing 400 rejections.
-    The recursive filter must drop it before upload.
-    """
+    """Regression (2026-05-01): new ``unstructured`` field ``metadata.table_extraction_method``
+    causes Azure AI Search 400s; the recursive filter must drop it before upload."""
     uploader = make_uploader()
     tree = uploader.get_index_field_tree(canonical_schema_index())
     doc = {
@@ -416,10 +364,8 @@ def test_filter_doc_against_tree_drops_unknown_deeply_nested_key():
 
 
 def test_filter_doc_against_tree_preserves_string_leaves_modeled_as_edm_string():
-    """Sub-trees the stager has json.dumps'd into a string (e.g. record_locator,
-    points) are modeled as Edm.String in the schema, so ``tree[key] is None``.
-    The recursion should pass them through unchanged regardless of value shape.
-    """
+    """Stager-stringified sub-trees (e.g. ``record_locator``, ``points``) are modeled as Edm.String
+    leaves (``tree[key] is None``) and must pass through unchanged."""
     uploader = make_uploader()
     tree = uploader.get_index_field_tree(canonical_schema_index())
     doc = {
@@ -502,19 +448,13 @@ def test_filter_doc_against_tree_empty_doc():
 
 
 def test_filter_doc_against_tree_handles_metadata_modeled_as_edm_string():
-    """Customer schemas that model ``metadata`` as a flat Edm.String column
-    (i.e. JSON blob) end up with ``tree["metadata"] is None``. The recursion
-    must pass the metadata value through verbatim regardless of shape."""
+    """Customer schemas that model ``metadata`` as Edm.String (JSON blob) yield
+    ``tree["metadata"] is None``; the value must pass through verbatim regardless of shape."""
     uploader = make_uploader()
     tree = {"id": None, "metadata": None}
     doc = {"id": "1", "metadata": {"any": "shape", "nested": {"a": 1}}}
     filtered = uploader.filter_doc_against_tree(doc, tree)
     assert filtered == doc
-
-
-# ---------------------------------------------------------------------------
-# collect_dropped_paths
-# ---------------------------------------------------------------------------
 
 
 def test_collect_dropped_paths_empty_when_no_drops():
@@ -551,8 +491,7 @@ def test_collect_dropped_paths_mixes_top_level_and_nested():
 
 
 def test_collect_dropped_paths_dedup_and_sort_across_collection_items():
-    """When the same unknown sub-key appears in multiple list items the path is
-    reported only once, sorted with all other paths."""
+    """Repeated unknown sub-keys across list items are reported once, sorted with the rest."""
     uploader = make_uploader()
     index = make_nested_index(
         [
@@ -574,17 +513,9 @@ def test_collect_dropped_paths_dedup_and_sort_across_collection_items():
     assert uploader.collect_dropped_paths(doc, tree) == ["key_value_pairs.junk"]
 
 
-# ---------------------------------------------------------------------------
-# run_data: end-to-end with a realistic schema
-# ---------------------------------------------------------------------------
-
-
 def test_run_data_strips_nested_unknown_field_before_upload(caplog):
-    """End-to-end: the canonical-schema customer hits ``unstructured``'s new
-    ``metadata.table_extraction_method`` field. ``run_data`` must:
-    - log the dotted path that will be dropped, and
-    - hand ``write_dict`` a doc with that nested key removed.
-    """
+    """End-to-end: ``run_data`` must log the dropped dotted path and hand ``write_dict``
+    a doc with ``metadata.table_extraction_method`` removed."""
     uploader = make_uploader()
     uploader.get_index = MagicMock(return_value=canonical_schema_index())
     uploader.can_delete = MagicMock(return_value=False)
@@ -663,15 +594,9 @@ def test_run_data_no_log_and_passthrough_when_doc_matches_canonical_schema(caplo
     assert list(sent_chunk) == [doc]
 
 
-# ---------------------------------------------------------------------------
-# Backwards compatibility: legacy methods still behave exactly as they did.
-# ---------------------------------------------------------------------------
-
-
 def test_legacy_filter_doc_still_returns_top_level_only_filter():
-    """``filter_doc`` is the old depth-0 filter. It is no longer called from
-    ``run_data`` but must remain available with its original semantics so any
-    existing subclass override or external caller keeps working."""
+    """The legacy depth-0 ``filter_doc`` is no longer called by ``run_data`` but must keep
+    its original semantics for any subclass override or external caller."""
     uploader = make_uploader()
     doc = {"id": "1", "metadata": {"foo": "bar", "table_extraction_method": "tatr"}, "junk": "x"}
     result = uploader.filter_doc(doc, {"id", "metadata"})

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.5.0"  # pragma: no cover
+__version__ = "1.5.1"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/azure_ai_search.py
+++ b/unstructured_ingest/processes/connectors/azure_ai_search.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 CONNECTOR_TYPE = "azure_ai_search"
 
-# Azure caps complex-type nesting at 10 levels (https://learn.microsoft.com/en-us/azure/search/search-limits-quotas-capacity).
+# Azure caps complex-type nesting at 10 levels
 _MAX_INDEX_FIELD_DEPTH = 10
 
 # Recursive map of the index schema: leaf scalars / primitive collections are ``None``;

--- a/unstructured_ingest/processes/connectors/azure_ai_search.py
+++ b/unstructured_ingest/processes/connectors/azure_ai_search.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Any, Generator, TypeAlias
 
 from pydantic import Field, Secret
 
@@ -27,13 +27,16 @@ from unstructured_ingest.utils.dep_check import requires_dependencies
 if TYPE_CHECKING:
     from azure.search.documents import SearchClient
     from azure.search.documents.indexes import SearchIndexClient
+    from azure.search.documents.indexes.models import SearchField, SearchIndex
 
 CONNECTOR_TYPE = "azure_ai_search"
 
-# Azure AI Search caps complex-type nesting at 10 levels; recursing past that is
-# pointless because the destination index could not have declared a deeper schema.
-# https://learn.microsoft.com/en-us/azure/search/search-limits-quotas-capacity
+# Azure caps complex-type nesting at 10 levels (https://learn.microsoft.com/en-us/azure/search/search-limits-quotas-capacity).
 _MAX_INDEX_FIELD_DEPTH = 10
+
+# Recursive map of the index schema: leaf scalars / primitive collections are ``None``;
+# complex / collection-of-complex sub-trees are nested ``FieldTree`` dicts.
+FieldTree: TypeAlias = "dict[str, FieldTree | None]"
 
 
 class AzureAISearchAccessConfig(AccessConfig):
@@ -247,23 +250,16 @@ class AzureAISearchUploader(Uploader):
     def filter_doc(self, doc: dict, index_field_names: set[str]) -> dict:
         return {k: v for k, v in doc.items() if k in index_field_names}
 
-    def get_index_field_tree(self, index) -> dict[str, Any]:
-        """Walk `index.fields` recursively and return a nested name->sub-tree map.
-
-        Each entry maps a field name to either:
-        - ``None`` for primitive / primitive-collection fields (leaves), or
-        - ``dict[str, ...]`` for ComplexType / Collection(ComplexType) fields.
-
-        The returned tree mirrors the destination index schema at every nesting
-        level it declares, so the same set-difference filter that already runs
-        at the top level can run at every level of the schema.
-        """
+    def get_index_field_tree(self, index: "SearchIndex") -> FieldTree:
+        """Build a nested tree mirroring the destination index schema."""
         return self._build_field_tree(index.fields, depth=0)
 
-    def _build_field_tree(self, fields, depth: int) -> dict[str, Any]:
+    def _build_field_tree(
+        self, fields: "list[SearchField] | None", depth: int
+    ) -> FieldTree:
         if depth >= _MAX_INDEX_FIELD_DEPTH:
             return {}
-        tree: dict[str, Any] = {}
+        tree: FieldTree = {}
         for f in fields or []:
             sub_fields = getattr(f, "fields", None)
             if sub_fields:
@@ -272,25 +268,18 @@ class AzureAISearchUploader(Uploader):
                 tree[f.name] = None
         return tree
 
-    def filter_doc_against_tree(self, doc: dict, tree: dict[str, Any]) -> dict:
-        """Recursively drop fields from ``doc`` that aren't declared in ``tree``.
-
-        - At each dict level, drop keys whose name isn't in the corresponding tree level.
-        - When a known key has a sub-tree (complex type), recurse into the value.
-        - When a known key holds a list of dicts and the schema is a complex collection,
-          recurse into each element.
-        - Leaves (sub-tree is ``None``) pass through unchanged. A leaf value that
-          happens to be a dict (e.g. a stager-stringified blob mapped to ``Edm.String``)
-          is preserved as-is; the SDK will surface any genuine type mismatch.
-        """
-        if not isinstance(doc, dict):
-            return doc
+    def filter_doc_against_tree(
+        self, doc: dict[str, Any], tree: FieldTree
+    ) -> dict[str, Any]:
+        """Drop any field in ``doc`` not declared in ``tree``, recursing into complex types."""
         out: dict[str, Any] = {}
         for key, value in doc.items():
             if key not in tree:
                 continue
             sub_tree = tree[key]
             if sub_tree is None:
+                # Leaf: pass value through; a dict mapped to Edm.String stays as-is and
+                # the SDK surfaces any genuine type mismatch.
                 out[key] = value
             elif isinstance(value, dict):
                 out[key] = self.filter_doc_against_tree(value, sub_tree)
@@ -306,16 +295,10 @@ class AzureAISearchUploader(Uploader):
         return out
 
     def collect_dropped_paths(
-        self, doc: dict, tree: dict[str, Any], prefix: str = ""
+        self, doc: dict[str, Any], tree: FieldTree, prefix: str = ""
     ) -> list[str]:
-        """Return a sorted list of dotted-path keys in ``doc`` that aren't in ``tree``.
-
-        Used to build the same ``"Following fields will be dropped..."`` INFO log
-        the connector has always emitted, just with full dotted paths so nested
-        drops are visible (e.g. ``metadata.table_extraction_method``).
-        """
-        if not isinstance(doc, dict):
-            return []
+        """Return sorted dotted paths in ``doc`` not declared in ``tree``
+        (e.g. ``metadata.table_extraction_method``)."""
         dropped: list[str] = []
         for key, value in doc.items():
             path = f"{prefix}.{key}" if prefix else key

--- a/unstructured_ingest/processes/connectors/azure_ai_search.py
+++ b/unstructured_ingest/processes/connectors/azure_ai_search.py
@@ -30,6 +30,11 @@ if TYPE_CHECKING:
 
 CONNECTOR_TYPE = "azure_ai_search"
 
+# Azure AI Search caps complex-type nesting at 10 levels; recursing past that is
+# pointless because the destination index could not have declared a deeper schema.
+# https://learn.microsoft.com/en-us/azure/search/search-limits-quotas-capacity
+_MAX_INDEX_FIELD_DEPTH = 10
+
 
 class AzureAISearchAccessConfig(AccessConfig):
     azure_ai_search_key: str = Field(
@@ -242,6 +247,92 @@ class AzureAISearchUploader(Uploader):
     def filter_doc(self, doc: dict, index_field_names: set[str]) -> dict:
         return {k: v for k, v in doc.items() if k in index_field_names}
 
+    def get_index_field_tree(self, index) -> dict[str, Any]:
+        """Walk `index.fields` recursively and return a nested name->sub-tree map.
+
+        Each entry maps a field name to either:
+        - ``None`` for primitive / primitive-collection fields (leaves), or
+        - ``dict[str, ...]`` for ComplexType / Collection(ComplexType) fields.
+
+        The returned tree mirrors the destination index schema at every nesting
+        level it declares, so the same set-difference filter that already runs
+        at the top level can run at every level of the schema.
+        """
+        return self._build_field_tree(index.fields, depth=0)
+
+    def _build_field_tree(self, fields, depth: int) -> dict[str, Any]:
+        if depth >= _MAX_INDEX_FIELD_DEPTH:
+            return {}
+        tree: dict[str, Any] = {}
+        for f in fields or []:
+            sub_fields = getattr(f, "fields", None)
+            if sub_fields:
+                tree[f.name] = self._build_field_tree(sub_fields, depth + 1)
+            else:
+                tree[f.name] = None
+        return tree
+
+    def filter_doc_against_tree(self, doc: dict, tree: dict[str, Any]) -> dict:
+        """Recursively drop fields from ``doc`` that aren't declared in ``tree``.
+
+        - At each dict level, drop keys whose name isn't in the corresponding tree level.
+        - When a known key has a sub-tree (complex type), recurse into the value.
+        - When a known key holds a list of dicts and the schema is a complex collection,
+          recurse into each element.
+        - Leaves (sub-tree is ``None``) pass through unchanged. A leaf value that
+          happens to be a dict (e.g. a stager-stringified blob mapped to ``Edm.String``)
+          is preserved as-is; the SDK will surface any genuine type mismatch.
+        """
+        if not isinstance(doc, dict):
+            return doc
+        out: dict[str, Any] = {}
+        for key, value in doc.items():
+            if key not in tree:
+                continue
+            sub_tree = tree[key]
+            if sub_tree is None:
+                out[key] = value
+            elif isinstance(value, dict):
+                out[key] = self.filter_doc_against_tree(value, sub_tree)
+            elif isinstance(value, list):
+                out[key] = [
+                    self.filter_doc_against_tree(item, sub_tree)
+                    if isinstance(item, dict)
+                    else item
+                    for item in value
+                ]
+            else:
+                out[key] = value
+        return out
+
+    def collect_dropped_paths(
+        self, doc: dict, tree: dict[str, Any], prefix: str = ""
+    ) -> list[str]:
+        """Return a sorted list of dotted-path keys in ``doc`` that aren't in ``tree``.
+
+        Used to build the same ``"Following fields will be dropped..."`` INFO log
+        the connector has always emitted, just with full dotted paths so nested
+        drops are visible (e.g. ``metadata.table_extraction_method``).
+        """
+        if not isinstance(doc, dict):
+            return []
+        dropped: list[str] = []
+        for key, value in doc.items():
+            path = f"{prefix}.{key}" if prefix else key
+            if key not in tree:
+                dropped.append(path)
+                continue
+            sub_tree = tree[key]
+            if sub_tree is None:
+                continue
+            if isinstance(value, dict):
+                dropped.extend(self.collect_dropped_paths(value, sub_tree, path))
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        dropped.extend(self.collect_dropped_paths(item, sub_tree, path))
+        return sorted(set(dropped))
+
     def precheck(self) -> None:
         try:
             with self.connection_config.get_search_client() as search_client:
@@ -264,14 +355,16 @@ class AzureAISearchUploader(Uploader):
         else:
             logger.warning("criteria for deleting previous content not met, skipping")
 
-        index_field_names = self.get_index_field_names(index)
-        if dropped := (set(data[0].keys()) - index_field_names) if data else set():
-            logger.info(
-                "Following fields will be dropped to match the index schema: "
-                f"{', '.join(sorted(dropped))}"
-            )
+        field_tree = self.get_index_field_tree(index)
+        if data:
+            dropped_paths = self.collect_dropped_paths(data[0], field_tree)
+            if dropped_paths:
+                logger.info(
+                    "Following fields will be dropped to match the index schema: "
+                    f"{', '.join(dropped_paths)}"
+                )
         filtered_data = [
-            self.filter_doc(doc=doc, index_field_names=index_field_names) for doc in data
+            self.filter_doc_against_tree(doc=doc, tree=field_tree) for doc in data
         ]
 
         batch_size = self.upload_config.batch_size


### PR DESCRIPTION
## Summary
Azure AI Search uploads were failing with `400: The property 'table_extraction_method' does not exist on type 'search.complex.metadata'` after `unstructured` added `metadata.table_extraction_method` (PR Unstructured-IO/unstructured#4346). The destination Edm.ComplexType validates strictly, so any field not declared in the index schema is rejected.

The connector already had a "drop unknown fields" filter, but it only inspected top-level keys (`set(doc) - set(index.fields)`), so anything new under `metadata.*` (or any other complex type) sailed past it and 400'd at the service.

## Fix
Replace the depth-0 filter with a schema-driven recursive one:

- `get_index_field_tree` walks `index.fields` recursively into a `FieldTree = dict[str, FieldTree | None]` (leaves → `None`, complex / collection-of-complex → nested dict).
- `filter_doc_against_tree` walks the document against that tree and drops any key not declared at the matching level, recursing into both `dict` values and `list[dict]` (collection-of-complex) values.
- `collect_dropped_paths` produces sorted dotted paths (e.g. `metadata.table_extraction_method`) for the existing `"Following fields will be dropped..."` INFO log so nested drops are now visible.
- Defensive cap at `_MAX_INDEX_FIELD_DEPTH = 10`, matching Azure's [documented complex-type nesting limit](https://learn.microsoft.com/en-us/azure/search/search-limits-quotas-capacity).

The legacy `filter_doc` and `get_index_field_names` are kept (with their original semantics) so any subclass override or external caller keeps working.

## Backward compatibility
- Customers whose docs already matched the schema: no behavior change (filter is a no-op when nothing is unknown).
- Customers who were silently shipping unknown nested keys: those keys are now stripped pre-upload instead of returning 400 — strictly an improvement and consistent with how the connector has always treated unknown top-level keys.
- Customers with `metadata` modeled as `Edm.String` (JSON blob): the value passes through verbatim regardless of shape (covered by a dedicated test).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Azure AI Search upload behavior by recursively filtering documents against the index schema; mistakes in schema-walking or depth limits could drop fields unexpectedly or mask type issues, but scope is isolated to this connector and covered by new unit/integration tests.
> 
> **Overview**
> Fixes Azure AI Search uploads failing with HTTP 400s when *nested* fields not declared in the index schema (e.g. `metadata.table_extraction_method`) are present.
> 
> `AzureAISearchUploader.run_data` now builds a recursive `FieldTree` from `index.fields`, prunes unknown keys at any depth (including collections of complex types), and logs dropped *dotted paths* via `collect_dropped_paths` (with a defensive max-depth cap). Extensive new unit tests plus an integration regression test cover nested-field dropping and logging; version is bumped to `1.5.1` and noted in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92222742bf4cc6bda73b60e62befe53240004b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->