### PR TITLE
feat(microsoft): add delegated oauth_token authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.2]
+
+### Enhancements
+
+- **feat(microsoft): add delegated `oauth_token` to SharePoint, OneDrive, and Outlook AccessConfigs.** Accepts a user access token directly, bypassing MSAL when present. `client_id` / `client_cred` become optional. Mirrors the Google Drive `oauth_token` pattern; refresh is not handled here.
+
 ## [1.5.1]
 
 ### Fixes

--- a/test/unit/connectors/test_onedrive.py
+++ b/test/unit/connectors/test_onedrive.py
@@ -1,8 +1,10 @@
 import pytest
+from pydantic import Secret
 
 from unstructured_ingest.error import ValueError
 from unstructured_ingest.processes.connectors.onedrive import (
     OnedriveAccessConfig,
+    OnedriveConnectionConfig,
 )
 
 
@@ -48,3 +50,34 @@ class TestOnedriveAccessConfig:
                 password="user-password",
                 oauth_token="ey.access.token",
             )
+
+    def test_empty_oauth_token_treated_as_missing(self):
+        """An empty-string oauth_token (e.g. unset env var) should not satisfy the auth requirement.
+
+        Validator and runtime both use truthiness; this test pins that consistency.
+        """
+        with pytest.raises(ValueError, match="must be set"):
+            OnedriveAccessConfig(oauth_token="")
+
+
+class TestOnedriveConnectionConfig:
+    """Tests for OnedriveConnectionConfig cross-field auth validation."""
+
+    def test_client_cred_without_client_id_raises(self):
+        """client_cred-based auth requires client_id; rejecting at config time
+        avoids cryptic AADSTS / MSAL errors at runtime."""
+        with pytest.raises(ValueError, match="client_id is required"):
+            OnedriveConnectionConfig(
+                user_pname="alice@contoso.com",
+                tenant="tenant-id",
+                access_config=Secret(OnedriveAccessConfig(client_cred="secret-value")),
+            )
+
+    def test_oauth_token_without_client_id_succeeds(self):
+        """oauth_token auth doesn't need client_id; this is the delegated path."""
+        config = OnedriveConnectionConfig(
+            user_pname="alice@contoso.com",
+            tenant="tenant-id",
+            access_config=Secret(OnedriveAccessConfig(oauth_token="ey.access.token")),
+        )
+        assert config.client_id is None

--- a/test/unit/connectors/test_onedrive.py
+++ b/test/unit/connectors/test_onedrive.py
@@ -17,9 +17,7 @@ class TestOnedriveAccessConfig:
 
     def test_client_cred_and_password(self):
         """client_cred + password is the password-grant flow and should be valid."""
-        config = OnedriveAccessConfig(
-            client_cred="secret-value", password="user-password"
-        )
+        config = OnedriveAccessConfig(client_cred="secret-value", password="user-password")
         assert config.client_cred == "secret-value"
         assert config.password == "user-password"
         assert config.oauth_token is None

