### PR TITLE
Fix google native files failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.2]
+
+### Fixes
+
+- **fix(google-drive): export Google-native Docs Editors files before download.** Google Docs, Sheets, Slides, and Drawings now use Drive export endpoints instead of raw media downloads, preventing 403 errors for files without binary content. Extension filters now include matching Google-native MIME types for exportable formats, and unsupported Google-native files fail clearly instead of falling through to direct download.
+
 ## [1.6.1]
 
 ### Enhancements

--- a/test/integration/connectors/test_google_drive.py
+++ b/test/integration/connectors/test_google_drive.py
@@ -207,7 +207,19 @@ MIME_TYPES_TO_TEST = [
     "application/vnd.google-apps.document",
     "application/vnd.google-apps.spreadsheet",
     "application/vnd.google-apps.presentation",
+    "application/vnd.google-apps.drawing",
 ]
+
+EXPECTED_EXPORT_EXTENSIONS = {
+    "application/vnd.google-apps.document": ".docx",
+    "application/vnd.google-apps.spreadsheet": ".xlsx",
+    "application/vnd.google-apps.presentation": ".pptx",
+    "application/vnd.google-apps.drawing": ".png",
+}
+
+OPTIONAL_NATIVE_MIME_TYPES = {
+    "application/vnd.google-apps.drawing",
+}
 
 
 @pytest.mark.asyncio
@@ -217,7 +229,7 @@ MIME_TYPES_TO_TEST = [
 async def test_google_drive_export_by_type(expected_mime, temp_dir):
     """
     Parametrized test for verifying export of each specific Google-native format
-    using exportLinks or webContentLink.
+    using the Drive API export endpoints.
     """
 
     drive_id = os.environ["GOOGLE_DRIVE_NATIVE_TEST_ID"]
@@ -239,6 +251,8 @@ async def test_google_drive_export_by_type(expected_mime, temp_dir):
 
     # Filter only the target MIME type
     target_files = [f for f in file_datas if f.additional_metadata.get("mimeType") == expected_mime]
+    if not target_files and expected_mime in OPTIONAL_NATIVE_MIME_TYPES:
+        pytest.skip(f"No optional Google-native fixture found with MIME type: {expected_mime}")
     assert target_files, f"No files found with MIME type: {expected_mime}"
 
     for file_data in target_files:
@@ -249,10 +263,8 @@ async def test_google_drive_export_by_type(expected_mime, temp_dir):
         assert out_path.stat().st_size > 0, f"{out_path} is empty"
 
         method = file_data.additional_metadata.get("download_method", "")
-        assert method in {
-            "export_link",
-            "web_content_link",
-        }, f"Unexpected download method: {method}"
+        assert method == "google_workspace_export", f"Unexpected download method: {method}"
+        assert out_path.suffix == EXPECTED_EXPORT_EXTENSIONS[expected_mime]
 
 
 @pytest.mark.asyncio

--- a/test/unit/connectors/test_google_drive.py
+++ b/test/unit/connectors/test_google_drive.py
@@ -1,11 +1,46 @@
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
-from unstructured_ingest.error import ValueError
+from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
+from unstructured_ingest.error import SourceConnectionError, ValueError
 from unstructured_ingest.processes.connectors.google_drive import (
+    GOOGLE_EXPORT_MIME_MAP,
     GoogleDriveAccessConfig,
+    GoogleDriveDownloader,
+    GoogleDriveDownloaderConfig,
+    GoogleDriveIndexer,
+    GoogleDriveIndexerConfig,
+    _get_extension,
 )
+
+
+def _make_file_data(mime_type: str, filename: str = "native-file") -> FileData:
+    return FileData(
+        connector_type="google_drive",
+        identifier="file-id",
+        source_identifiers=SourceIdentifiers(filename=filename, fullpath=filename),
+        additional_metadata={"mimeType": mime_type, "size": "0"},
+    )
+
+
+class _FakeGoogleDriveRequest:
+    def __init__(self, response: dict):
+        self.response = response
+
+    def execute(self) -> dict:
+        return self.response
+
+
+class _FakeGoogleDriveFilesClient:
+    def __init__(self, responses: list[dict]):
+        self.responses = responses
+        self.list_calls = []
+
+    def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        return _FakeGoogleDriveRequest(self.responses.pop(0))
 
 
 class TestGoogleDriveAccessConfig:
@@ -105,3 +140,156 @@ class TestGoogleDriveAccessConfig:
         )
         with pytest.raises(ValueError, match="both provided and have different values"):
             config.get_service_account_key()
