### PR TITLE
feat(embed): add default_headers support to OpenAIEmbeddingConfig

### DIFF
--- a/unstructured_ingest/embed/openai.py
+++ b/unstructured_ingest/embed/openai.py
@@ -30,6 +30,10 @@ class OpenAIEmbeddingConfig(EmbeddingConfig):
         default="text-embedding-ada-002", alias="model_name", description="OpenAI model name"
     )
     base_url: Optional[str] = Field(default=None, description="optional override for the base url")
+    default_headers: Optional[dict[str, SecretStr]] = Field(
+        default=None,
+        description="extra HTTP headers attached to every request",
+    )
 
     @requires_dependencies(["openai"], extras="openai")
     def wrap_error(self, e: Exception) -> Exception:
@@ -90,18 +94,32 @@ class OpenAIEmbeddingConfig(EmbeddingConfig):
         from openai import DefaultHttpxClient, OpenAI
 
         client = DefaultHttpxClient(verify=ssl_context_with_optional_ca_override())
-        return OpenAI(
-            api_key=self.api_key.get_secret_value(), http_client=client, base_url=self.base_url
-        )
+        kwargs = {
+            "api_key": self.api_key.get_secret_value(),
+            "http_client": client,
+            "base_url": self.base_url,
+        }
+        if self.default_headers:
+            kwargs["default_headers"] = {
+                k: v.get_secret_value() for k, v in self.default_headers.items()
+            }
+        return OpenAI(**kwargs)
 
     @requires_dependencies(["openai"], extras="openai")
     def get_async_client(self) -> "AsyncOpenAI":
         from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 
         client = DefaultAsyncHttpxClient(verify=ssl_context_with_optional_ca_override())
-        return AsyncOpenAI(
-            api_key=self.api_key.get_secret_value(), http_client=client, base_url=self.base_url
-        )
+        kwargs = {
+            "api_key": self.api_key.get_secret_value(),
+            "http_client": client,
+            "base_url": self.base_url,
+        }
+        if self.default_headers:
+            kwargs["default_headers"] = {
+                k: v.get_secret_value() for k, v in self.default_headers.items()
+            }
+        return AsyncOpenAI(**kwargs)
 
 
 @dataclass


### PR DESCRIPTION
### What changes

`unstructured_ingest/embed/openai.py`

- Adds `default_headers: Optional[dict[str, SecretStr]]` to `OpenAIEmbeddingConfig`
- In `get_client()` and `get_async_client()`: extracts header values via `.get_secret_value()` and passes `default_headers=` to the OpenAI SDK constructor
- Uses explicit dict comprehension (not `model_dump`) to avoid SecretStr serialization to `"**********"`

The OpenAI SDK's `default_headers` constructor param attaches extra headers to every request without interfering with Bearer token construction. This enables custom OpenAI-compatible endpoints that require additional auth headers.

### Test plan

- [ ] Unit test: verify `get_client()` passes extracted headers when `default_headers` is set
- [ ] Unit test: verify `get_client()` omits `default_headers` kwarg when field is `None`
- [ ] Manual: configure an embedder with `default_headers` pointing at a custom endpoint, confirm headers appear on requests