--- a/test/unit/connectors/test_onedrive.py
+++ b/test/unit/connectors/test_onedrive.py
@@ -1,0 +1,52 @@
+import pytest
+
+from unstructured_ingest.error import ValueError
+from unstructured_ingest.processes.connectors.onedrive import (
+    OnedriveAccessConfig,
+)
+
+
+class TestOnedriveAccessConfig:
+    """Tests for OnedriveAccessConfig authentication validation."""
+
+    def test_client_cred_only(self):
+        """Client credential alone should be valid (app-only authentication)."""
+        config = OnedriveAccessConfig(client_cred="secret-value")
+        assert config.client_cred == "secret-value"
+        assert config.oauth_token is None
+
+    def test_client_cred_and_password(self):
+        """client_cred + password is the password-grant flow and should be valid."""
+        config = OnedriveAccessConfig(
+            client_cred="secret-value", password="user-password"
+        )
+        assert config.client_cred == "secret-value"
+        assert config.password == "user-password"
+        assert config.oauth_token is None
+
+    def test_oauth_token_only(self):
+        """OAuth token alone should be valid (delegated authentication)."""
+        config = OnedriveAccessConfig(oauth_token="ey.access.token")
+        assert config.oauth_token == "ey.access.token"
+        assert config.client_cred is None
+
+    def test_no_auth_raises_error(self):
+        """No authentication provided should raise ValueError."""
+        with pytest.raises(ValueError, match="must be set"):
+            OnedriveAccessConfig()
+
+    def test_oauth_and_client_cred_raises_error(self):
+        """Both oauth_token and client_cred provided should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot use both"):
+            OnedriveAccessConfig(
+                client_cred="secret-value",
+                oauth_token="ey.access.token",
+            )
+
+    def test_oauth_and_password_raises_error(self):
+        """oauth_token combined with password should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot use both"):
+            OnedriveAccessConfig(
+                password="user-password",
+                oauth_token="ey.access.token",
+            )

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -1,0 +1,36 @@
+import pytest
+
+from unstructured_ingest.error import ValueError
+from unstructured_ingest.processes.connectors.outlook import (
+    OutlookAccessConfig,
+)
+
+
+class TestOutlookAccessConfig:
+    """Tests for OutlookAccessConfig authentication validation."""
+
+    def test_client_cred_only(self):
+        """Client credential alone should be valid (app-only authentication)."""
+        config = OutlookAccessConfig(client_cred="secret-value")
+        # `client_credential` is the field name; `client_cred` is the alias.
+        assert config.client_credential == "secret-value"
+        assert config.oauth_token is None
+
+    def test_oauth_token_only(self):
+        """OAuth token alone should be valid (delegated authentication)."""
+        config = OutlookAccessConfig(oauth_token="ey.access.token")
+        assert config.oauth_token == "ey.access.token"
+        assert config.client_credential is None
+
+    def test_no_auth_raises_error(self):
+        """No authentication provided should raise ValueError."""
+        with pytest.raises(ValueError, match="must be set"):
+            OutlookAccessConfig()
+
+    def test_oauth_and_client_cred_raises_error(self):
+        """Both oauth_token and client_cred provided should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot use both"):
+            OutlookAccessConfig(
+                client_cred="secret-value",
+                oauth_token="ey.access.token",
+            )

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -1,8 +1,10 @@
 import pytest
+from pydantic import Secret
 
 from unstructured_ingest.error import ValueError
 from unstructured_ingest.processes.connectors.outlook import (
     OutlookAccessConfig,
+    OutlookConnectionConfig,
 )
 
 
@@ -34,3 +36,30 @@ class TestOutlookAccessConfig:
                 client_cred="secret-value",
                 oauth_token="ey.access.token",
             )
+
+    def test_empty_oauth_token_treated_as_missing(self):
+        """An empty-string oauth_token (e.g. unset env var) should not satisfy the auth requirement.
+
+        Validator and runtime both use truthiness; this test pins that consistency.
+        """
+        with pytest.raises(ValueError, match="must be set"):
+            OutlookAccessConfig(oauth_token="")
+
+
+class TestOutlookConnectionConfig:
+    """Tests for OutlookConnectionConfig cross-field auth validation."""
+
+    def test_client_cred_without_client_id_raises(self):
+        """client_cred-based auth requires client_id; rejecting at config time
+        avoids cryptic AADSTS / MSAL errors at runtime."""
+        with pytest.raises(ValueError, match="client_id is required"):
+            OutlookConnectionConfig(
+                access_config=Secret(OutlookAccessConfig(client_cred="secret-value")),
+            )
+
+    def test_oauth_token_without_client_id_succeeds(self):
+        """oauth_token auth doesn't need client_id; this is the delegated path."""
+        config = OutlookConnectionConfig(
+            access_config=Secret(OutlookAccessConfig(oauth_token="ey.access.token")),
+        )
+        assert config.client_id is None

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -3,15 +3,53 @@ from unittest.mock import Mock
 import pytest
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
-from unstructured_ingest.error import SourceConnectionError
+from unstructured_ingest.error import SourceConnectionError, ValueError
 from unstructured_ingest.processes.connectors.sharepoint import (
     MICROSOFT_ROLE_MAPPING,
+    SharepointAccessConfig,
     SharepointConnectionConfig,
     SharepointDownloader,
     SharepointDownloaderConfig,
     SharepointIndexer,
     SharepointIndexerConfig,
 )
