### PR TITLE
fix: azure ai search write error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.1]
+
+### Fixes
+
+- **fix(azure-ai-search): drop unknown nested fields before upload** The uploader's field filter only checked top-level keys, so sub-fields of complex types (e.g. `metadata.table_extraction_method`) reached Azure and triggered `400 The property '...' does not exist on type 'search.complex.metadata' or is not present in the API version '2025-09-01'`. Replaced the flat field-name set with a nested schema dict and made `filter_doc` recurse into complex types and collections of complex objects so unknown sub-fields are stripped before upload.
+
 ## [1.5.0]
 
 ### Enhancements

--- a/test/integration/connectors/test_azure_ai_search.py
+++ b/test/integration/connectors/test_azure_ai_search.py
@@ -30,6 +30,7 @@ from test.integration.connectors.utils.validation.destination import (
 )
 from test.integration.utils import requires_env
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
+from unstructured_ingest.error import WriteError
 from unstructured_ingest.processes.connectors.azure_ai_search import (
     CONNECTOR_TYPE,
     RECORD_ID_LABEL,
@@ -235,6 +236,105 @@ async def test_azure_ai_search_destination(
     uploader.run(path=staged_filepath, file_data=file_data)
     with uploader.connection_config.get_search_client() as search_client:
         validate_count(search_client=search_client, expected_count=expected_count)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+@requires_env("AZURE_SEARCH_API_KEY")
+async def test_azure_ai_search_destination_drops_unknown_nested_fields(
+    upload_file: Path,
+    index: str,
+    tmp_path: Path,
+):
+    """Regression test for error:
+    "The property 'table_extraction_method' does not exist on type
+    'search.complex.metadata' or is not present in the API version '2025-09-01'."
+
+    The uploader must drop nested fields not declared in the index's complex schema
+    (and stray top-level fields) before calling Azure, so the upload still succeeds.
+    """
+    file_data = FileData(
+        source_identifiers=SourceIdentifiers(fullpath=upload_file.name, filename=upload_file.name),
+        connector_type=CONNECTOR_TYPE,
+        identifier="mock file data nested filter",
+    )
+    stager = AzureAISearchUploadStager(upload_stager_config=AzureAISearchUploadStagerConfig())
+
+    uploader = AzureAISearchUploader(
+        connection_config=AzureAISearchConnectionConfig(
+            access_config=AzureAISearchAccessConfig(key=get_api_key()),
+            endpoint=ENDPOINT,
+            index=index,
+        ),
+        upload_config=AzureAISearchUploaderConfig(),
+    )
+    staged_filepath = stager.run(
+        elements_filepath=upload_file,
+        file_data=file_data,
+        output_dir=tmp_path,
+        output_filename=upload_file.name,
+    )
+
+    with staged_filepath.open() as f:
+        staged_elements = json.load(f)
+    assert staged_elements, "expected staged elements for the regression test"
+    for element in staged_elements:
+        element.setdefault("metadata", {})["table_extraction_method"] = "auto"
+        element["unsupported_top_level_field"] = "drop me"
+
+    uploader.precheck()
+    uploader.run_data(data=staged_elements, file_data=file_data)
+
+    expected_count = len(staged_elements)
+    with uploader.connection_config.get_search_client() as search_client:
+        validate_count(search_client=search_client, expected_count=expected_count)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+@requires_env("AZURE_SEARCH_API_KEY")
+async def test_azure_ai_search_destination_rejects_unknown_nested_fields_when_unfiltered(
+    index: str,
+):
+    """Azure-side contract test: confirms the upstream cause of the production 400.
+
+    Bypasses ``filter_doc`` by calling ``write_dict`` directly with a document that
+    declares ``metadata.table_extraction_method`` — a field not present in the index's
+    complex metadata schema. Azure must reject the upload, and the uploader must
+    surface that as ``WriteError`` mentioning the offending property and complex type.
+
+    If this test starts passing without raising, Azure has loosened its strict-typing
+    rules and the recursive filter may no longer be necessary.
+    """
+    uploader = AzureAISearchUploader(
+        connection_config=AzureAISearchConnectionConfig(
+            access_config=AzureAISearchAccessConfig(key=get_api_key()),
+            endpoint=ENDPOINT,
+            index=index,
+        ),
+        upload_config=AzureAISearchUploaderConfig(),
+    )
+
+    bad_doc = {
+        "id": "expect-rejection-1",
+        RECORD_ID_LABEL: "regression-azure-strict-typing",
+        "text": "should never be indexed",
+        "metadata": {
+            "filename": "doc.pdf",
+            "filetype": "pdf",
+            "table_extraction_method": "auto",
+        },
+    }
+
+    with (
+        uploader.connection_config.get_search_client() as search_client,
+        pytest.raises(WriteError) as excinfo,
+    ):
+        uploader.write_dict(elements_dict=[bad_doc], search_client=search_client)
+
+    error_message = str(excinfo.value)
+    assert "table_extraction_method" in error_message
+    assert "search.complex.metadata" in error_message
 
 
 @pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)

--- a/test/integration/connectors/test_azure_ai_search.py
+++ b/test/integration/connectors/test_azure_ai_search.py
@@ -30,7 +30,7 @@ from test.integration.connectors.utils.validation.destination import (
 )
 from test.integration.utils import requires_env
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
-from unstructured_ingest.error import WriteError
+from unstructured_ingest.error import DestinationConnectionError
 from unstructured_ingest.processes.connectors.azure_ai_search import (
     CONNECTOR_TYPE,
     RECORD_ID_LABEL,
@@ -301,7 +301,7 @@ async def test_azure_ai_search_destination_rejects_unknown_nested_fields_when_un
     Bypasses ``filter_doc`` by calling ``write_dict`` directly with a document that
     declares ``metadata.table_extraction_method`` — a field not present in the index's
     complex metadata schema. Azure must reject the upload, and the uploader must
-    surface that as ``WriteError`` mentioning the offending property and complex type.
+    surface that error mentioning the offending property and complex type.
 
     If this test starts passing without raising, Azure has loosened its strict-typing
     rules and the recursive filter may no longer be necessary.
@@ -328,7 +328,7 @@ async def test_azure_ai_search_destination_rejects_unknown_nested_fields_when_un
 
     with (
         uploader.connection_config.get_search_client() as search_client,
-        pytest.raises(WriteError) as excinfo,
+        pytest.raises(DestinationConnectionError) as excinfo,
     ):
         uploader.write_dict(elements_dict=[bad_doc], search_client=search_client)
 

--- a/test/unit/processes/connectors/test_azure_ai_search.py
+++ b/test/unit/processes/connectors/test_azure_ai_search.py
@@ -2,6 +2,12 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
+from azure.search.documents.indexes.models import (
+    ComplexField,
+    SearchFieldDataType,
+    SearchIndex,
+    SimpleField,
+)
 
 from unstructured_ingest.error import ValueError as IngestValueError
 from unstructured_ingest.processes.connectors.azure_ai_search import (
@@ -10,15 +16,22 @@ from unstructured_ingest.processes.connectors.azure_ai_search import (
 )
 
 
+def make_field(name: str, key: bool = False, filterable: bool = False, sub_fields=None):
+    """Build a mock SearchField. ``sub_fields`` mirrors Azure's ComplexField semantics:
+    None for simple fields, a list (possibly empty) for complex/composite fields."""
+    f = MagicMock()
+    f.name = name
+    f.key = key
+    f.filterable = filterable
+    f.fields = sub_fields
+    return f
+
+
 def make_index(field_specs: list[tuple[str, bool, bool]]):
     """Build a mock index with fields defined by (name, key, filterable) tuples."""
-    fields = []
-    for name, key, filterable in field_specs:
-        f = MagicMock()
-        f.name = name
-        f.key = key
-        f.filterable = filterable
-        fields.append(f)
+    fields = [
+        make_field(name, key=key, filterable=filterable) for name, key, filterable in field_specs
+    ]
     index = MagicMock()
     index.fields = fields
     return index
@@ -34,20 +47,58 @@ def make_uploader(**kwargs) -> AzureAISearchUploader:
 
 
 # ---------------------------------------------------------------------------
-# get_index_field_names
+# get_index_schema
 # ---------------------------------------------------------------------------
 
 
-def test_get_index_field_names_returns_set_of_names():
+def test_get_index_schema_returns_flat_dict_for_simple_fields():
     uploader = make_uploader()
     index = make_index([("id", True, False), ("text", False, False), ("record_id", False, True)])
-    assert uploader.get_index_field_names(index) == {"id", "text", "record_id"}
+    assert uploader.get_index_schema(index) == {"id": None, "text": None, "record_id": None}
 
 
-def test_get_index_field_names_empty_index():
+def test_get_index_schema_empty_index():
     uploader = make_uploader()
     index = make_index([])
-    assert uploader.get_index_field_names(index) == set()
+    assert uploader.get_index_schema(index) == {}
+
+
+def test_get_index_schema_walks_into_complex_field_subfields():
+    uploader = make_uploader()
+    metadata_subfields = [make_field("filename"), make_field("filetype")]
+    index = MagicMock()
+    index.fields = [
+        make_field("id", key=True),
+        make_field("metadata", sub_fields=metadata_subfields),
+    ]
+    assert uploader.get_index_schema(index) == {
+        "id": None,
+        "metadata": {"filename": None, "filetype": None},
+    }
+
+
+def test_get_index_schema_handles_nested_complex_fields():
+    uploader = make_uploader()
+    data_source = make_field("data_source", sub_fields=[make_field("url"), make_field("version")])
+    metadata = make_field("metadata", sub_fields=[make_field("filename"), data_source])
+    index = MagicMock()
+    index.fields = [make_field("id", key=True), metadata]
+    assert uploader.get_index_schema(index) == {
+        "id": None,
+        "metadata": {
+            "filename": None,
+            "data_source": {"url": None, "version": None},
+        },
+    }
+
+
+def test_get_index_schema_empty_complex_field_yields_empty_dict():
+    """An empty ComplexField means no sub-fields are allowed — different from a simple field."""
+    uploader = make_uploader()
+    empty_complex = make_field("empty", sub_fields=[])
+    index = MagicMock()
+    index.fields = [empty_complex]
+    assert uploader.get_index_schema(index) == {"empty": {}}
 
 
 # ---------------------------------------------------------------------------
@@ -96,10 +147,10 @@ def test_get_index_key_raises_when_no_key_field():
 # ---------------------------------------------------------------------------
 
 
-def test_filter_doc_removes_unknown_fields():
+def test_filter_doc_removes_unknown_top_level_fields():
     uploader = make_uploader()
     doc = {"id": "1", "text": "hello", "unknown_field": "drop me"}
-    result = uploader.filter_doc(doc, {"id", "text"})
+    result = uploader.filter_doc(doc, {"id": None, "text": None})
     assert result == {"id": "1", "text": "hello"}
     assert "unknown_field" not in result
 
@@ -107,13 +158,95 @@ def test_filter_doc_removes_unknown_fields():
 def test_filter_doc_keeps_all_fields_when_all_known():
     uploader = make_uploader()
     doc = {"id": "1", "text": "hello"}
-    result = uploader.filter_doc(doc, {"id", "text", "extra"})
+    result = uploader.filter_doc(doc, {"id": None, "text": None, "extra": None})
     assert result == {"id": "1", "text": "hello"}
 
 
 def test_filter_doc_empty_doc():
     uploader = make_uploader()
-    assert uploader.filter_doc({}, {"id", "text"}) == {}
+    assert uploader.filter_doc({}, {"id": None, "text": None}) == {}
+
+
+def test_filter_doc_drops_unknown_field_inside_complex_metadata():
+    """Reproduces the Azure 400 'table_extraction_method does not exist on type
+    search.complex.metadata' bug: nested fields not present in the complex sub-schema
+    must be dropped before upload."""
+    uploader = make_uploader()
+    schema = {
+        "id": None,
+        "metadata": {"filename": None, "filetype": None},
+    }
+    doc = {
+        "id": "1",
+        "metadata": {
+            "filename": "doc.pdf",
+            "filetype": "pdf",
+            "table_extraction_method": "auto",
+        },
+    }
+    result = uploader.filter_doc(doc, schema)
+    assert result == {
+        "id": "1",
+        "metadata": {"filename": "doc.pdf", "filetype": "pdf"},
+    }
+
+
+def test_filter_doc_recurses_into_doubly_nested_complex_fields():
+    uploader = make_uploader()
+    schema = {
+        "metadata": {
+            "filename": None,
+            "data_source": {"url": None, "version": None},
+        },
+    }
+    doc = {
+        "metadata": {
+            "filename": "doc.pdf",
+            "extra_meta": "drop",
+            "data_source": {
+                "url": "x",
+                "version": "1",
+                "secret_field": "drop",
+            },
+        },
+    }
+    result = uploader.filter_doc(doc, schema)
+    assert result == {
+        "metadata": {
+            "filename": "doc.pdf",
+            "data_source": {"url": "x", "version": "1"},
+        },
+    }
+
+
+def test_filter_doc_filters_within_collection_of_complex_objects():
+    uploader = make_uploader()
+    schema = {"items": {"name": None}}
+    doc = {"items": [{"name": "a", "drop": "x"}, {"name": "b"}]}
+    result = uploader.filter_doc(doc, schema)
+    assert result == {"items": [{"name": "a"}, {"name": "b"}]}
+
+
+def test_filter_doc_passes_through_collection_of_simple_values():
+    uploader = make_uploader()
+    schema = {"tags": None}
+    doc = {"tags": ["a", "b", "c"]}
+    result = uploader.filter_doc(doc, schema)
+    assert result == {"tags": ["a", "b", "c"]}
+
+
+def test_filter_doc_does_not_mutate_input_doc():
+    uploader = make_uploader()
+    schema = {"id": None, "metadata": {"filename": None}}
+    doc = {
+        "id": "1",
+        "metadata": {"filename": "doc.pdf", "table_extraction_method": "auto"},
+    }
+    uploader.filter_doc(doc, schema)
+    assert doc == {
+        "id": "1",
+        "metadata": {"filename": "doc.pdf", "table_extraction_method": "auto"},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -163,3 +296,86 @@ def test_run_data_no_log_when_no_dropped_fields(caplog):
         uploader.run_data(data=data, file_data=file_data)
 
     assert not any("will be dropped" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Integration with the real Azure SDK schema objects (no API calls)
+# ---------------------------------------------------------------------------
+
+
+def _build_realistic_index() -> SearchIndex:
+    """Mirrors the shape of the production index that triggered the
+    'table_extraction_method does not exist on type search.complex.metadata' bug."""
+    data_source = ComplexField(
+        name="data_source",
+        fields=[
+            SimpleField(name="url", type=SearchFieldDataType.String),
+            SimpleField(name="version", type=SearchFieldDataType.String),
+        ],
+    )
+    metadata = ComplexField(
+        name="metadata",
+        fields=[
+            SimpleField(name="filename", type=SearchFieldDataType.String),
+            SimpleField(name="filetype", type=SearchFieldDataType.String),
+            data_source,
+        ],
+    )
+    return SearchIndex(
+        name="test-index",
+        fields=[
+            SimpleField(name="id", type=SearchFieldDataType.String, key=True),
+            SimpleField(name="text", type=SearchFieldDataType.String),
+            metadata,
+        ],
+    )
+
+
+def test_get_index_schema_against_real_azure_sdk_objects():
+    uploader = make_uploader()
+    schema = uploader.get_index_schema(_build_realistic_index())
+    assert schema == {
+        "id": None,
+        "text": None,
+        "metadata": {
+            "filename": None,
+            "filetype": None,
+            "data_source": {"url": None, "version": None},
+        },
+    }
+
+
+def test_filter_doc_drops_table_extraction_method_against_real_sdk_schema():
+    """End-to-end: the exact scenario from the production 400 error — a document with
+    metadata.table_extraction_method against a complex metadata schema that doesn't
+    declare it. Must be dropped before upload."""
+    uploader = make_uploader()
+    schema = uploader.get_index_schema(_build_realistic_index())
+    doc = {
+        "id": "abc",
+        "text": "some content",
+        "metadata": {
+            "filename": "doc.pdf",
+            "filetype": "pdf",
+            "table_extraction_method": "auto",
+            "data_source": {
+                "url": "https://example.com/doc.pdf",
+                "version": "1",
+                "etag": "deadbeef",
+            },
+        },
+        "stray_top_level": "should be dropped too",
+    }
+    filtered = uploader.filter_doc(doc, schema)
+    assert filtered == {
+        "id": "abc",
+        "text": "some content",
+        "metadata": {
+            "filename": "doc.pdf",
+            "filetype": "pdf",
+            "data_source": {
+                "url": "https://example.com/doc.pdf",
+                "version": "1",
+            },
+        },
+    }

--- a/test/unit/processes/connectors/test_azure_ai_search.py
+++ b/test/unit/processes/connectors/test_azure_ai_search.py
@@ -2,12 +2,6 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
-from azure.search.documents.indexes.models import (
-    ComplexField,
-    SearchFieldDataType,
-    SearchIndex,
-    SimpleField,
-)
 
 from unstructured_ingest.error import ValueError as IngestValueError
 from unstructured_ingest.processes.connectors.azure_ai_search import (
@@ -296,86 +290,3 @@ def test_run_data_no_log_when_no_dropped_fields(caplog):
         uploader.run_data(data=data, file_data=file_data)
 
     assert not any("will be dropped" in record.message for record in caplog.records)
-
-
-# ---------------------------------------------------------------------------
-# Integration with the real Azure SDK schema objects (no API calls)
-# ---------------------------------------------------------------------------
-
-
-def _build_realistic_index() -> SearchIndex:
-    """Mirrors the shape of the production index that triggered the
-    'table_extraction_method does not exist on type search.complex.metadata' bug."""
-    data_source = ComplexField(
-        name="data_source",
-        fields=[
-            SimpleField(name="url", type=SearchFieldDataType.String),
-            SimpleField(name="version", type=SearchFieldDataType.String),
-        ],
-    )
-    metadata = ComplexField(
-        name="metadata",
-        fields=[
-            SimpleField(name="filename", type=SearchFieldDataType.String),
-            SimpleField(name="filetype", type=SearchFieldDataType.String),
-            data_source,
-        ],
-    )
-    return SearchIndex(
-        name="test-index",
-        fields=[
-            SimpleField(name="id", type=SearchFieldDataType.String, key=True),
-            SimpleField(name="text", type=SearchFieldDataType.String),
-            metadata,
-        ],
-    )
-
-
-def test_get_index_schema_against_real_azure_sdk_objects():
-    uploader = make_uploader()
-    schema = uploader.get_index_schema(_build_realistic_index())
-    assert schema == {
-        "id": None,
-        "text": None,
-        "metadata": {
-            "filename": None,
-            "filetype": None,
-            "data_source": {"url": None, "version": None},
-        },
-    }
-
-
-def test_filter_doc_drops_table_extraction_method_against_real_sdk_schema():
-    """End-to-end: the exact scenario from the production 400 error — a document with
-    metadata.table_extraction_method against a complex metadata schema that doesn't
-    declare it. Must be dropped before upload."""
-    uploader = make_uploader()
-    schema = uploader.get_index_schema(_build_realistic_index())
-    doc = {
-        "id": "abc",
-        "text": "some content",
-        "metadata": {
-            "filename": "doc.pdf",
-            "filetype": "pdf",
-            "table_extraction_method": "auto",
-            "data_source": {
-                "url": "https://example.com/doc.pdf",
-                "version": "1",
-                "etag": "deadbeef",
-            },
-        },
-        "stray_top_level": "should be dropped too",
-    }
-    filtered = uploader.filter_doc(doc, schema)
-    assert filtered == {
-        "id": "abc",
-        "text": "some content",
-        "metadata": {
-            "filename": "doc.pdf",
-            "filetype": "pdf",
-            "data_source": {
-                "url": "https://example.com/doc.pdf",
-                "version": "1",
-            },
-        },
-    }

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.5.0"  # pragma: no cover
+__version__ = "1.5.1"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/azure_ai_search.py
+++ b/unstructured_ingest/processes/connectors/azure_ai_search.py
@@ -236,11 +236,34 @@ class AzureAISearchUploader(Uploader):
             raise ValueError("no key field found in index fields")
         return key_fields[0].name
 
-    def get_index_field_names(self, index) -> set[str]:
-        return {field.name for field in index.fields}
+    def get_index_schema(self, index) -> dict:
+        """Builds a nested schema dict from an Azure index. Simple fields map to ``None``;
+        complex fields map to a dict of their sub-fields."""
 
-    def filter_doc(self, doc: dict, index_field_names: set[str]) -> dict:
-        return {k: v for k, v in doc.items() if k in index_field_names}
+        def walk(fields):
+            if fields is None:
+                return None
+            return {f.name: walk(getattr(f, "fields", None)) for f in fields}
+
+        return walk(index.fields) or {}
+
+    def filter_doc(self, doc: dict, schema: dict) -> dict:
+        """Recursively drops fields not present in ``schema``. Recurses into dicts and
+        into lists of dicts when the corresponding schema entry is itself a dict."""
+        out: dict = {}
+        for k, v in doc.items():
+            if k not in schema:
+                continue
+            sub = schema[k]
+            if isinstance(sub, dict) and isinstance(v, dict):
+                out[k] = self.filter_doc(v, sub)
+            elif isinstance(sub, dict) and isinstance(v, list):
+                out[k] = [
+                    self.filter_doc(item, sub) if isinstance(item, dict) else item for item in v
+                ]
+            else:
+                out[k] = v
+        return out
 
     def precheck(self) -> None:
         try:
@@ -264,15 +287,13 @@ class AzureAISearchUploader(Uploader):
         else:
             logger.warning("criteria for deleting previous content not met, skipping")
 
-        index_field_names = self.get_index_field_names(index)
-        if dropped := (set(data[0].keys()) - index_field_names) if data else set():
+        schema = self.get_index_schema(index)
+        if dropped := (set(data[0].keys()) - set(schema.keys())) if data else set():
             logger.info(
                 "Following fields will be dropped to match the index schema: "
                 f"{', '.join(sorted(dropped))}"
             )
-        filtered_data = [
-            self.filter_doc(doc=doc, index_field_names=index_field_names) for doc in data
-        ]
+        filtered_data = [self.filter_doc(doc=doc, schema=schema) for doc in data]
 
         batch_size = self.upload_config.batch_size
         with self.connection_config.get_search_client() as search_client:


### PR DESCRIPTION
## Summary
- Azure AI Search rejected uploads with `400 The property 'table_extraction_method' does not exist on type 'search.complex.metadata'` because the uploader's field filter only checked top-level keys — sub-fields of complex types passed through unfiltered.
- Replaced `get_index_field_names()` / flat-set `filter_doc()` with `get_index_schema()` returning a nested dict and a recursive `filter_doc()` that walks complex types and collections of complex objects.
- Top-level drop-logging behavior preserved.

## Test plan
- [ ] Unit: `test_filter_doc_drops_unknown_field_inside_complex_metadata` and 11 other new cases cover nested filtering, deep nesting, collections of complex objects, simple-collection passthrough, input non-mutation, and the schema walker against real Azure SDK `SimpleField`/`ComplexField`/`SearchIndex` objects.
- [ ] Integration (gated by `AZURE_SEARCH_API_KEY`):
  - `test_azure_ai_search_destination_drops_unknown_nested_fields` — stages real elements, injects `metadata.table_extraction_method` plus a stray top-level field, runs the uploader against a real index, asserts upload succeeds and document count matches.
  - `test_azure_ai_search_destination_rejects_unknown_nested_fields_when_unfiltered` — bypasses the filter via `write_dict` and asserts Azure raises `WriteError` mentioning both `table_extraction_method` and `search.complex.metadata`. Pins the upstream Azure contract: if this stops failing, the filter is no longer load-bearing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Azure AI Search upload filtering to recurse into complex/nested fields and lists, which could drop data if schema inference is wrong, but is narrowly scoped to pre-upload shaping and covered by new unit/integration tests.
> 
> **Overview**
> Fixes Azure AI Search uploads failing on strict complex-type validation by replacing the flat top-level field allowlist with a **nested index schema** (`get_index_schema`) and a **recursive** `filter_doc` that strips unknown sub-fields inside complex objects and collections.
> 
> Adds unit coverage for schema-walking and nested/list filtering behavior, plus integration regression/contract tests that (1) verify uploads succeed after injecting unsupported nested/top-level fields and (2) confirm Azure rejects the same doc when bypassing filtering. Bumps version to `1.5.1` and records the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ce02ce98978b6514d042dd9169cc42d9bd3e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->