+
+
+class TestGoogleDriveNativeExports:
+    @pytest.mark.parametrize(
+        ("source_mime_type", "expected_extension"),
+        [
+            ("application/vnd.google-apps.document", ".docx"),
+            ("application/vnd.google-apps.spreadsheet", ".xlsx"),
+            ("application/vnd.google-apps.presentation", ".pptx"),
+            ("application/vnd.google-apps.drawing", ".png"),
+        ],
+    )
+    def test_get_extension_uses_source_mime_type(self, source_mime_type, expected_extension):
+        file_data = _make_file_data(source_mime_type)
+
+        assert _get_extension(file_data) == expected_extension
+
+    @pytest.mark.parametrize(
+        ("source_mime_type", "expected_extension"),
+        [
+            ("application/vnd.google-apps.document", ".docx"),
+            ("application/vnd.google-apps.spreadsheet", ".xlsx"),
+            ("application/vnd.google-apps.presentation", ".pptx"),
+            ("application/vnd.google-apps.drawing", ".png"),
+        ],
+    )
+    def test_downloader_exports_supported_google_native_files(
+        self, tmp_path, source_mime_type, expected_extension
+    ):
+        file_data = _make_file_data(source_mime_type)
+        downloader = GoogleDriveDownloader(
+            connection_config=MagicMock(),
+            download_config=GoogleDriveDownloaderConfig(download_dir=tmp_path),
+        )
+        export_calls = []
+        direct_download = MagicMock()
+
+        def export_file(file_id, download_path, mime_type, file_size):
+            export_calls.append(
+                {
+                    "file_id": file_id,
+                    "download_path": download_path,
+                    "mime_type": mime_type,
+                    "file_size": file_size,
+                }
+            )
+            download_path.write_bytes(b"exported")
+
+        downloader._export_gdrive_native_file = export_file
+        downloader._direct_download_file = direct_download
+
+        download_path = downloader._download_file(file_data)
+
+        assert download_path.suffix == expected_extension
+        assert download_path.exists()
+        assert export_calls == [
+            {
+                "file_id": "file-id",
+                "download_path": download_path,
+                "mime_type": GOOGLE_EXPORT_MIME_MAP[source_mime_type],
+                "file_size": 0,
+            }
+        ]
+        direct_download.assert_not_called()
+        assert file_data.additional_metadata["export_mime_type"] == GOOGLE_EXPORT_MIME_MAP[
+            source_mime_type
+        ]
+        assert file_data.additional_metadata["export_extension"] == expected_extension
+        assert file_data.additional_metadata["download_method"] == "google_workspace_export"
+
+    def test_downloader_rejects_unsupported_google_native_files(self, tmp_path):
+        file_data = _make_file_data("application/vnd.google-apps.form")
+        downloader = GoogleDriveDownloader(
+            connection_config=MagicMock(),
+            download_config=GoogleDriveDownloaderConfig(download_dir=tmp_path),
+        )
+        downloader._export_gdrive_native_file = MagicMock()
+        downloader._direct_download_file = MagicMock()
+
+        with pytest.raises(
+            SourceConnectionError, match="Unsupported Google Drive native MIME type"
+        ):
+            downloader._download_file(file_data)
+
+        downloader._export_gdrive_native_file.assert_not_called()
+        downloader._direct_download_file.assert_not_called()
+
+
+class TestGoogleDriveExtensionFiltering:
+    def test_get_paginated_results_includes_native_mimes_for_export_extensions(self):
+        files_client = MagicMock()
+        files_client.list.return_value.execute.return_value = {"files": []}
+        indexer = GoogleDriveIndexer(
+            connection_config=MagicMock(),
+            index_config=GoogleDriveIndexerConfig(),
+        )
+
+        indexer.get_paginated_results(
+            files_client=files_client,
+            object_id="folder-id",
+            extensions=["docx", ".xlsx", "pptx", "png"],
+        )
+
+        query = files_client.list.call_args.kwargs["q"]
+        assert "fileExtension = 'docx'" in query
+        assert "fileExtension = 'xlsx'" in query
+        assert "fileExtension = 'pptx'" in query
+        assert "fileExtension = 'png'" in query
+        assert "mimeType = 'application/vnd.google-apps.document'" in query
+        assert "mimeType = 'application/vnd.google-apps.spreadsheet'" in query
+        assert "mimeType = 'application/vnd.google-apps.presentation'" in query
+        assert "mimeType = 'application/vnd.google-apps.drawing'" in query
+        assert "mimeType = 'application/vnd.google-apps.folder'" in query
+
+    def test_count_files_recursively_matches_native_mimes_for_export_extensions(self):
+        files_client = _FakeGoogleDriveFilesClient(
+            responses=[
+                {
+                    "files": [
+                        {
+                            "id": "doc",
+                            "mimeType": "application/vnd.google-apps.document",
+                        },
+                        {
+                            "id": "drawing",
+                            "mimeType": "application/vnd.google-apps.drawing",
+                        },
+                        {
+                            "id": "form",
+                            "mimeType": "application/vnd.google-apps.form",
+                        },
+                        {
+                            "id": "binary-docx",
+                            "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # noqa: E501
+                            "fileExtension": "docx",
+                        },
+                        {
+                            "id": "pdf",
+                            "mimeType": "application/pdf",
+                            "fileExtension": "pdf",
+                        },
+                    ]
+                }
+            ]
+        )
+
+        count = GoogleDriveIndexer.count_files_recursively(
+            files_client=files_client,
+            folder_id="folder-id",
+            extensions=["docx", "png"],
+        )
+
+        assert count == 3

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.1"  # pragma: no cover
+__version__ = "1.6.2"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     from googleapiclient.discovery import Resource as GoogleAPIResource
 
 CONNECTOR_TYPE = "google_drive"
+GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+GOOGLE_DRIVE_NATIVE_MIME_PREFIX = "application/vnd.google-apps."
 
 
 # Maps Google-native Drive MIME types → export MIME types
@@ -39,6 +41,7 @@ GOOGLE_EXPORT_MIME_MAP = {
     "application/vnd.google-apps.document": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # noqa: E501
     "application/vnd.google-apps.spreadsheet": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # noqa: E501
     "application/vnd.google-apps.presentation": "application/vnd.openxmlformats-officedocument.presentationml.presentation",  # noqa: E501
+    "application/vnd.google-apps.drawing": "image/png",
 }
 
 # Maps export MIME types → file extensions
@@ -48,11 +51,51 @@ EXPORT_EXTENSION_MAP = {
     "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
     "application/pdf": ".pdf",
     "text/html": ".html",
+    "image/png": ".png",
 }
 
 # LRO Export Size Threshold is 10MB in real but the exported file might be slightly larger
 # than the original Google Workspace file - thus the threshold is set to 9MB
 LRO_EXPORT_SIZE_THRESHOLD = 9 * 1024 * 1024  # 9MB
+
+
+def _normalized_extensions(extensions: Optional[list[str]]) -> set[str]:
+    return {extension.lower().lstrip(".") for extension in extensions or []}
+
+
+def _native_mime_types_for_extensions(extensions: Optional[list[str]]) -> set[str]:
+    extensions_set = _normalized_extensions(extensions)
+    native_mime_types = set()
+    for native_mime_type, export_mime_type in GOOGLE_EXPORT_MIME_MAP.items():
+        export_extension = EXPORT_EXTENSION_MAP.get(export_mime_type, "").lstrip(".").lower()
+        if export_extension in extensions_set:
+            native_mime_types.add(native_mime_type)
+    return native_mime_types
+
+
+def _matches_extension_or_native_export(record: dict, extensions: Optional[list[str]]) -> bool:
+    extensions_set = _normalized_extensions(extensions)
+    if not extensions_set:
+        return True
+
+    file_ext = (record.get("fileExtension") or "").lower().lstrip(".")
+    if file_ext in extensions_set:
+        return True
+
+    return record.get("mimeType") in _native_mime_types_for_extensions(extensions)
+
+
+def _build_extension_query_filter(extensions: list[str]) -> str:
+    extension_clauses = [
+        f"fileExtension = '{extension}'" for extension in sorted(_normalized_extensions(extensions))
+    ]
+    native_mime_clauses = [
+        f"mimeType = '{mime_type}'"
+        for mime_type in sorted(_native_mime_types_for_extensions(extensions))
+    ]
+    clauses = extension_clauses + native_mime_clauses
+    clauses.append(f"mimeType = '{GOOGLE_DRIVE_FOLDER_MIME_TYPE}'")
+    return " or ".join(clauses)
 
 
 class GoogleDriveAccessConfig(AccessConfig):