+
+
+class TestSharepointAccessConfig:
+    """Tests for SharepointAccessConfig authentication validation."""
+
+    def test_client_cred_only(self):
+        """Client credential alone should be valid (app-only authentication)."""
+        config = SharepointAccessConfig(client_cred="secret-value")
+        assert config.client_cred == "secret-value"
+        assert config.oauth_token is None
+
+    def test_oauth_token_only(self):
+        """OAuth token alone should be valid (delegated authentication)."""
+        config = SharepointAccessConfig(oauth_token="ey.access.token")
+        assert config.oauth_token == "ey.access.token"
+        assert config.client_cred is None
+
+    def test_no_auth_raises_error(self):
+        """No authentication provided should raise ValueError."""
+        with pytest.raises(ValueError, match="must be set"):
+            SharepointAccessConfig()
+
+    def test_oauth_and_client_cred_raises_error(self):
+        """Both oauth_token and client_cred provided should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot use both"):
+            SharepointAccessConfig(
+                client_cred="secret-value",
+                oauth_token="ey.access.token",
+            )
+
+    def test_oauth_and_password_raises_error(self):
+        """oauth_token combined with password should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot use both"):
+            SharepointAccessConfig(
+                password="user-password",
+                oauth_token="ey.access.token",
+            )
 
 
 @pytest.fixture

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from pydantic import Secret
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
 from unstructured_ingest.error import SourceConnectionError, ValueError
@@ -50,6 +51,43 @@ class TestSharepointAccessConfig:
                 password="user-password",
                 oauth_token="ey.access.token",
             )
+
+    def test_empty_oauth_token_treated_as_missing(self):
+        """An empty-string oauth_token (e.g. unset env var) should not satisfy the auth requirement.
+
+        Validator and runtime both use truthiness; this test pins that consistency.
+        """
+        with pytest.raises(ValueError, match="must be set"):
+            SharepointAccessConfig(oauth_token="")
+
+
+class TestSharepointConnectionConfig:
+    """Tests for SharepointConnectionConfig cross-field auth validation.
+
+    SharepointConnectionConfig inherits the validator from OnedriveConnectionConfig;
+    these tests verify the inheritance carries the cross-field constraint through.
+    """
+
+    def test_client_cred_without_client_id_raises(self):
+        """client_cred-based auth requires client_id; rejecting at config time
+        avoids cryptic AADSTS / MSAL errors at runtime."""
+        with pytest.raises(ValueError, match="client_id is required"):
+            SharepointConnectionConfig(
+                site="https://contoso.sharepoint.com/sites/acme",
+                user_pname="alice@contoso.com",
+                tenant="tenant-id",
+                access_config=Secret(SharepointAccessConfig(client_cred="secret-value")),
+            )
+
+    def test_oauth_token_without_client_id_succeeds(self):
+        """oauth_token auth doesn't need client_id; this is the delegated path."""
+        config = SharepointConnectionConfig(
+            site="https://contoso.sharepoint.com/sites/acme",
+            user_pname="alice@contoso.com",
+            tenant="tenant-id",
+            access_config=Secret(SharepointAccessConfig(oauth_token="ey.access.token")),
+        )
+        assert config.client_id is None
 
 
 @pytest.fixture

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.5.1"  # pragma: no cover
+__version__ = "1.5.2"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -54,9 +54,7 @@ MAX_BYTES_SIZE = 512_000_000
 
 
 class OnedriveAccessConfig(AccessConfig):
