### PR TITLE
feat(FS-1981): connector oauth refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.1]
+
+### Enhancements
+
+- **feat(oauth): add `refresh_token` field to Google Drive, GCS, OneDrive, SharePoint, and Outlook AccessConfigs.** Allows the platform to persist and retrieve OAuth refresh tokens alongside access tokens, enabling automatic token refresh before job dispatch. Dropbox already had this field.
+
 ## [1.6.0]
 
 ### Enhancements

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.0"  # pragma: no cover
+__version__ = "1.6.1"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/fsspec/gcs.py
+++ b/unstructured_ingest/processes/connectors/fsspec/gcs.py
@@ -72,6 +72,12 @@ class GcsAccessConfig(FsspecAccessConfig):
         default=None, description=service_account_key_description
     )
     token: Union[str, dict, None] = Field(init=False, default=None)
+    refresh_token: Optional[str] = Field(
+        default=None,
+        description="OAuth 2.0 refresh token for obtaining new access tokens. "
+        "Long-lived; used by the platform to refresh expired access tokens "
+        "before each job run.",
+    )
 
     def model_post_init(self, __context: Any) -> None:
         ALLOWED_AUTH_VALUES = "google_default", "cache", "anon", "browser", "cloud"

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -69,6 +69,12 @@ class GoogleDriveAccessConfig(AccessConfig):
         "Obtain via Google OAuth Playground or your OAuth application. "
         "Tokens typically expire after 1 hour.",
     )
+    refresh_token: Optional[str] = Field(
+        default=None,
+        description="OAuth 2.0 refresh token for obtaining new access tokens. "
+        "Long-lived; used by the platform to refresh expired access tokens "
+        "before each job run.",
+    )
 
     def model_post_init(self, __context: Any) -> None:
         has_service_account = (

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -60,9 +60,14 @@ class OnedriveAccessConfig(AccessConfig):
         default=None,
         description=(
             "OAuth 2.0 access token for delegated user authentication. "
-            "Tokens typically expire after ~1 hour; this connector does not "
-            "refresh tokens."
+            "Tokens typically expire after ~1 hour."
         ),
+    )
+    refresh_token: Optional[str] = Field(
+        default=None,
+        description="OAuth 2.0 refresh token for obtaining new access tokens. "
+        "Long-lived; used by the platform to refresh expired access tokens "
+        "before each job run.",
     )
 
     def model_post_init(self, __context: Any) -> None:

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -45,9 +45,14 @@ class OutlookAccessConfig(AccessConfig):
         default=None,
         description=(
             "OAuth 2.0 access token for delegated user authentication. "
-            "Tokens typically expire after ~1 hour; this connector does not "
-            "refresh tokens."
+            "Tokens typically expire after ~1 hour."
         ),
+    )
+    refresh_token: Optional[str] = Field(
+        default=None,
+        description="OAuth 2.0 refresh token for obtaining new access tokens. "
+        "Long-lived; used by the platform to refresh expired access tokens "
+        "before each job run.",
     )
 
     def model_post_init(self, __context: Any) -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk schema-only change: adds new optional config fields and updates documentation/versioning, with no runtime token refresh behavior added here.
> 
> **Overview**
> Bumps the library version to `1.6.1` and documents the change in `CHANGELOG.md`.
> 
> Adds an optional `refresh_token` field to `GoogleDriveAccessConfig`, `GcsAccessConfig`, `OnedriveAccessConfig`, and `OutlookAccessConfig` so the platform can persist refresh tokens alongside access tokens (and removes wording that these connectors do not refresh tokens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313045234cde1c5271156106db6abdc006728bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->