@@ -244,16 +287,11 @@ class GoogleDriveIndexer(Indexer):
                     pageSize=1000,
                 ).execute()
                 for item in response.get("files", []):
-                    if item.get("mimeType") == "application/vnd.google-apps.folder":
+                    if item.get("mimeType") == GOOGLE_DRIVE_FOLDER_MIME_TYPE:
                         # Always traverse sub-folders regardless of extension filter.
                         stack.append(item["id"])
                     else:
-                        if extensions:
-                            # Use a case-insensitive comparison for the file extension.
-                            file_ext = (item.get("fileExtension") or "").lower()
-                            if file_ext in valid_exts:
-                                count += 1
-                        else:
+                        if not valid_exts or _matches_extension_or_native_export(item, extensions):
                             count += 1
                 page_token = response.get("nextPageToken")
                 if not page_token:
@@ -337,7 +375,7 @@ class GoogleDriveIndexer(Indexer):
 
     @staticmethod
     def is_dir(record: dict) -> bool:
-        return record.get("mimeType") == "application/vnd.google-apps.folder"
+        return record.get("mimeType") == GOOGLE_DRIVE_FOLDER_MIME_TYPE
 
     @staticmethod
     def map_file_data(root_info: dict) -> FileData:
@@ -395,8 +433,7 @@ class GoogleDriveIndexer(Indexer):
         q = f"'{object_id}' in parents"
         # Filter by extension but still include any directories
         if extensions:
-            ext_filter = " or ".join([f"fileExtension = '{e}'" for e in extensions])
-            q = f"{q} and ({ext_filter} or mimeType = 'application/vnd.google-apps.folder')"
+            q = f"{q} and ({_build_extension_query_filter(extensions)})"
         logger.debug(f"query used when indexing: {q}")
         logger.debug("response fields limited to: {}".format(", ".join(self.fields)))
         done = False
@@ -527,7 +564,7 @@ def _get_extension(file_data: FileData) -> str:
     """
     Returns the extension for a given source MIME type.
     """
-    source_mime_type = file_data.additional_metadata.get("export_mime_type", "")
+    source_mime_type = file_data.additional_metadata.get("mimeType", "")
     export_mime_type = GOOGLE_EXPORT_MIME_MAP.get(source_mime_type, "")
     if export_mime_type:
         return EXPORT_EXTENSION_MAP.get(export_mime_type, "")
@@ -861,6 +898,10 @@ class GoogleDriveDownloader(Downloader):
         if mime_type in GOOGLE_EXPORT_MIME_MAP:
             # For Google Workspace files, use export functionality
             ext = _get_extension(file_data)
+            if not ext:
+                raise SourceConnectionError(
+                    f"Unsupported Google Drive export MIME type for file {file_id}: {mime_type}"
+                )
             download_path = download_path.with_suffix(ext)
             download_path.parent.mkdir(parents=True, exist_ok=True)
             export_mime = GOOGLE_EXPORT_MIME_MAP[mime_type]
@@ -876,6 +917,11 @@ class GoogleDriveDownloader(Downloader):
                     "export_extension": ext,
                     "download_method": "google_workspace_export",
                 }
+            )
+        elif mime_type.startswith(GOOGLE_DRIVE_NATIVE_MIME_PREFIX):
+            raise SourceConnectionError(
+                f"Unsupported Google Drive native MIME type for file {file_id}: {mime_type}. "
+                "Docs Editors files must be exported before download."
             )
         else:
             # For other files, use direct download


### PR DESCRIPTION
The failure was caused by Google Docs Editors files being treated like binary Drive files in some paths. Google rejects files.get(...?alt=media) for native Docs/Sheets/Slides/Drawings with a 403 and requires files.export(...) instead.

The mitigation makes export handling explicit: supported native formats are exported to processable formats, extension-filtered indexing now includes exportable native MIME types, and unsupported Google-native types fail clearly instead of surfacing as misleading direct-download 403s.