-    client_cred: Optional[str] = Field(
-        default=None, description="Microsoft App client secret"
-    )
+    client_cred: Optional[str] = Field(default=None, description="Microsoft App client secret")
     password: Optional[str] = Field(description="Service account password", default=None)
     oauth_token: Optional[str] = Field(
         default=None,
@@ -73,20 +71,19 @@ class OnedriveAccessConfig(AccessConfig):
         has_password = self.password is not None
 
         if not has_client_cred and not has_oauth_token:
-            raise ValueError(
-                "either client_cred or oauth_token must be set"
-            )
+            raise ValueError("either client_cred or oauth_token must be set")
 
         if has_oauth_token and (has_client_cred or has_password):
-            raise ValueError(
-                "cannot use both oauth_token and client_cred/password authentication"
-            )
+            raise ValueError("cannot use both oauth_token and client_cred/password authentication")
 
 
 class OnedriveConnectionConfig(ConnectionConfig):
     client_id: Optional[str] = Field(
         default=None,
-        description="Microsoft app client ID. Required for app-only and password-grant authentication; not required when using oauth_token.",
+        description=(
+            "Microsoft app client ID. Required for app-only and password-grant authentication;"
+            " not required when using oauth_token."
+        ),
     )
     user_pname: str = Field(
         description="User principal name or service account, usually your Azure AD email."
@@ -117,9 +114,7 @@ class OnedriveConnectionConfig(ConnectionConfig):
         if access_config.oauth_token:
             # Delegated user authentication: hand the access token through directly.
             # Tokens typically expire after ~1 hour; refresh is not handled here.
-            logger.warning(
-                "Using OAuth token authentication. Tokens expire after ~1 hour."
-            )
+            logger.warning("Using OAuth token authentication. Tokens expire after ~1 hour.")
             return {"access_token": access_config.oauth_token, "token_type": "Bearer"}
 
         if access_config.password:

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -8,7 +8,7 @@ from time import time
 from typing import TYPE_CHECKING, Any, AsyncIterator, Optional
 
 from dateutil import parser
-from pydantic import Field, Secret
+from pydantic import Field, Secret, model_validator
 
 from unstructured_ingest.data_types.file_data import (
     FileData,
@@ -66,9 +66,11 @@ class OnedriveAccessConfig(AccessConfig):
     )
 
     def model_post_init(self, __context: Any) -> None:
-        has_client_cred = self.client_cred is not None
-        has_oauth_token = self.oauth_token is not None
-        has_password = self.password is not None
+        # Use truthiness so empty strings (e.g. from unset env vars) are treated
+        # consistently with the runtime auth-mode check in get_token below.
+        has_client_cred = bool(self.client_cred)
+        has_oauth_token = bool(self.oauth_token)
+        has_password = bool(self.password)
 
         if not has_client_cred and not has_oauth_token:
             raise ValueError("either client_cred or oauth_token must be set")
@@ -99,6 +101,25 @@ class OnedriveConnectionConfig(ConnectionConfig):
     )
     access_config: Secret[OnedriveAccessConfig]
 
+    @model_validator(mode="after")
+    def _require_client_id_without_oauth(self) -> "OnedriveConnectionConfig":
+        # client_id lives on ConnectionConfig (above) and oauth_token on AccessConfig,
+        # so this cross-field rule can't live in either model_post_init alone.
+        if not self.access_config.get_secret_value().oauth_token and not self.client_id:
+            raise ValueError("client_id is required when oauth_token is not set")
+        return self
+
+    def _log_oauth_advisory(self) -> None:
+        """Emit a one-shot advisory at precheck time when delegated OAuth is in use.
+
+        Lives on ConnectionConfig so Indexer/Uploader/Downloader prechecks share
+        one source of truth instead of each duplicating the message. Called from
+        precheck (once per step instance) rather than from get_token (called per
+        Graph request) to avoid log spam during normal indexing.
+        """
+        if self.access_config.get_secret_value().oauth_token:
+            logger.warning("Using OAuth token authentication. Tokens expire after ~1 hour.")
+
     def get_drive(self) -> "Drive":
         client = self.get_client()
         drive = client.users[self.user_pname].drive
@@ -114,7 +135,6 @@ class OnedriveConnectionConfig(ConnectionConfig):
         if access_config.oauth_token:
             # Delegated user authentication: hand the access token through directly.
             # Tokens typically expire after ~1 hour; refresh is not handled here.
-            logger.warning("Using OAuth token authentication. Tokens expire after ~1 hour.")
             return {"access_token": access_config.oauth_token, "token_type": "Bearer"}
 
         if access_config.password:
@@ -193,6 +213,7 @@ class OnedriveIndexer(Indexer):
     connector_type: str = CONNECTOR_TYPE
 
     def precheck(self) -> None:
+        self.connection_config._log_oauth_advisory()
         try:
             token_resp: dict = self.connection_config.get_token()
             if error := token_resp.get("error"):
@@ -391,6 +412,7 @@ class OnedriveUploader(Uploader):
     def precheck(self) -> None:
         from office365.runtime.client_request_exception import ClientRequestException
 
+        self.connection_config._log_oauth_advisory()
         try:
             token_resp: dict = self.connection_config.get_token()
             if error := token_resp.get("error"):

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -54,12 +54,40 @@ MAX_BYTES_SIZE = 512_000_000
 
 
 class OnedriveAccessConfig(AccessConfig):
-    client_cred: str = Field(description="Microsoft App client secret")
+    client_cred: Optional[str] = Field(
+        default=None, description="Microsoft App client secret"
+    )
     password: Optional[str] = Field(description="Service account password", default=None)
+    oauth_token: Optional[str] = Field(
+        default=None,
+        description=(
+            "OAuth 2.0 access token for delegated user authentication. "
+            "Tokens typically expire after ~1 hour; this connector does not "
+            "refresh tokens."
+        ),
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        has_client_cred = self.client_cred is not None
+        has_oauth_token = self.oauth_token is not None
+        has_password = self.password is not None
+
+        if not has_client_cred and not has_oauth_token:
+            raise ValueError(
+                "either client_cred or oauth_token must be set"
+            )
+
+        if has_oauth_token and (has_client_cred or has_password):
+            raise ValueError(
+                "cannot use both oauth_token and client_cred/password authentication"
+            )
 
 
 class OnedriveConnectionConfig(ConnectionConfig):
-    client_id: str = Field(description="Microsoft app client ID")
+    client_id: Optional[str] = Field(
+        default=None,
+        description="Microsoft app client ID. Required for app-only and password-grant authentication; not required when using oauth_token.",
+    )
     user_pname: str = Field(
         description="User principal name or service account, usually your Azure AD email."
     )
@@ -84,7 +112,17 @@ class OnedriveConnectionConfig(ConnectionConfig):
         from msal import ConfidentialClientApplication
         from requests import post
 
-        if self.access_config.get_secret_value().password:
+        access_config = self.access_config.get_secret_value()
+
+        if access_config.oauth_token:
+            # Delegated user authentication: hand the access token through directly.
+            # Tokens typically expire after ~1 hour; refresh is not handled here.
+            logger.warning(
+                "Using OAuth token authentication. Tokens expire after ~1 hour."
+            )
+            return {"access_token": access_config.oauth_token, "token_type": "Bearer"}
+
+        if access_config.password:
             url = f"https://login.microsoftonline.com/{self.tenant}/oauth2/v2.0/token"
             headers = {"Content-Type": "application/x-www-form-urlencoded"}
             data = {

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -55,21 +55,20 @@ class OutlookAccessConfig(AccessConfig):
         has_oauth_token = self.oauth_token is not None
 
         if not has_client_cred and not has_oauth_token:
-            raise ValueError(
-                "either client_cred or oauth_token must be set"
-            )
+            raise ValueError("either client_cred or oauth_token must be set")
 
         if has_client_cred and has_oauth_token:
-            raise ValueError(
-                "cannot use both oauth_token and client_cred authentication"
-            )
+            raise ValueError("cannot use both oauth_token and client_cred authentication")
 
 
 class OutlookConnectionConfig(ConnectionConfig):
     access_config: Secret[OutlookAccessConfig]
     client_id: Optional[str] = Field(
         default=None,
-        description="Azure AD App client ID. Required for app-only authentication; not required when using oauth_token.",
+        description=(
+            "Azure AD App client ID. Required for app-only authentication;"
+            " not required when using oauth_token."
+        ),
     )
     tenant: str = Field(
         default="common", description="ID or domain name associated with your Azure AD instance"
@@ -89,9 +88,7 @@ class OutlookConnectionConfig(ConnectionConfig):
         if access_config.oauth_token:
             # Delegated user authentication: hand the access token through directly.
             # Tokens typically expire after ~1 hour; refresh is not handled here.
-            logger.warning(
-                "Using OAuth token authentication. Tokens expire after ~1 hour."
-            )
+            logger.warning("Using OAuth token authentication. Tokens expire after ~1 hour.")
             return {"access_token": access_config.oauth_token, "token_type": "Bearer"}
 
         # NOTE: It'd be nice to use `msal.authority.AuthorityBuilder` here paired with AZURE_PUBLIC

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -5,7 +5,7 @@ from datetime import timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Coroutine, Generator, Optional
 
-from pydantic import Field, Secret
+from pydantic import Field, Secret, model_validator
 
 from unstructured_ingest.data_types.file_data import (
     FileData,
@@ -51,8 +51,10 @@ class OutlookAccessConfig(AccessConfig):
     )
 
     def model_post_init(self, __context: Any) -> None:
-        has_client_cred = self.client_credential is not None
-        has_oauth_token = self.oauth_token is not None
+        # Use truthiness so empty strings (e.g. from unset env vars) are treated
+        # consistently with the runtime auth-mode check in _acquire_token below.
+        has_client_cred = bool(self.client_credential)
+        has_oauth_token = bool(self.oauth_token)
 
         if not has_client_cred and not has_oauth_token:
             raise ValueError("either client_cred or oauth_token must be set")
@@ -78,6 +80,25 @@ class OutlookConnectionConfig(ConnectionConfig):
         description="Authentication token provider for Microsoft apps",
     )
 
+    @model_validator(mode="after")
+    def _require_client_id_without_oauth(self) -> "OutlookConnectionConfig":
+        # client_id lives on ConnectionConfig (above) and oauth_token on AccessConfig,
+        # so this cross-field rule can't live in either model_post_init alone.
+        if not self.access_config.get_secret_value().oauth_token and not self.client_id:
+            raise ValueError("client_id is required when oauth_token is not set")
+        return self
+
+    def _log_oauth_advisory(self) -> None:
+        """Emit a one-shot advisory at precheck time when delegated OAuth is in use.
+
+        Lives on ConnectionConfig so Indexer/Downloader prechecks share one source
+        of truth instead of each duplicating the message. Called from precheck
+        (once per step instance) rather than from _acquire_token (called per Graph
+        request) to avoid log spam during normal indexing.
+        """
+        if self.access_config.get_secret_value().oauth_token:
+            logger.warning("Using OAuth token authentication. Tokens expire after ~1 hour.")
+
     @requires_dependencies(["msal"], extras="outlook")
     def _acquire_token(self):
         """Acquire token via MSAL, or hand through a delegated OAuth token."""
@@ -88,7 +109,6 @@ class OutlookConnectionConfig(ConnectionConfig):
         if access_config.oauth_token:
             # Delegated user authentication: hand the access token through directly.
             # Tokens typically expire after ~1 hour; refresh is not handled here.
-            logger.warning("Using OAuth token authentication. Tokens expire after ~1 hour.")
             return {"access_token": access_config.oauth_token, "token_type": "Bearer"}
 
         # NOTE: It'd be nice to use `msal.authority.AuthorityBuilder` here paired with AZURE_PUBLIC
@@ -140,6 +160,7 @@ class OutlookIndexer(Indexer):
 
     @SourceConnectionError.wrap
     def precheck(self) -> None:
+        self.connection_config._log_oauth_advisory()
         client = self.connection_config.get_client()
         client.users[self.index_config.user_email].get().execute_query()
 

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -3,7 +3,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Coroutine, Generator
+from typing import TYPE_CHECKING, Any, Coroutine, Generator, Optional
 
 from pydantic import Field, Secret
 
@@ -38,12 +38,39 @@ CONNECTOR_TYPE = "outlook"
 
 
 class OutlookAccessConfig(AccessConfig):
-    client_credential: str = Field(description="Azure AD App client secret", alias="client_cred")
+    client_credential: Optional[str] = Field(
+        default=None, description="Azure AD App client secret", alias="client_cred"
+    )
+    oauth_token: Optional[str] = Field(
+        default=None,
+        description=(
+            "OAuth 2.0 access token for delegated user authentication. "
+            "Tokens typically expire after ~1 hour; this connector does not "
+            "refresh tokens."
+        ),
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        has_client_cred = self.client_credential is not None
+        has_oauth_token = self.oauth_token is not None
+
+        if not has_client_cred and not has_oauth_token:
+            raise ValueError(
+                "either client_cred or oauth_token must be set"
+            )
+
+        if has_client_cred and has_oauth_token:
+            raise ValueError(
+                "cannot use both oauth_token and client_cred authentication"
+            )
 
 
 class OutlookConnectionConfig(ConnectionConfig):
     access_config: Secret[OutlookAccessConfig]
-    client_id: str = Field(description="Azure AD App client ID")
+    client_id: Optional[str] = Field(
+        default=None,
+        description="Azure AD App client ID. Required for app-only authentication; not required when using oauth_token.",
+    )
     tenant: str = Field(
         default="common", description="ID or domain name associated with your Azure AD instance"
     )
@@ -54,8 +81,18 @@ class OutlookConnectionConfig(ConnectionConfig):
 
     @requires_dependencies(["msal"], extras="outlook")
     def _acquire_token(self):
-        """Acquire token via MSAL"""
+        """Acquire token via MSAL, or hand through a delegated OAuth token."""
         from msal import ConfidentialClientApplication
+
+        access_config = self.access_config.get_secret_value()
+
+        if access_config.oauth_token:
+            # Delegated user authentication: hand the access token through directly.
+            # Tokens typically expire after ~1 hour; refresh is not handled here.
+            logger.warning(
+                "Using OAuth token authentication. Tokens expire after ~1 hour."
+            )
+            return {"access_token": access_config.oauth_token, "token_type": "Bearer"}
 
         # NOTE: It'd be nice to use `msal.authority.AuthorityBuilder` here paired with AZURE_PUBLIC
         # constant as default in the future but they do not fit well with `authority_url` right now
@@ -63,7 +100,7 @@ class OutlookConnectionConfig(ConnectionConfig):
         app = ConfidentialClientApplication(
             authority=authority_url,
             client_id=self.client_id,
-            client_credential=self.access_config.get_secret_value().client_credential,
+            client_credential=access_config.client_credential,
         )
         token = app.acquire_token_for_client(scopes=["https://graph.microsoft.com/.default"])
         return token

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -318,6 +318,8 @@ class SharepointIndexer(OnedriveIndexer):
         """Validate SharePoint connection before indexing."""
         from office365.runtime.client_request_exception import ClientRequestException
 
+        self.connection_config._log_oauth_advisory()
+
         # Validate authentication - this call will raise UserAuthError if invalid
         self.connection_config.get_token()
 

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -69,7 +69,7 @@ MICROSOFT_ROLE_MAPPING: dict[str, list[str]] = {
 
 
 class SharepointAccessConfig(OnedriveAccessConfig):
-    client_cred: str = Field(description="Microsoft App client secret")
+    pass
 
 
 class SharepointConnectionConfig(OnedriveConnectionConfig):


### PR DESCRIPTION
## Summary

Mirror the Google Drive `oauth_token` pattern across the three Microsoft Graph connectors (SharePoint, OneDrive, Outlook).

- Add Optional `oauth_token` to `OnedriveAccessConfig` and `OutlookAccessConfig` (`SharepointAccessConfig` inherits from `OnedriveAccessConfig`).
- `client_cred` / `client_credential` and `client_id` become Optional so a delegated user access token can be supplied without app credentials.
- `model_post_init` validators enforce at-least-one auth method and mutual exclusion of `oauth_token` with `client_cred` / `password`.
- `get_token` / `_acquire_token` short-circuit on `oauth_token`: hand the bearer token through directly, no MSAL round-trip. Existing app-only and password-grant paths are unchanged.
- Schema-validation unit tests for each AccessConfig variant.
- Bump to 1.5.2; CHANGELOG entry added.

Tokens typically expire after ~1 hour; refresh handling is out of scope for this connector — same model as the Google Drive `oauth_token` field.

## Test plan

- [ ] CI passes (unit tests for the new schema validators)
- [ ] Existing integration tests still pass (no behaviour change for app-only or password-grant flows)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Microsoft Graph authentication/config validation for OneDrive/SharePoint/Outlook; misconfiguration could break existing credential-based flows, though changes are gated by new validation and the prior MSAL paths remain.
> 
> **Overview**
> Adds *delegated OAuth* support to the Microsoft Graph connectors by introducing an optional `oauth_token` on OneDrive/SharePoint/Outlook access configs and allowing `client_id`/`client_cred` to be omitted when a user access token is supplied.
> 
> Implements stricter Pydantic validation (mutual exclusion and “at least one auth method”) plus a cross-field rule requiring `client_id` when `oauth_token` is not set, and logs a one-time warning during `precheck` when token-based auth is used.
> 
> Includes new unit tests covering these auth/validation combinations, and bumps the package to `1.5.2` with a CHANGELOG entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb41d4b3314768e0971c6c90c46f0644f93106a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->