### PR TITLE
PLU-180: add denied_permissions_data field to FileDataSourceMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.3]
+
+### Enhancements
+
+- **feat(schema): add `denied_permissions_data` field to `FileDataSourceMetadata`.** Mirrors the shape of `permissions_data` (list of normalized read/update/delete dicts) but holds explicit DENY ACL entries from sources that expose them. The new field is optional and defaults to `None`; existing connectors (Drive, SharePoint, Box, Confluence) leave it unset because their source APIs don't expose deny semantics. Needed by the upcoming FileNet connector ACL passthrough, which is the first source with first-class DENY entries.
+
 ## [1.6.2]
 
 ### Fixes

--- a/test/integration/connectors/expected_results/astradb/file_data/25b75f1d-a2ea-4c97-b75f-1da2eadc97f7.csv.json
+++ b/test/integration/connectors/expected_results/astradb/file_data/25b75f1d-a2ea-4c97-b75f-1da2eadc97f7.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749474599.0632136",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/astradb/file_data/43d02113-723f-5ec1-acbb-c8da8d3650dc.json
+++ b/test/integration/connectors/expected_results/astradb/file_data/43d02113-723f-5ec1-acbb-c8da8d3650dc.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749474598.4987292",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/astradb/file_data/60297eea-73d7-4fca-a97e-ea73d7cfca62.csv.json
+++ b/test/integration/connectors/expected_results/astradb/file_data/60297eea-73d7-4fca-a97e-ea73d7cfca62.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749474599.0628886",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/astradb/file_data/641d99e3-9941-4c18-9d99-e399414c183d.csv.json
+++ b/test/integration/connectors/expected_results/astradb/file_data/641d99e3-9941-4c18-9d99-e399414c183d.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749474599.0630517",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/astradb/file_data/762c0093-2277-4f3e-ac00-932277af3e0e.csv.json
+++ b/test/integration/connectors/expected_results/astradb/file_data/762c0093-2277-4f3e-ac00-932277af3e0e.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749474599.0626802",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/astradb/file_data/ae40df94-0b3a-4f89-80df-940b3a6f8966.csv.json
+++ b/test/integration/connectors/expected_results/astradb/file_data/ae40df94-0b3a-4f89-80df-940b3a6f8966.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749474599.0633657",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/box_second_tier/file_data/8b0303ba-7c77-5e47-b0ff-790b8fc9881f.json
+++ b/test/integration/connectors/expected_results/box_second_tier/file_data/8b0303ba-7c77-5e47-b0ff-790b8fc9881f.json
@@ -44,6 +44,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": 296006
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/box_top_folder/file_data/11333818-b47e-5991-b32f-701975b2caca.json
+++ b/test/integration/connectors/expected_results/box_top_folder/file_data/11333818-b47e-5991-b32f-701975b2caca.json
@@ -44,6 +44,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": 142776
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/confluence_small/file_data/196720.json
+++ b/test/integration/connectors/expected_results/confluence_small/file_data/196720.json
@@ -42,6 +42,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/confluence_small/file_data/196722.json
+++ b/test/integration/connectors/expected_results/confluence_small/file_data/196722.json
@@ -42,6 +42,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/confluence_small/file_data/196752.json
+++ b/test/integration/connectors/expected_results/confluence_small/file_data/196752.json
@@ -42,6 +42,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/confluence_small/file_data/196760.json
+++ b/test/integration/connectors/expected_results/confluence_small/file_data/196760.json
@@ -42,6 +42,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/confluence_small/file_data/196766.json
+++ b/test/integration/connectors/expected_results/confluence_small/file_data/196766.json
@@ -42,6 +42,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/confluence_small/file_data/425986.json
+++ b/test/integration/connectors/expected_results/confluence_small/file_data/425986.json
@@ -42,6 +42,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/databricks_volumes_native/file_data/9a6eb650-98d6-5465-8f1d-aa7118eee87e.json
+++ b/test/integration/connectors/expected_results/databricks_volumes_native/file_data/9a6eb650-98d6-5465-8f1d-aa7118eee87e.json
@@ -14,6 +14,7 @@
     "date_modified": "1729186569000",
     "date_processed": null,
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/databricks_volumes_native_pat/file_data/9a6eb650-98d6-5465-8f1d-aa7118eee87e.json
+++ b/test/integration/connectors/expected_results/databricks_volumes_native_pat/file_data/9a6eb650-98d6-5465-8f1d-aa7118eee87e.json
@@ -14,6 +14,7 @@
     "date_modified": "1729186569000",
     "date_processed": null,
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/discord/file_data/1099442333440802930.json
+++ b/test/integration/connectors/expected_results/discord/file_data/1099442333440802930.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "2025-06-09T11:28:02.447816",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {},

--- a/test/integration/connectors/expected_results/discord/file_data/1099601456321003600.json
+++ b/test/integration/connectors/expected_results/discord/file_data/1099601456321003600.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "2025-06-09T11:28:05.482597",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {},

--- a/test/integration/connectors/expected_results/dropbox/file_data/00a08c10-1e52-5ade-8561-0819e1bdec38.json
+++ b/test/integration/connectors/expected_results/dropbox/file_data/00a08c10-1e52-5ade-8561-0819e1bdec38.json
@@ -18,6 +18,7 @@
     "date_modified": "1697625367.0",
     "date_processed": "1740750104.742579",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 1235192
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/dropbox/file_data/364c6697-4ed5-5976-88bf-c9c4dac07283.json
+++ b/test/integration/connectors/expected_results/dropbox/file_data/364c6697-4ed5-5976-88bf-c9c4dac07283.json
@@ -18,6 +18,7 @@
     "date_modified": "1697625366.0",
     "date_processed": "1740750098.8805876",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 6161
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/dropbox/file_data/8139a859-73b6-5442-866e-b5de0d81b6e6.json
+++ b/test/integration/connectors/expected_results/dropbox/file_data/8139a859-73b6-5442-866e-b5de0d81b6e6.json
@@ -18,6 +18,7 @@
     "date_modified": "1697625367.0",
     "date_processed": "1740750096.1792338",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 10308
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/dropbox/file_data/980b8fb3-5b3d-52e3-875f-147a162e16c3.json
+++ b/test/integration/connectors/expected_results/dropbox/file_data/980b8fb3-5b3d-52e3-875f-147a162e16c3.json
@@ -18,6 +18,7 @@
     "date_modified": "1697625366.0",
     "date_processed": "1740750102.082137",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 6161
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/73bd091b-f16a-5d30-b5bf-de62c85ccbe1.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/73bd091b-f16a-5d30-b5bf-de62c85ccbe1.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749474614.2889657",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-0.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-0.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.3109841",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-1.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-1.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.3112416",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-2.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-2.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.311481",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-3.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-3.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.3116956",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-4.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-4.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.3118968",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-5.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-5.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.312095",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-6.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-6.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.3123071",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-7.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-7.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.3125076",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-8.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-8.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.3127048",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/elasticsearch/file_data/movies-9.json
+++ b/test/integration/connectors/expected_results/elasticsearch/file_data/movies-9.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474614.3128998",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/file_data/25b75f1d-a2ea-4c97-b75f-1da2eadc97f7.csv.json
+++ b/test/integration/connectors/expected_results/file_data/25b75f1d-a2ea-4c97-b75f-1da2eadc97f7.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749467347.305853",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/file_data/43d02113-723f-5ec1-acbb-c8da8d3650dc.json
+++ b/test/integration/connectors/expected_results/file_data/43d02113-723f-5ec1-acbb-c8da8d3650dc.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749467346.9802878",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/file_data/60297eea-73d7-4fca-a97e-ea73d7cfca62.csv.json
+++ b/test/integration/connectors/expected_results/file_data/60297eea-73d7-4fca-a97e-ea73d7cfca62.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749467347.306548",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/file_data/641d99e3-9941-4c18-9d99-e399414c183d.csv.json
+++ b/test/integration/connectors/expected_results/file_data/641d99e3-9941-4c18-9d99-e399414c183d.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749467347.3060627",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/file_data/762c0093-2277-4f3e-ac00-932277af3e0e.csv.json
+++ b/test/integration/connectors/expected_results/file_data/762c0093-2277-4f3e-ac00-932277af3e0e.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749467347.3062322",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/file_data/ae40df94-0b3a-4f89-80df-940b3a6f8966.csv.json
+++ b/test/integration/connectors/expected_results/file_data/ae40df94-0b3a-4f89-80df-940b3a6f8966.csv.json
@@ -16,6 +16,7 @@
     "date_modified": null,
     "date_processed": "1749467347.3063884",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/github/file_data/7311a514-9924-571d-827e-db955b96320a.json
+++ b/test/integration/connectors/expected_results/github/file_data/7311a514-9924-571d-827e-db955b96320a.json
@@ -18,6 +18,7 @@
         "mode": "100644"
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": 1127
   },
   "additional_metadata": {},

--- a/test/integration/connectors/expected_results/github/file_data/7630c7f7-4d81-5ec0-b041-c94abc25e1ee.json
+++ b/test/integration/connectors/expected_results/github/file_data/7630c7f7-4d81-5ec0-b041-c94abc25e1ee.json
@@ -18,6 +18,7 @@
         "mode": "100644"
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": 3001
   },
   "additional_metadata": {},

--- a/test/integration/connectors/expected_results/google_drive/file_data/117qrVqiCoR5EjYMsDHGdy3UMkEtKr9Q8.json
+++ b/test/integration/connectors/expected_results/google_drive/file_data/117qrVqiCoR5EjYMsDHGdy3UMkEtKr9Q8.json
@@ -57,6 +57,7 @@
         "pendingOwner": false
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/google_drive/file_data/1SpQuE7jHz9nMt5hfQXsiok1SgIdRYX5o.json
+++ b/test/integration/connectors/expected_results/google_drive/file_data/1SpQuE7jHz9nMt5hfQXsiok1SgIdRYX5o.json
@@ -57,6 +57,7 @@
         "pendingOwner": false
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/google_drive/file_data/1m1TUgyLv0hHdlsuL7DOWBAKQtvrhWNiV.json
+++ b/test/integration/connectors/expected_results/google_drive/file_data/1m1TUgyLv0hHdlsuL7DOWBAKQtvrhWNiV.json
@@ -57,6 +57,7 @@
         "pendingOwner": false
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/google_drive/file_data/1yXGjX5j0MhKb01vfGRjNJqXyrHBnHxVo.json
+++ b/test/integration/connectors/expected_results/google_drive/file_data/1yXGjX5j0MhKb01vfGRjNJqXyrHBnHxVo.json
@@ -57,6 +57,7 @@
         "pendingOwner": false
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/google_drive_e2e/file_data/117qrVqiCoR5EjYMsDHGdy3UMkEtKr9Q8.json
+++ b/test/integration/connectors/expected_results/google_drive_e2e/file_data/117qrVqiCoR5EjYMsDHGdy3UMkEtKr9Q8.json
@@ -53,6 +53,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/google_drive_e2e/file_data/1SpQuE7jHz9nMt5hfQXsiok1SgIdRYX5o.json
+++ b/test/integration/connectors/expected_results/google_drive_e2e/file_data/1SpQuE7jHz9nMt5hfQXsiok1SgIdRYX5o.json
@@ -53,6 +53,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/google_drive_e2e/file_data/1m1TUgyLv0hHdlsuL7DOWBAKQtvrhWNiV.json
+++ b/test/integration/connectors/expected_results/google_drive_e2e/file_data/1m1TUgyLv0hHdlsuL7DOWBAKQtvrhWNiV.json
@@ -53,6 +53,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/google_drive_e2e/file_data/1yXGjX5j0MhKb01vfGRjNJqXyrHBnHxVo.json
+++ b/test/integration/connectors/expected_results/google_drive_e2e/file_data/1yXGjX5j0MhKb01vfGRjNJqXyrHBnHxVo.json
@@ -53,6 +53,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/google_drive_source/file_data/1r-RDeDtKprFQWST4PCIPV618y_sBL7N7EEWg7q4kZrU.json
+++ b/test/integration/connectors/expected_results/google_drive_source/file_data/1r-RDeDtKprFQWST4PCIPV618y_sBL7N7EEWg7q4kZrU.json
@@ -43,6 +43,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10000.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10000.json
@@ -26,6 +26,7 @@
     "date_modified": "2025-02-21T13:25:46.017+0000",
     "date_processed": "1751302527.99865",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10000a.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10000a.json
@@ -25,6 +25,7 @@
     "date_modified": "2025-02-21T13:25:46.017+0000",
     "date_processed": "1751302527.99865",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 516618
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10001.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10001.json
@@ -18,6 +18,7 @@
     "date_modified": "2023-08-24T12:03:31.591+0000",
     "date_processed": "1751302529.5262542",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10002.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10002.json
@@ -18,6 +18,7 @@
     "date_modified": "2023-08-23T14:36:31.252+0000",
     "date_processed": "1751302529.9340868",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10003.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10003.json
@@ -18,6 +18,7 @@
     "date_modified": "2023-09-29T05:55:11.447+0000",
     "date_processed": "1751302526.1978061",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10004.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10004.json
@@ -18,6 +18,7 @@
     "date_modified": "2023-09-29T05:55:11.351+0000",
     "date_processed": "1751302526.649159",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10005.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10005.json
@@ -18,6 +18,7 @@
     "date_modified": "2023-08-22T11:32:21.717+0000",
     "date_processed": "1751302527.04862",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10013.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10013.json
@@ -18,6 +18,7 @@
     "date_modified": "2023-08-24T12:04:47.543+0000",
     "date_processed": "1751302530.361567",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/jira/file_data/10014.json
+++ b/test/integration/connectors/expected_results/jira/file_data/10014.json
@@ -18,6 +18,7 @@
     "date_modified": "2023-08-24T13:39:02.055+0000",
     "date_processed": "1751302524.9207869",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_0.json
+++ b/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_0.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443113.609303",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_1.json
+++ b/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_1.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443113.650538",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_2.json
+++ b/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_2.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443113.690078",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_3.json
+++ b/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_3.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443113.721693",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_4.json
+++ b/test/integration/connectors/expected_results/kafka-cloud/file_data/fake-topic_0_4.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443113.760659",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_0.json
+++ b/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_0.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443134.787072",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_1.json
+++ b/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_1.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443134.796267",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_2.json
+++ b/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_2.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443134.798773",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_3.json
+++ b/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_3.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443134.800767",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_4.json
+++ b/test/integration/connectors/expected_results/kafka-local/file_data/fake-topic_0_4.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1734443134.802675",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/mongodb/file_data/172fdbf9-275b-5e38-82e6-4ec730d42460.json
+++ b/test/integration/connectors/expected_results/mongodb/file_data/172fdbf9-275b-5e38-82e6-4ec730d42460.json
@@ -13,6 +13,7 @@
     "date_modified": null,
     "date_processed": "1749474748.0297651",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/mongodb/file_data/659daefa21dd8c9054b084b6.json
+++ b/test/integration/connectors/expected_results/mongodb/file_data/659daefa21dd8c9054b084b6.json
@@ -18,6 +18,7 @@
     "date_modified": null,
     "date_processed": "1749474748.0297651",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/mongodb/file_data/659daefa21dd8c9054b084b7.json
+++ b/test/integration/connectors/expected_results/mongodb/file_data/659daefa21dd8c9054b084b7.json
@@ -18,6 +18,7 @@
     "date_modified": null,
     "date_processed": "1749474748.0297651",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/mongodb/file_data/659daefa21dd8c9054b084b8.json
+++ b/test/integration/connectors/expected_results/mongodb/file_data/659daefa21dd8c9054b084b8.json
@@ -18,6 +18,7 @@
     "date_modified": null,
     "date_processed": "1749474748.0297651",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/mongodb/file_data/659daefa21dd8c9054b084b9.json
+++ b/test/integration/connectors/expected_results/mongodb/file_data/659daefa21dd8c9054b084b9.json
@@ -18,6 +18,7 @@
     "date_modified": null,
     "date_processed": "1749474748.0297651",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/notion_database/file_data/1722c3765a0a8082b382ebc2c62d3f4c.json
+++ b/test/integration/connectors/expected_results/notion_database/file_data/1722c3765a0a8082b382ebc2c62d3f4c.json
@@ -16,6 +16,7 @@
     "date_modified": "2025-04-25T13:45:00.000Z",
     "date_processed": "1776015867.182077",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/notion_page/file_data/1572c3765a0a806299f0dd6999f9e4c7.json
+++ b/test/integration/connectors/expected_results/notion_page/file_data/1572c3765a0a806299f0dd6999f9e4c7.json
@@ -16,6 +16,7 @@
     "date_modified": "2025-01-07T19:24:00.000Z",
     "date_processed": "1776015869.7829351",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/onedrive/file_data/01FKMPQP5P3IF7RTMOW5EZPDJGEBVUREKR.json
+++ b/test/integration/connectors/expected_results/onedrive/file_data/01FKMPQP5P3IF7RTMOW5EZPDJGEBVUREKR.json
@@ -17,6 +17,7 @@
     "date_modified": "1738191393.0",
     "date_processed": "1749467372.213391",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/73bd091b-f16a-5d30-b5bf-de62c85ccbe1.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/73bd091b-f16a-5d30-b5bf-de62c85ccbe1.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7270613",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-0.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-0.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7823493",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-1.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-1.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.782552",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-2.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-2.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7827108",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-3.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-3.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7828617",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-4.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-4.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7830107",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-5.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-5.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7831542",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-6.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-6.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7833216",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-7.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-7.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7834716",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-8.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-8.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.783613",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/opensearch/file_data/movies-9.json
+++ b/test/integration/connectors/expected_results/opensearch/file_data/movies-9.json
@@ -20,6 +20,7 @@
     "date_modified": null,
     "date_processed": "1749474698.7837527",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/1c704234-e0da-5676-be32-a12cc6407b3d.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/1c704234-e0da-5676-be32-a12cc6407b3d.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4465034",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/324354db-0465-56ca-a023-072481f5dd03.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/324354db-0465-56ca-a023-072481f5dd03.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4308963",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-1-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-1-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4308963",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-10-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-10-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4465034",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-2-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-2-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4308963",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-3-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-3-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4308963",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-4-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-4-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4308963",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-5-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-5-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4308963",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-6-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-6-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4308963",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-7-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-7-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4465034",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-8-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-8-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4465034",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/postgres/file_data/cars-9-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/postgres/file_data/cars-9-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467370.4465034",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/s3-minio/file_data/61ec39a6-5088-5edd-abd2-6c36aa996068.json
+++ b/test/integration/connectors/expected_results/s3-minio/file_data/61ec39a6-5088-5edd-abd2-6c36aa996068.json
@@ -17,6 +17,7 @@
     "date_modified": "1734441655.218",
     "date_processed": "1734441655.777463",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 19610
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/s3-specialchar/file_data/869bf15f-e840-51dc-a818-8d0b817817c9.json
+++ b/test/integration/connectors/expected_results/s3-specialchar/file_data/869bf15f-e840-51dc-a818-8d0b817817c9.json
@@ -17,6 +17,7 @@
     "date_modified": "1731627148.0",
     "date_processed": "1750862131.7378173",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 14
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/s3-specialchar/file_data/e2cb44ab-2f1a-5037-901d-a284371047bb.json
+++ b/test/integration/connectors/expected_results/s3-specialchar/file_data/e2cb44ab-2f1a-5037-901d-a284371047bb.json
@@ -17,6 +17,7 @@
     "date_modified": "1750861154.0",
     "date_processed": "1750862132.0641234",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 47
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/s3/file_data/4b30fb79-f071-557e-9357-ca8af7295ab2.json
+++ b/test/integration/connectors/expected_results/s3/file_data/4b30fb79-f071-557e-9357-ca8af7295ab2.json
@@ -17,6 +17,7 @@
     "date_modified": "1676196572.0",
     "date_processed": "1734441638.170231",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 806335
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/s3/file_data/6375773c-0da2-5b4a-a337-ef63f6f96d94.json
+++ b/test/integration/connectors/expected_results/s3/file_data/6375773c-0da2-5b4a-a337-ef63f6f96d94.json
@@ -17,6 +17,7 @@
     "date_modified": "1676196636.0",
     "date_processed": "1734441636.945536",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 6164777
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/s3/file_data/bc4d433b-6e7b-5512-bb38-a2048b338e68.json
+++ b/test/integration/connectors/expected_results/s3/file_data/bc4d433b-6e7b-5512-bb38-a2048b338e68.json
@@ -17,6 +17,7 @@
     "date_modified": "1697584841.0",
     "date_processed": "1734441638.0059168",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 138124
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/s3/file_data/ed83cc0e-d390-5018-bb74-bc4e2e46a206.json
+++ b/test/integration/connectors/expected_results/s3/file_data/ed83cc0e-d390-5018-bb74-bc4e2e46a206.json
@@ -20,6 +20,7 @@
     "date_modified": "1720544414.0",
     "date_processed": "1734441636.53835",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": 2215938
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint/file_data/01QKP26QZL5KBVQTQ3IRDYF72MRH2QKKR3.json
+++ b/test/integration/connectors/expected_results/sharepoint/file_data/01QKP26QZL5KBVQTQ3IRDYF72MRH2QKKR3.json
@@ -17,6 +17,7 @@
     "date_modified": "1738129296.0",
     "date_processed": "1739549929.526217",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ.json
+++ b/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG.json
+++ b/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
+++ b/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
+++ b/test/integration/connectors/expected_results/sharepoint1/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint2/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
+++ b/test/integration/connectors/expected_results/sharepoint2/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint2/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
+++ b/test/integration/connectors/expected_results/sharepoint2/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint3/file_data/01QKP26Q7PST2HZ7PAXFBYQ5G2QF2NLSPN.json
+++ b/test/integration/connectors/expected_results/sharepoint3/file_data/01QKP26Q7PST2HZ7PAXFBYQ5G2QF2NLSPN.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint3/file_data/01QKP26QZL5KBVQTQ3IRDYF72MRH2QKKR3.json
+++ b/test/integration/connectors/expected_results/sharepoint3/file_data/01QKP26QZL5KBVQTQ3IRDYF72MRH2QKKR3.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ.json
+++ b/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSABDC6JJIUHKJF2C5ZFGJF3C6XJ.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG.json
+++ b/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSAVBNSXPKVIBZC3ZD53KENINVGG.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
+++ b/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSEXY3G5U3B5GBFY7TZKAY236XAL.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
+++ b/test/integration/connectors/expected_results/sharepoint4/file_data/0153RHRSFFVW43WTVG5ZFY5WL7ZH3GUOGT.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSBCDXFGQVNK6NCZOQZY3CZ2CCI2.json
+++ b/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSBCDXFGQVNK6NCZOQZY3CZ2CCI2.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C.json
+++ b/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSFPJTHUKBK7AFEJO3WOAEA3RC7D.json
+++ b/test/integration/connectors/expected_results/sharepoint5/file_data/0153RHRSFPJTHUKBK7AFEJO3WOAEA3RC7D.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sharepoint6/file_data/0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C.json
+++ b/test/integration/connectors/expected_results/sharepoint6/file_data/0153RHRSD4LQFV3VWQRZCY3E724WTG5G6C.json
@@ -48,6 +48,7 @@
         }
       }
     ],
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/1c704234-e0da-5676-be32-a12cc6407b3d.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/1c704234-e0da-5676-be32-a12cc6407b3d.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749467428.9559476",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/324354db-0465-56ca-a023-072481f5dd03.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/324354db-0465-56ca-a023-072481f5dd03.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749467428.8552265",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-1-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-1-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.8552265",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-10-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-10-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.9559476",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-2-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-2-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.8552265",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-3-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-3-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.8552265",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-4-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-4-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.8552265",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-5-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-5-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.8552265",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-6-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-6-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.8552265",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-7-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-7-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.9559476",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-8-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-8-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.9559476",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/singlestore/file_data/cars-9-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/singlestore/file_data/cars-9-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467428.9559476",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-1-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-1-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697905.791383",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-10-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-10-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.25373",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-11-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-11-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.7148118",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-12-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-12-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.7148118",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-13-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-13-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.7148118",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-14-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-14-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.7148118",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-15-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-15-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.7148118",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-16-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-16-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697907.162648",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-17-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-17-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697907.162648",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-18-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-18-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697907.162648",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-19-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-19-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697907.162648",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-2-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-2-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697905.791383",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-20-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-20-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697907.162648",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-3-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-3-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697905.791383",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-4-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-4-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697905.791383",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-5-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-5-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697905.791383",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-6-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-6-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.25373",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-7-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-7-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.25373",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-8-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-8-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.25373",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/snowflake/file_data/cars-9-a2ccd8ea.json
+++ b/test/integration/connectors/expected_results/snowflake/file_data/cars-9-a2ccd8ea.json
@@ -11,6 +11,7 @@
     "date_modified": null,
     "date_processed": "1729697906.25373",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/1c704234-e0da-5676-be32-a12cc6407b3d.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/1c704234-e0da-5676-be32-a12cc6407b3d.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9711626",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/324354db-0465-56ca-a023-072481f5dd03.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/324354db-0465-56ca-a023-072481f5dd03.json
@@ -10,6 +10,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9652185",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-1-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-1-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9652185",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-10-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-10-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9711626",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-2-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-2-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9652185",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-3-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-3-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9652185",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-4-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-4-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9652185",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-5-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-5-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9652185",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-6-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-6-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9652185",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-7-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-7-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9711626",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-8-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-8-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9711626",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/sqlite/file_data/cars-9-5fb93ce5.json
+++ b/test/integration/connectors/expected_results/sqlite/file_data/cars-9-5fb93ce5.json
@@ -14,6 +14,7 @@
     "date_modified": null,
     "date_processed": "1749467484.9711626",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/zendesk-articles/file_data/34257293234331.json
+++ b/test/integration/connectors/expected_results/zendesk-articles/file_data/34257293234331.json
@@ -14,6 +14,7 @@
     "date_modified": "2025-02-21T16:20:22+00:00",
     "date_processed": "1749468799.7933412",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323898267.json
+++ b/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323898267.json
@@ -14,6 +14,7 @@
     "date_modified": "2025-02-21T16:20:22+00:00",
     "date_processed": "1749468799.7922013",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323910555.json
+++ b/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323910555.json
@@ -14,6 +14,7 @@
     "date_modified": "2025-02-21T16:20:22+00:00",
     "date_processed": "1749468799.790897",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323933467.json
+++ b/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323933467.json
@@ -14,6 +14,7 @@
     "date_modified": "2025-02-21T16:20:22+00:00",
     "date_processed": "1749468799.7898233",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323948187.json
+++ b/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323948187.json
@@ -14,6 +14,7 @@
     "date_modified": "2025-02-21T16:20:22+00:00",
     "date_processed": "1749468799.788721",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323962779.json
+++ b/test/integration/connectors/expected_results/zendesk-articles/file_data/34257323962779.json
@@ -14,6 +14,7 @@
     "date_modified": "2025-02-21T16:20:22+00:00",
     "date_processed": "1749468799.7875247",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/zendesk-articles/file_data/34257441305499.json
+++ b/test/integration/connectors/expected_results/zendesk-articles/file_data/34257441305499.json
@@ -14,6 +14,7 @@
     "date_modified": "2025-02-21T16:44:55+00:00",
     "date_processed": "1749468799.7859802",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test/integration/connectors/expected_results/zendesk-articles/file_data/34257467168795.json
+++ b/test/integration/connectors/expected_results/zendesk-articles/file_data/34257467168795.json
@@ -14,6 +14,7 @@
     "date_modified": "2025-02-21T16:44:56+00:00",
     "date_processed": "1749468799.781138",
     "permissions_data": null,
+    "denied_permissions_data": null,
     "filesize_bytes": null
   },
   "additional_metadata": {

--- a/test_e2e/expected-structured-output/Sharepoint/Document.docx.json
+++ b/test_e2e/expected-structured-output/Sharepoint/Document.docx.json
@@ -25,6 +25,7 @@
         "date_created": "1719424686.0",
         "date_modified": "1726516830.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 21614
       }
     }

--- a/test_e2e/expected-structured-output/Sharepoint/SitePages/This-is-a-title.aspx.json
+++ b/test_e2e/expected-structured-output/Sharepoint/SitePages/This-is-a-title.aspx.json
@@ -20,6 +20,7 @@
         "date_created": null,
         "date_modified": "1690787017.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1452
       }
     }
@@ -45,6 +46,7 @@
         "date_created": null,
         "date_modified": "1690787017.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1452
       }
     }
@@ -70,6 +72,7 @@
         "date_created": null,
         "date_modified": "1690787017.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1452
       }
     }
@@ -95,6 +98,7 @@
         "date_created": null,
         "date_modified": "1690787017.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1452
       }
     }

--- a/test_e2e/expected-structured-output/Sharepoint/fake-text.txt.json
+++ b/test_e2e/expected-structured-output/Sharepoint/fake-text.txt.json
@@ -19,6 +19,7 @@
         "date_created": "1686891895.0",
         "date_modified": "1686891895.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -43,6 +44,7 @@
         "date_created": "1686891895.0",
         "date_modified": "1686891895.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -67,6 +69,7 @@
         "date_created": "1686891895.0",
         "date_modified": "1686891895.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -91,6 +94,7 @@
         "date_created": "1686891895.0",
         "date_modified": "1686891895.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -115,6 +119,7 @@
         "date_created": "1686891895.0",
         "date_modified": "1686891895.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -139,6 +144,7 @@
         "date_created": "1686891895.0",
         "date_modified": "1686891895.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }

--- a/test_e2e/expected-structured-output/Sharepoint/ideas-page.html.json
+++ b/test_e2e/expected-structured-output/Sharepoint/ideas-page.html.json
@@ -20,6 +20,7 @@
         "date_created": "1686891887.0",
         "date_modified": "1686891887.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6161
       }
     }

--- a/test_e2e/expected-structured-output/Sharepoint/nested/2023-Jan-economic-outlook.pdf.json
+++ b/test_e2e/expected-structured-output/Sharepoint/nested/2023-Jan-economic-outlook.pdf.json
@@ -20,6 +20,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -45,6 +46,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -70,6 +72,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -95,6 +98,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -120,6 +124,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -145,6 +150,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -170,6 +176,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -195,6 +202,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -220,6 +228,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -245,6 +254,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -270,6 +280,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -295,6 +306,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -320,6 +332,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -345,6 +358,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -370,6 +384,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -395,6 +410,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -420,6 +436,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -445,6 +462,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -470,6 +488,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -495,6 +514,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -520,6 +540,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -545,6 +566,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -570,6 +592,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -595,6 +618,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -620,6 +644,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -645,6 +670,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -670,6 +696,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -695,6 +722,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -720,6 +748,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -745,6 +774,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -770,6 +800,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -795,6 +826,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -820,6 +852,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -845,6 +878,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -870,6 +904,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -895,6 +930,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -920,6 +956,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -945,6 +982,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -970,6 +1008,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -995,6 +1034,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1020,6 +1060,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1045,6 +1086,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1070,6 +1112,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1095,6 +1138,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1120,6 +1164,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1145,6 +1190,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1170,6 +1216,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1195,6 +1242,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1220,6 +1268,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1245,6 +1294,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1270,6 +1320,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1295,6 +1346,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1320,6 +1372,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1345,6 +1398,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1371,6 +1425,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1396,6 +1451,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1421,6 +1477,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1446,6 +1503,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1471,6 +1529,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1496,6 +1555,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1521,6 +1581,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1546,6 +1607,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1571,6 +1633,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1596,6 +1659,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1621,6 +1685,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1646,6 +1711,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1671,6 +1737,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1696,6 +1763,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1721,6 +1789,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1746,6 +1815,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1771,6 +1841,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1796,6 +1867,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1821,6 +1893,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1846,6 +1919,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1871,6 +1945,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1896,6 +1971,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1921,6 +1997,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1946,6 +2023,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1971,6 +2049,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1996,6 +2075,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2021,6 +2101,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2046,6 +2127,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2071,6 +2153,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2096,6 +2179,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2121,6 +2205,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2146,6 +2231,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2171,6 +2257,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2196,6 +2283,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2221,6 +2309,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2246,6 +2335,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2271,6 +2361,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2296,6 +2387,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2321,6 +2413,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2346,6 +2439,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2371,6 +2465,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2396,6 +2491,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2421,6 +2517,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2446,6 +2543,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2471,6 +2569,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2496,6 +2595,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2521,6 +2621,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2546,6 +2647,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2571,6 +2673,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2596,6 +2699,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2621,6 +2725,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2646,6 +2751,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2671,6 +2777,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2696,6 +2803,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2721,6 +2829,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2746,6 +2855,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2771,6 +2881,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2796,6 +2907,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2821,6 +2933,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2846,6 +2959,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2871,6 +2985,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2896,6 +3011,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2921,6 +3037,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2946,6 +3063,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2971,6 +3089,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2996,6 +3115,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3021,6 +3141,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3046,6 +3167,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3071,6 +3193,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3096,6 +3219,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3121,6 +3245,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3146,6 +3271,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3171,6 +3297,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3196,6 +3323,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3221,6 +3349,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3246,6 +3375,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3271,6 +3401,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3296,6 +3427,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3321,6 +3453,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3346,6 +3479,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3371,6 +3505,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3396,6 +3531,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3421,6 +3557,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3446,6 +3583,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3471,6 +3609,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3496,6 +3635,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3521,6 +3661,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3546,6 +3687,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3571,6 +3713,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3596,6 +3739,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3621,6 +3765,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3646,6 +3791,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3671,6 +3817,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3696,6 +3843,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3721,6 +3869,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3746,6 +3895,7 @@
         "date_created": "1719424775.0",
         "date_modified": "1719424775.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }

--- a/test_e2e/expected-structured-output/Sharepoint/nested/page-with-formula.pdf.json
+++ b/test_e2e/expected-structured-output/Sharepoint/nested/page-with-formula.pdf.json
@@ -20,6 +20,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -45,6 +46,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -70,6 +72,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -95,6 +98,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -120,6 +124,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -145,6 +150,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -170,6 +176,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -195,6 +202,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -220,6 +228,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -245,6 +254,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -270,6 +280,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -295,6 +306,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -320,6 +332,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -345,6 +358,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -370,6 +384,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -395,6 +410,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -420,6 +436,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -445,6 +462,7 @@
         "date_created": "1719424780.0",
         "date_modified": "1719424780.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }

--- a/test_e2e/expected-structured-output/Sharepoint/permissions-fake-text.docx.json
+++ b/test_e2e/expected-structured-output/Sharepoint/permissions-fake-text.docx.json
@@ -19,6 +19,7 @@
         "date_created": "1698404784.0",
         "date_modified": "1698404854.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 20054
       }
     }
@@ -43,6 +44,7 @@
         "date_created": "1698404784.0",
         "date_modified": "1698404854.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 20054
       }
     }
@@ -67,6 +69,7 @@
         "date_created": "1698404784.0",
         "date_modified": "1698404854.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 20054
       }
     }
@@ -91,6 +94,7 @@
         "date_created": "1698404784.0",
         "date_modified": "1698404854.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 20054
       }
     }
@@ -115,6 +119,7 @@
         "date_created": "1698404784.0",
         "date_modified": "1698404854.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 20054
       }
     }
@@ -139,6 +144,7 @@
         "date_created": "1698404784.0",
         "date_modified": "1698404854.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 20054
       }
     }

--- a/test_e2e/expected-structured-output/Sharepoint/stanley-cups.xlsx.json
+++ b/test_e2e/expected-structured-output/Sharepoint/stanley-cups.xlsx.json
@@ -21,6 +21,7 @@
         "date_created": "1686891905.0",
         "date_modified": "1686891905.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 15538
       }
     }
@@ -48,6 +49,7 @@
         "date_created": "1686891905.0",
         "date_modified": "1686891905.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 15538
       }
     }
@@ -74,6 +76,7 @@
         "date_created": "1686891905.0",
         "date_modified": "1686891905.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 15538
       }
     }
@@ -101,6 +104,7 @@
         "date_created": "1686891905.0",
         "date_modified": "1686891905.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 15538
       }
     }

--- a/test_e2e/expected-structured-output/astradb/25b75f1d-a2ea-4c97-b75f-1da2eadc97f7.csv.json
+++ b/test_e2e/expected-structured-output/astradb/25b75f1d-a2ea-4c97-b75f-1da2eadc97f7.csv.json
@@ -18,6 +18,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 326
       }
     }

--- a/test_e2e/expected-structured-output/astradb/60297eea-73d7-4fca-a97e-ea73d7cfca62.csv.json
+++ b/test_e2e/expected-structured-output/astradb/60297eea-73d7-4fca-a97e-ea73d7cfca62.csv.json
@@ -18,6 +18,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 442
       }
     }

--- a/test_e2e/expected-structured-output/astradb/641d99e3-9941-4c18-9d99-e399414c183d.csv.json
+++ b/test_e2e/expected-structured-output/astradb/641d99e3-9941-4c18-9d99-e399414c183d.csv.json
@@ -18,6 +18,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 338
       }
     }

--- a/test_e2e/expected-structured-output/astradb/762c0093-2277-4f3e-ac00-932277af3e0e.csv.json
+++ b/test_e2e/expected-structured-output/astradb/762c0093-2277-4f3e-ac00-932277af3e0e.csv.json
@@ -18,6 +18,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 341
       }
     }

--- a/test_e2e/expected-structured-output/astradb/ae40df94-0b3a-4f89-80df-940b3a6f8966.csv.json
+++ b/test_e2e/expected-structured-output/astradb/ae40df94-0b3a-4f89-80df-940b3a6f8966.csv.json
@@ -18,6 +18,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 241
       }
     }

--- a/test_e2e/expected-structured-output/azure/Core-Skills-for-Biomedical-Data-Scientists-2-pages.pdf.json
+++ b/test_e2e/expected-structured-output/azure/Core-Skills-for-Biomedical-Data-Scientists-2-pages.pdf.json
@@ -20,6 +20,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -45,6 +46,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -70,6 +72,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -95,6 +98,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -120,6 +124,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -145,6 +150,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -170,6 +176,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -195,6 +202,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -220,6 +228,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -245,6 +254,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -270,6 +280,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -295,6 +306,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -320,6 +332,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -345,6 +358,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -370,6 +384,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -395,6 +410,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -420,6 +436,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -445,6 +462,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -470,6 +488,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -495,6 +514,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -520,6 +540,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -545,6 +566,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -570,6 +592,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -595,6 +618,7 @@
         "date_created": "1678440764.0",
         "date_modified": "1678440764.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }

--- a/test_e2e/expected-structured-output/azure/IRS-form-1987.pdf.json
+++ b/test_e2e/expected-structured-output/azure/IRS-form-1987.pdf.json
@@ -19,6 +19,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -43,6 +44,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -67,6 +69,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -91,6 +94,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -115,6 +119,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -139,6 +144,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -163,6 +169,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -187,6 +194,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -211,6 +219,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -235,6 +244,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -259,6 +269,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -283,6 +294,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -307,6 +319,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -331,6 +344,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -355,6 +369,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -379,6 +394,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -403,6 +419,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -427,6 +444,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -451,6 +469,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -475,6 +494,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -499,6 +519,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -523,6 +544,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -547,6 +569,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -571,6 +594,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -595,6 +619,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -619,6 +644,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -643,6 +669,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -667,6 +694,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -691,6 +719,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -715,6 +744,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -739,6 +769,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -763,6 +794,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -787,6 +819,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -811,6 +844,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -835,6 +869,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -859,6 +894,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -883,6 +919,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -907,6 +944,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -931,6 +969,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -955,6 +994,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -979,6 +1019,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1003,6 +1044,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1027,6 +1069,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1051,6 +1094,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1075,6 +1119,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1099,6 +1144,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1123,6 +1169,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1147,6 +1194,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1171,6 +1219,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1195,6 +1244,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1219,6 +1269,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1243,6 +1294,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1267,6 +1319,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1291,6 +1344,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1315,6 +1369,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1339,6 +1394,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1363,6 +1419,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1387,6 +1444,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1411,6 +1469,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1435,6 +1494,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1459,6 +1519,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1483,6 +1544,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1507,6 +1569,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1531,6 +1594,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1555,6 +1619,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1579,6 +1644,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1603,6 +1669,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1627,6 +1694,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1651,6 +1719,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1675,6 +1744,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1699,6 +1769,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1723,6 +1794,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1747,6 +1819,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1771,6 +1844,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1795,6 +1869,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1819,6 +1894,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1843,6 +1919,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1867,6 +1944,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1891,6 +1969,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1915,6 +1994,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1939,6 +2019,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1963,6 +2044,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -1987,6 +2069,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }
@@ -2011,6 +2094,7 @@
         "date_created": "1678440990.0",
         "date_modified": "1678440990.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 312030
       }
     }

--- a/test_e2e/expected-structured-output/azure/IRS-form-1987.png.json
+++ b/test_e2e/expected-structured-output/azure/IRS-form-1987.png.json
@@ -19,6 +19,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -43,6 +44,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -67,6 +69,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -91,6 +94,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -115,6 +119,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -139,6 +144,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -163,6 +169,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -187,6 +194,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -211,6 +219,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -235,6 +244,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -259,6 +269,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -283,6 +294,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -307,6 +319,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -331,6 +344,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -355,6 +369,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -379,6 +394,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -403,6 +419,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -427,6 +444,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -451,6 +469,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -475,6 +494,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -499,6 +519,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -523,6 +544,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -547,6 +569,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -571,6 +594,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -595,6 +619,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -619,6 +644,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -643,6 +669,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -667,6 +694,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -691,6 +719,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -715,6 +744,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -739,6 +769,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -763,6 +794,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -787,6 +819,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -811,6 +844,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -835,6 +869,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -859,6 +894,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -883,6 +919,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -907,6 +944,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -931,6 +969,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -955,6 +994,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -979,6 +1019,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -1003,6 +1044,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }
@@ -1027,6 +1069,7 @@
         "date_created": "1678441495.0",
         "date_modified": "1678441495.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712624
       }
     }

--- a/test_e2e/expected-structured-output/azure/rfc854.txt.json
+++ b/test_e2e/expected-structured-output/azure/rfc854.txt.json
@@ -18,6 +18,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -41,6 +42,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -64,6 +66,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -87,6 +90,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -110,6 +114,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -133,6 +138,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -156,6 +162,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -179,6 +186,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -202,6 +210,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -225,6 +234,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -248,6 +258,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -271,6 +282,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -294,6 +306,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -317,6 +330,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -340,6 +354,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -363,6 +378,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -386,6 +402,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -409,6 +426,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -432,6 +450,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -455,6 +474,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -478,6 +498,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -501,6 +522,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -524,6 +546,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -547,6 +570,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -570,6 +594,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -593,6 +618,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -616,6 +642,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -639,6 +666,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -662,6 +690,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -685,6 +714,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -708,6 +738,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -731,6 +762,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -754,6 +786,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -777,6 +810,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -800,6 +834,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -823,6 +858,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -846,6 +882,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -869,6 +906,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -892,6 +930,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -915,6 +954,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -938,6 +978,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -961,6 +1002,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -984,6 +1026,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1007,6 +1050,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1030,6 +1074,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1053,6 +1098,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1076,6 +1122,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1099,6 +1146,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1122,6 +1170,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1145,6 +1194,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1168,6 +1218,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1191,6 +1242,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1214,6 +1266,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1237,6 +1290,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1260,6 +1314,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1283,6 +1338,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1306,6 +1362,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1329,6 +1386,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1352,6 +1410,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1375,6 +1434,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1398,6 +1458,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1421,6 +1482,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1444,6 +1506,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1467,6 +1530,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1490,6 +1554,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1513,6 +1578,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1536,6 +1602,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1559,6 +1626,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1582,6 +1650,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1605,6 +1674,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1628,6 +1698,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1651,6 +1722,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1674,6 +1746,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1697,6 +1770,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1720,6 +1794,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1743,6 +1818,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1766,6 +1842,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1789,6 +1866,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1812,6 +1890,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1835,6 +1914,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1858,6 +1938,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1881,6 +1962,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1904,6 +1986,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1927,6 +2010,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1950,6 +2034,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1973,6 +2058,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -1996,6 +2082,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2019,6 +2106,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2042,6 +2130,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2065,6 +2154,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2088,6 +2178,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2111,6 +2202,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2134,6 +2226,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2157,6 +2250,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2180,6 +2274,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2203,6 +2298,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2226,6 +2322,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2249,6 +2346,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2272,6 +2370,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2295,6 +2394,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2318,6 +2418,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2341,6 +2442,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2364,6 +2466,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2387,6 +2490,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2410,6 +2514,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2433,6 +2538,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2456,6 +2562,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2479,6 +2586,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2502,6 +2610,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2525,6 +2634,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2548,6 +2658,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2571,6 +2682,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2594,6 +2706,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2617,6 +2730,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2640,6 +2754,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2663,6 +2778,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2686,6 +2802,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2709,6 +2826,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2732,6 +2850,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2755,6 +2874,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2778,6 +2898,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2801,6 +2922,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2824,6 +2946,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2847,6 +2970,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2870,6 +2994,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2893,6 +3018,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2916,6 +3042,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2939,6 +3066,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2962,6 +3090,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -2985,6 +3114,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3008,6 +3138,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3031,6 +3162,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3054,6 +3186,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3077,6 +3210,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3100,6 +3234,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3123,6 +3258,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3146,6 +3282,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3169,6 +3306,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3192,6 +3330,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }
@@ -3215,6 +3354,7 @@
         "date_created": "1678442150.0",
         "date_modified": "1678442150.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 38517
       }
     }

--- a/test_e2e/expected-structured-output/azure/spring-weather.html.json
+++ b/test_e2e/expected-structured-output/azure/spring-weather.html.json
@@ -25,6 +25,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -55,6 +56,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -78,6 +80,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -101,6 +104,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -124,6 +128,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -155,6 +160,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -184,6 +190,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -213,6 +220,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -242,6 +250,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -271,6 +280,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -300,6 +310,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -329,6 +340,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -358,6 +370,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -387,6 +400,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -416,6 +430,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -445,6 +460,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -474,6 +490,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -503,6 +520,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -532,6 +550,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -561,6 +580,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -590,6 +610,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -619,6 +640,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -648,6 +670,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -677,6 +700,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -706,6 +730,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -735,6 +760,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -764,6 +790,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -793,6 +820,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -822,6 +850,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -851,6 +880,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -880,6 +910,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -909,6 +940,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -938,6 +970,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -967,6 +1000,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -996,6 +1030,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1025,6 +1060,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1054,6 +1090,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1083,6 +1120,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1112,6 +1150,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1141,6 +1180,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1170,6 +1210,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1199,6 +1240,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1228,6 +1270,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1257,6 +1300,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1286,6 +1330,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1315,6 +1360,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1344,6 +1390,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1373,6 +1420,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1402,6 +1450,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1431,6 +1480,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1460,6 +1510,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1489,6 +1540,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1518,6 +1570,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1547,6 +1600,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1576,6 +1630,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1605,6 +1660,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1634,6 +1690,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1663,6 +1720,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1692,6 +1750,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1721,6 +1780,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1750,6 +1810,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1779,6 +1840,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1808,6 +1870,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1837,6 +1900,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1866,6 +1930,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1895,6 +1960,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1924,6 +1990,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1953,6 +2020,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -1982,6 +2050,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2011,6 +2080,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2040,6 +2110,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2069,6 +2140,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2098,6 +2170,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2127,6 +2200,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2156,6 +2230,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2185,6 +2260,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2214,6 +2290,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2243,6 +2320,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2272,6 +2350,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2301,6 +2380,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2330,6 +2410,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2359,6 +2440,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2388,6 +2470,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2417,6 +2500,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2446,6 +2530,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2469,6 +2554,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2492,6 +2578,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2521,6 +2608,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2556,6 +2644,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2585,6 +2674,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2608,6 +2698,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2632,6 +2723,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2662,6 +2754,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2697,6 +2790,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2732,6 +2826,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }
@@ -2767,6 +2862,7 @@
         "date_created": "1678441216.0",
         "date_modified": "1678441216.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 24052
       }
     }

--- a/test_e2e/expected-structured-output/box/handbook-1p.docx.json
+++ b/test_e2e/expected-structured-output/box/handbook-1p.docx.json
@@ -20,6 +20,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -50,6 +51,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -80,6 +82,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -104,6 +107,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -128,6 +132,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -152,6 +157,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -176,6 +182,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -200,6 +207,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -224,6 +232,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -248,6 +257,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -272,6 +282,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -296,6 +307,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -320,6 +332,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -344,6 +357,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -369,6 +383,7 @@
         "date_created": "1688874451.0",
         "date_modified": "1688874451.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }

--- a/test_e2e/expected-structured-output/box/nested-1/ideas-page.html.json
+++ b/test_e2e/expected-structured-output/box/nested-1/ideas-page.html.json
@@ -20,6 +20,7 @@
         "date_created": "1688874401.0",
         "date_modified": "1688874401.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6161
       }
     }

--- a/test_e2e/expected-structured-output/box/nested-1/nested-2/ideas-page.html.json
+++ b/test_e2e/expected-structured-output/box/nested-1/nested-2/ideas-page.html.json
@@ -20,6 +20,7 @@
         "date_created": "1688874389.0",
         "date_modified": "1688874389.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6161
       }
     }

--- a/test_e2e/expected-structured-output/box/science-exploration-1p.pptx.json
+++ b/test_e2e/expected-structured-output/box/science-exploration-1p.pptx.json
@@ -20,6 +20,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -45,6 +46,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -70,6 +72,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -95,6 +98,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -120,6 +124,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -145,6 +150,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -170,6 +176,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -195,6 +202,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -220,6 +228,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -245,6 +254,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -270,6 +280,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -295,6 +306,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -320,6 +332,7 @@
         "date_created": "1688874428.0",
         "date_modified": "1688874428.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }

--- a/test_e2e/expected-structured-output/couchbase/unstructured-10748.txt.json
+++ b/test_e2e/expected-structured-output/couchbase/unstructured-10748.txt.json
@@ -22,6 +22,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -49,6 +50,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -76,6 +78,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -103,6 +106,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -130,6 +134,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -157,6 +162,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -184,6 +190,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -211,6 +218,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -238,6 +246,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }
@@ -265,6 +274,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 80
       }
     }

--- a/test_e2e/expected-structured-output/couchbase/unstructured-1543.txt.json
+++ b/test_e2e/expected-structured-output/couchbase/unstructured-1543.txt.json
@@ -22,6 +22,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -49,6 +50,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -76,6 +78,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -103,6 +106,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -130,6 +134,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -157,6 +162,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -184,6 +190,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -211,6 +218,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -238,6 +246,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }
@@ -265,6 +274,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 103
       }
     }

--- a/test_e2e/expected-structured-output/couchbase/unstructured-16264.txt.json
+++ b/test_e2e/expected-structured-output/couchbase/unstructured-16264.txt.json
@@ -22,6 +22,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -49,6 +50,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -76,6 +78,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -103,6 +106,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -130,6 +134,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -157,6 +162,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -184,6 +190,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -211,6 +218,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -238,6 +246,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }
@@ -265,6 +274,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 85
       }
     }

--- a/test_e2e/expected-structured-output/couchbase/unstructured-1739.txt.json
+++ b/test_e2e/expected-structured-output/couchbase/unstructured-1739.txt.json
@@ -22,6 +22,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -49,6 +50,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -76,6 +78,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -103,6 +106,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -130,6 +134,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -157,6 +162,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -184,6 +190,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -211,6 +218,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -238,6 +246,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }
@@ -265,6 +274,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 95
       }
     }

--- a/test_e2e/expected-structured-output/couchbase/unstructured-3494.txt.json
+++ b/test_e2e/expected-structured-output/couchbase/unstructured-3494.txt.json
@@ -22,6 +22,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -49,6 +50,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -76,6 +78,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -103,6 +106,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -130,6 +134,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -157,6 +162,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -184,6 +190,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -211,6 +218,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -238,6 +246,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }
@@ -265,6 +274,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 87
       }
     }

--- a/test_e2e/expected-structured-output/discord/1099442333440802930.txt.json
+++ b/test_e2e/expected-structured-output/discord/1099442333440802930.txt.json
@@ -18,6 +18,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1179
       }
     }
@@ -41,6 +42,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1179
       }
     }
@@ -64,6 +66,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1179
       }
     }
@@ -87,6 +90,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1179
       }
     }

--- a/test_e2e/expected-structured-output/discord/1099601456321003600.txt.json
+++ b/test_e2e/expected-structured-output/discord/1099601456321003600.txt.json
@@ -18,6 +18,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 79
       }
     }
@@ -41,6 +42,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 79
       }
     }

--- a/test_e2e/expected-structured-output/dropbox/handbook-1p.docx.json
+++ b/test_e2e/expected-structured-output/dropbox/handbook-1p.docx.json
@@ -20,6 +20,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -50,6 +51,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -80,6 +82,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -104,6 +107,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -128,6 +132,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -152,6 +157,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -176,6 +182,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -200,6 +207,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -224,6 +232,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -248,6 +257,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -272,6 +282,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -296,6 +307,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -320,6 +332,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -344,6 +357,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }
@@ -369,6 +383,7 @@
         "date_created": "1687408568.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 10308
       }
     }

--- a/test_e2e/expected-structured-output/dropbox/nested-1/ideas-page.html.json
+++ b/test_e2e/expected-structured-output/dropbox/nested-1/ideas-page.html.json
@@ -20,6 +20,7 @@
         "date_created": "1687408594.0",
         "date_modified": "1697646966.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6161
       }
     }

--- a/test_e2e/expected-structured-output/dropbox/nested-2/ideas-page.html.json
+++ b/test_e2e/expected-structured-output/dropbox/nested-2/ideas-page.html.json
@@ -20,6 +20,7 @@
         "date_created": "1687408613.0",
         "date_modified": "1697646966.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6161
       }
     }

--- a/test_e2e/expected-structured-output/dropbox/science-exploration-1p.pptx.json
+++ b/test_e2e/expected-structured-output/dropbox/science-exploration-1p.pptx.json
@@ -20,6 +20,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -45,6 +46,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -70,6 +72,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -95,6 +98,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -120,6 +124,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -145,6 +150,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -170,6 +176,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -195,6 +202,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -220,6 +228,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -245,6 +254,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -270,6 +280,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -295,6 +306,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }
@@ -320,6 +332,7 @@
         "date_created": "1687408562.0",
         "date_modified": "1697646967.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1235192
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-0-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-0-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1281
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1281
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1281
       }
     }
@@ -99,6 +102,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1281
       }
     }
@@ -125,6 +129,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 1281
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-1-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-1-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 712
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-2-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-2-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 626
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 626
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 626
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-3-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-3-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 301
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 301
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 301
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-4-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-4-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 796
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 796
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 796
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-5-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-5-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 552
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 552
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 552
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-6-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-6-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 279
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 279
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 279
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-7-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-7-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 465
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 465
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 465
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-8-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-8-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 780
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 780
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 780
       }
     }

--- a/test_e2e/expected-structured-output/elasticsearch/movies-9-57554198.json
+++ b/test_e2e/expected-structured-output/elasticsearch/movies-9-57554198.json
@@ -21,6 +21,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 673
       }
     }
@@ -47,6 +48,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 673
       }
     }
@@ -73,6 +75,7 @@
         "date_created": null,
         "date_modified": null,
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 673
       }
     }

--- a/test_e2e/expected-structured-output/gcs/ideas-page.html.json
+++ b/test_e2e/expected-structured-output/gcs/ideas-page.html.json
@@ -20,6 +20,7 @@
         "date_created": "1687304971.038",
         "date_modified": "1687304971.038",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6161
       }
     }

--- a/test_e2e/expected-structured-output/gcs/nested-1/fake-text.txt.json
+++ b/test_e2e/expected-structured-output/gcs/nested-1/fake-text.txt.json
@@ -19,6 +19,7 @@
         "date_created": "1687304893.303",
         "date_modified": "1687304893.303",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -43,6 +44,7 @@
         "date_created": "1687304893.303",
         "date_modified": "1687304893.303",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -67,6 +69,7 @@
         "date_created": "1687304893.303",
         "date_modified": "1687304893.303",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -91,6 +94,7 @@
         "date_created": "1687304893.303",
         "date_modified": "1687304893.303",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -115,6 +119,7 @@
         "date_created": "1687304893.303",
         "date_modified": "1687304893.303",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -139,6 +144,7 @@
         "date_created": "1687304893.303",
         "date_modified": "1687304893.303",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }

--- a/test_e2e/expected-structured-output/gcs/nested-1/nested/ideas-page.html.json
+++ b/test_e2e/expected-structured-output/gcs/nested-1/nested/ideas-page.html.json
@@ -20,6 +20,7 @@
         "date_created": "1687304893.75",
         "date_modified": "1687304893.75",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6161
       }
     }

--- a/test_e2e/expected-structured-output/gcs/nested-2/fake-text.txt.json
+++ b/test_e2e/expected-structured-output/gcs/nested-2/fake-text.txt.json
@@ -19,6 +19,7 @@
         "date_created": "1687304904.192",
         "date_modified": "1687304904.192",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -43,6 +44,7 @@
         "date_created": "1687304904.192",
         "date_modified": "1687304904.192",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -67,6 +69,7 @@
         "date_created": "1687304904.192",
         "date_modified": "1687304904.192",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -91,6 +94,7 @@
         "date_created": "1687304904.192",
         "date_modified": "1687304904.192",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -115,6 +119,7 @@
         "date_created": "1687304904.192",
         "date_modified": "1687304904.192",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }
@@ -139,6 +144,7 @@
         "date_created": "1687304904.192",
         "date_modified": "1687304904.192",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 169
       }
     }

--- a/test_e2e/expected-structured-output/gcs/nested-2/nested/ideas-page.html.json
+++ b/test_e2e/expected-structured-output/gcs/nested-2/nested/ideas-page.html.json
@@ -20,6 +20,7 @@
         "date_created": "1687304904.586",
         "date_modified": "1687304904.586",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6161
       }
     }

--- a/test_e2e/expected-structured-output/gcs/nested-2/stanley-cups.xlsx.json
+++ b/test_e2e/expected-structured-output/gcs/nested-2/stanley-cups.xlsx.json
@@ -21,6 +21,7 @@
         "date_created": "1687304904.973",
         "date_modified": "1687304904.973",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6339
       }
     }
@@ -48,6 +49,7 @@
         "date_created": "1687304904.973",
         "date_modified": "1687304904.973",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6339
       }
     }
@@ -74,6 +76,7 @@
         "date_created": "1687304904.973",
         "date_modified": "1687304904.973",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6339
       }
     }
@@ -101,6 +104,7 @@
         "date_created": "1687304904.973",
         "date_modified": "1687304904.973",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6339
       }
     }

--- a/test_e2e/expected-structured-output/gitlab/docs/_index.md.json
+++ b/test_e2e/expected-structured-output/gitlab/docs/_index.md.json
@@ -22,6 +22,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -49,6 +50,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -76,6 +78,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -103,6 +106,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -130,6 +134,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -157,6 +162,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -184,6 +190,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -211,6 +218,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -254,6 +262,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -287,6 +296,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -314,6 +324,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -341,6 +352,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -368,6 +380,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -395,6 +408,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -422,6 +436,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -449,6 +464,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -476,6 +492,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -509,6 +526,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }
@@ -542,6 +560,7 @@
             "mode": "100644"
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2542
       }
     }

--- a/test_e2e/expected-structured-output/google-drive/fake.docx.json
+++ b/test_e2e/expected-structured-output/google-drive/fake.docx.json
@@ -51,7 +51,8 @@
               "groups": []
             }
           }
-        ]
+        ],
+        "denied_permissions_data": null
       }
     }
   }

--- a/test_e2e/expected-structured-output/google-drive/foo.txt.json
+++ b/test_e2e/expected-structured-output/google-drive/foo.txt.json
@@ -50,7 +50,8 @@
               "groups": []
             }
           }
-        ]
+        ],
+        "denied_permissions_data": null
       }
     }
   }

--- a/test_e2e/expected-structured-output/google-drive/test-drive-doc.docx.json
+++ b/test_e2e/expected-structured-output/google-drive/test-drive-doc.docx.json
@@ -56,7 +56,8 @@
               "groups": []
             }
           }
-        ]
+        ],
+        "denied_permissions_data": null
       }
     }
   },
@@ -117,7 +118,8 @@
               "groups": []
             }
           }
-        ]
+        ],
+        "denied_permissions_data": null
       }
     }
   }

--- a/test_e2e/expected-structured-output/outlook/21be155fb0c95885.eml.json
+++ b/test_e2e/expected-structured-output/outlook/21be155fb0c95885.eml.json
@@ -27,6 +27,7 @@
         "date_created": "1689435368.0",
         "date_modified": "1689435537.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 9179
       }
     }

--- a/test_e2e/expected-structured-output/outlook/497eba8c81c801c6.eml.json
+++ b/test_e2e/expected-structured-output/outlook/497eba8c81c801c6.eml.json
@@ -27,6 +27,7 @@
         "date_created": "1690248382.0",
         "date_modified": "1690248401.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 9197
       }
     }

--- a/test_e2e/expected-structured-output/outlook/4a16a411f162ebbb.eml.json
+++ b/test_e2e/expected-structured-output/outlook/4a16a411f162ebbb.eml.json
@@ -27,6 +27,7 @@
         "date_created": "1688960344.0",
         "date_modified": "1689460572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 9244
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/azure/Core-Skills-for-Biomedical-Data-Scientists-2-pages.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/azure/Core-Skills-for-Biomedical-Data-Scientists-2-pages.pdf.json
@@ -18,6 +18,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -41,6 +42,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -64,6 +66,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -87,6 +90,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -110,6 +114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -133,6 +138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -156,6 +162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -179,6 +186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -202,6 +210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -225,6 +234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -248,6 +258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -271,6 +282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -294,6 +306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -317,6 +330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -340,6 +354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -363,6 +378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -386,6 +402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -409,6 +426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -432,6 +450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -455,6 +474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -478,6 +498,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -501,6 +522,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -524,6 +546,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -547,6 +570,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }
@@ -570,6 +594,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41164
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/biomed-api/65/11/main.PMC6312790.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/biomed-api/65/11/main.PMC6312790.pdf.json
@@ -25,6 +25,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -55,6 +56,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -78,6 +80,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -108,6 +111,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -131,6 +135,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -154,6 +159,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -177,6 +183,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -200,6 +207,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -223,6 +231,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -246,6 +255,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -269,6 +279,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -292,6 +303,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -315,6 +327,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -338,6 +351,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -361,6 +375,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -384,6 +399,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -407,6 +423,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -430,6 +447,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -453,6 +471,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -483,6 +502,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -523,6 +543,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -546,6 +567,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -569,6 +591,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -592,6 +615,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -615,6 +639,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -638,6 +663,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -661,6 +687,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -684,6 +711,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -707,6 +735,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -730,6 +759,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -753,6 +783,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -776,6 +807,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -799,6 +831,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -822,6 +855,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -845,6 +879,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -868,6 +903,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -891,6 +927,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -914,6 +951,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -937,6 +975,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -960,6 +999,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -983,6 +1023,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1006,6 +1047,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1029,6 +1071,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1052,6 +1095,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1075,6 +1119,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1098,6 +1143,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1121,6 +1167,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1144,6 +1191,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1167,6 +1215,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1190,6 +1239,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1213,6 +1263,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1236,6 +1287,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1259,6 +1311,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1282,6 +1335,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1305,6 +1359,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1328,6 +1383,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1351,6 +1407,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1374,6 +1431,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1397,6 +1455,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1420,6 +1479,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1443,6 +1503,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1466,6 +1527,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1489,6 +1551,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1512,6 +1575,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1535,6 +1599,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1558,6 +1623,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1581,6 +1647,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1604,6 +1671,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1627,6 +1695,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1650,6 +1719,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1673,6 +1743,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1696,6 +1767,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1719,6 +1791,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1742,6 +1815,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1765,6 +1839,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1788,6 +1863,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1811,6 +1887,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1834,6 +1911,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1857,6 +1935,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1880,6 +1959,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1903,6 +1983,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1926,6 +2007,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1949,6 +2031,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1972,6 +2055,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -1995,6 +2079,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2018,6 +2103,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2041,6 +2127,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2064,6 +2151,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2087,6 +2175,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2110,6 +2199,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2133,6 +2223,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2156,6 +2247,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2179,6 +2271,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2202,6 +2295,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2225,6 +2319,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2248,6 +2343,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2271,6 +2367,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2294,6 +2391,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2317,6 +2415,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2340,6 +2439,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2363,6 +2463,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2386,6 +2487,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2409,6 +2511,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2432,6 +2535,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2455,6 +2559,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2478,6 +2583,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2501,6 +2607,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2524,6 +2631,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2547,6 +2655,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2570,6 +2679,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2593,6 +2703,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2616,6 +2727,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2639,6 +2751,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2662,6 +2775,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2685,6 +2799,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2708,6 +2823,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2731,6 +2847,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2754,6 +2871,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2777,6 +2895,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2800,6 +2919,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2823,6 +2943,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2846,6 +2967,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2869,6 +2991,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2892,6 +3015,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2915,6 +3039,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2938,6 +3063,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2961,6 +3087,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -2984,6 +3111,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3007,6 +3135,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3030,6 +3159,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3053,6 +3183,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3076,6 +3207,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3099,6 +3231,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3122,6 +3255,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3145,6 +3279,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3168,6 +3303,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3191,6 +3327,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3214,6 +3351,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3237,6 +3375,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3260,6 +3399,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3283,6 +3423,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3306,6 +3447,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3329,6 +3471,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3352,6 +3495,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3375,6 +3519,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3398,6 +3543,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3421,6 +3567,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3444,6 +3591,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3467,6 +3615,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3490,6 +3639,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3513,6 +3663,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3536,6 +3687,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3559,6 +3711,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3582,6 +3735,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3605,6 +3759,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3628,6 +3783,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3651,6 +3807,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3674,6 +3831,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3697,6 +3855,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3720,6 +3879,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3743,6 +3903,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3766,6 +3927,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3789,6 +3951,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3812,6 +3975,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3835,6 +3999,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3858,6 +4023,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3881,6 +4047,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3904,6 +4071,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3927,6 +4095,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3950,6 +4119,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3973,6 +4143,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -3996,6 +4167,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4026,6 +4198,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4056,6 +4229,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4079,6 +4253,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4109,6 +4284,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4144,6 +4320,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4174,6 +4351,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4209,6 +4387,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4239,6 +4418,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4274,6 +4454,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4319,6 +4500,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4349,6 +4531,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }
@@ -4372,6 +4555,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 569096
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/biomed-api/75/29/main.PMC6312793.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/biomed-api/75/29/main.PMC6312793.pdf.json
@@ -25,6 +25,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -55,6 +56,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -78,6 +80,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -108,6 +111,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -131,6 +135,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -154,6 +159,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -177,6 +183,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -200,6 +207,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -223,6 +231,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -246,6 +255,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -269,6 +279,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -292,6 +303,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -315,6 +327,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -355,6 +368,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -385,6 +399,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -425,6 +440,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -448,6 +464,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -471,6 +488,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -494,6 +512,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -517,6 +536,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -547,6 +567,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -570,6 +591,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -593,6 +615,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -616,6 +639,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -639,6 +663,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -662,6 +687,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -685,6 +711,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -708,6 +735,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -731,6 +759,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -754,6 +783,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -777,6 +807,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -800,6 +831,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -830,6 +862,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -853,6 +886,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -876,6 +910,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -899,6 +934,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -922,6 +958,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -945,6 +982,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -968,6 +1006,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -991,6 +1030,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1014,6 +1054,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1037,6 +1078,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1060,6 +1102,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1083,6 +1126,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1106,6 +1150,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1129,6 +1174,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1152,6 +1198,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1175,6 +1222,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1198,6 +1246,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1221,6 +1270,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1244,6 +1294,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1267,6 +1318,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1290,6 +1342,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1313,6 +1366,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1336,6 +1390,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1359,6 +1414,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1382,6 +1438,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1405,6 +1462,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1428,6 +1486,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1451,6 +1510,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1474,6 +1534,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1497,6 +1558,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1520,6 +1582,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1543,6 +1606,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1566,6 +1630,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1589,6 +1654,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1612,6 +1678,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1635,6 +1702,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1658,6 +1726,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1681,6 +1750,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1704,6 +1774,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1727,6 +1798,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1750,6 +1822,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1773,6 +1846,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1796,6 +1870,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1819,6 +1894,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1842,6 +1918,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1865,6 +1942,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1888,6 +1966,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1911,6 +1990,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1934,6 +2014,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1957,6 +2038,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -1980,6 +2062,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2003,6 +2086,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2026,6 +2110,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2049,6 +2134,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2072,6 +2158,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2095,6 +2182,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2118,6 +2206,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2141,6 +2230,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2164,6 +2254,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2187,6 +2278,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2217,6 +2309,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2247,6 +2340,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2270,6 +2364,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2300,6 +2395,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2335,6 +2431,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2365,6 +2462,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2400,6 +2498,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2430,6 +2529,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2465,6 +2565,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2495,6 +2596,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2525,6 +2627,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2555,6 +2658,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2590,6 +2694,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }
@@ -2613,6 +2718,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 149031
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/biomed-path/07/07/sbaa031.073.PMC7234218.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/biomed-path/07/07/sbaa031.073.PMC7234218.pdf.json
@@ -18,6 +18,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -41,6 +42,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -64,6 +66,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -87,6 +90,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -110,6 +114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -133,6 +138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -156,6 +162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -179,6 +186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -202,6 +210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -225,6 +234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -248,6 +258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -271,6 +282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -294,6 +306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }
@@ -317,6 +330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 41300
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/s3-filter/page-with-formula.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/s3-filter/page-with-formula.pdf.json
@@ -25,6 +25,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -48,6 +49,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -71,6 +73,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -94,6 +97,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -117,6 +121,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -140,6 +145,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -163,6 +169,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -186,6 +193,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -209,6 +217,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -232,6 +241,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -255,6 +265,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -278,6 +289,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -301,6 +313,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -324,6 +337,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -364,6 +378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -387,6 +402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -417,6 +433,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -440,6 +457,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -463,6 +481,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -486,6 +505,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -509,6 +529,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -532,6 +553,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -555,6 +577,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -585,6 +608,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -608,6 +632,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -631,6 +656,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/s3-filter/recalibrating-risk-report.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/s3-filter/recalibrating-risk-report.pdf.json
@@ -18,6 +18,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -41,6 +42,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -64,6 +66,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -87,6 +90,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -110,6 +114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -133,6 +138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -156,6 +162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -179,6 +186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -202,6 +210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -225,6 +234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -248,6 +258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -271,6 +282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -294,6 +306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -317,6 +330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -340,6 +354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -363,6 +378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -386,6 +402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -409,6 +426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -432,6 +450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -455,6 +474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -478,6 +498,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -501,6 +522,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -524,6 +546,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -547,6 +570,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -570,6 +594,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -593,6 +618,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -616,6 +642,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -639,6 +666,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -662,6 +690,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -685,6 +714,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -708,6 +738,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -731,6 +762,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -754,6 +786,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -777,6 +810,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -800,6 +834,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -823,6 +858,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -846,6 +882,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -869,6 +906,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -892,6 +930,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -915,6 +954,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -938,6 +978,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -961,6 +1002,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -984,6 +1026,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1007,6 +1050,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1030,6 +1074,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1053,6 +1098,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1076,6 +1122,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1099,6 +1146,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1122,6 +1170,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1145,6 +1194,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1168,6 +1218,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1191,6 +1242,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1214,6 +1266,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1237,6 +1290,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1260,6 +1314,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1283,6 +1338,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1306,6 +1362,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1329,6 +1386,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1352,6 +1410,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1375,6 +1434,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1398,6 +1458,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1421,6 +1482,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1444,6 +1506,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1467,6 +1530,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1490,6 +1554,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1513,6 +1578,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1536,6 +1602,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1559,6 +1626,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1582,6 +1650,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1605,6 +1674,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1628,6 +1698,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1651,6 +1722,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1674,6 +1746,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1697,6 +1770,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1720,6 +1794,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1743,6 +1818,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1766,6 +1842,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1789,6 +1866,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1812,6 +1890,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1835,6 +1914,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1858,6 +1938,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1881,6 +1962,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1904,6 +1986,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1927,6 +2010,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1950,6 +2034,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1973,6 +2058,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1996,6 +2082,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2019,6 +2106,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2042,6 +2130,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2065,6 +2154,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2088,6 +2178,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2111,6 +2202,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2134,6 +2226,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2157,6 +2250,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2180,6 +2274,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2203,6 +2298,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2226,6 +2322,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2249,6 +2346,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2272,6 +2370,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2295,6 +2394,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2318,6 +2418,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2341,6 +2442,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2364,6 +2466,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2387,6 +2490,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2410,6 +2514,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2433,6 +2538,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2456,6 +2562,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2479,6 +2586,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2502,6 +2610,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2525,6 +2634,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2548,6 +2658,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2571,6 +2682,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2594,6 +2706,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2617,6 +2730,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2640,6 +2754,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2663,6 +2778,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2686,6 +2802,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2709,6 +2826,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2732,6 +2850,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2755,6 +2874,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2778,6 +2898,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2801,6 +2922,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2824,6 +2946,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2847,6 +2970,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2870,6 +2994,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2893,6 +3018,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2916,6 +3042,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2939,6 +3066,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2962,6 +3090,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2985,6 +3114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3008,6 +3138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3031,6 +3162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3054,6 +3186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3077,6 +3210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3100,6 +3234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3123,6 +3258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3146,6 +3282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3169,6 +3306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3192,6 +3330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3215,6 +3354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3238,6 +3378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3261,6 +3402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3284,6 +3426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3307,6 +3450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3330,6 +3474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/s3/2023-Jan-economic-outlook.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/s3/2023-Jan-economic-outlook.pdf.json
@@ -18,6 +18,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -41,6 +42,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -64,6 +66,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -87,6 +90,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -110,6 +114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -133,6 +138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -156,6 +162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -179,6 +186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -202,6 +210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -225,6 +234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -248,6 +258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -271,6 +282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -294,6 +306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -317,6 +330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -340,6 +354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -363,6 +378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -386,6 +402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -409,6 +426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -432,6 +450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -455,6 +474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -478,6 +498,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -501,6 +522,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -524,6 +546,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -547,6 +570,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -570,6 +594,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -593,6 +618,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -616,6 +642,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -639,6 +666,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -662,6 +690,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -685,6 +714,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -708,6 +738,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -731,6 +762,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -754,6 +786,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -777,6 +810,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -800,6 +834,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -823,6 +858,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -846,6 +882,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -869,6 +906,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -892,6 +930,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -915,6 +954,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -938,6 +978,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -961,6 +1002,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -984,6 +1026,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1007,6 +1050,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1030,6 +1074,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1053,6 +1098,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1076,6 +1122,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1099,6 +1146,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1122,6 +1170,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1145,6 +1194,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1168,6 +1218,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1191,6 +1242,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1214,6 +1266,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1237,6 +1290,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1260,6 +1314,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1283,6 +1338,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1306,6 +1362,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1329,6 +1386,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1352,6 +1410,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1375,6 +1434,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1398,6 +1458,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1421,6 +1482,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1444,6 +1506,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1467,6 +1530,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1490,6 +1554,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1513,6 +1578,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1536,6 +1602,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1559,6 +1626,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1582,6 +1650,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1605,6 +1674,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1628,6 +1698,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1651,6 +1722,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1674,6 +1746,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1697,6 +1770,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1720,6 +1794,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1743,6 +1818,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1766,6 +1842,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1789,6 +1866,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1812,6 +1890,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1835,6 +1914,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1858,6 +1938,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1881,6 +1962,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1904,6 +1986,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1927,6 +2010,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1950,6 +2034,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1973,6 +2058,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1996,6 +2082,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2019,6 +2106,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2042,6 +2130,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2065,6 +2154,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2088,6 +2178,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2111,6 +2202,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2134,6 +2226,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2157,6 +2250,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2180,6 +2274,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2203,6 +2298,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2226,6 +2322,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2249,6 +2346,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2272,6 +2370,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2295,6 +2394,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2318,6 +2418,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2341,6 +2442,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2364,6 +2466,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2387,6 +2490,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2410,6 +2514,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2433,6 +2538,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2456,6 +2562,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2479,6 +2586,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2502,6 +2610,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2525,6 +2634,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2548,6 +2658,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2571,6 +2682,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2594,6 +2706,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2617,6 +2730,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2640,6 +2754,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2663,6 +2778,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2686,6 +2802,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2709,6 +2826,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2732,6 +2850,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2755,6 +2874,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2778,6 +2898,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2801,6 +2922,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2824,6 +2946,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2847,6 +2970,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2870,6 +2994,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2893,6 +3018,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2916,6 +3042,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2939,6 +3066,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2962,6 +3090,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2985,6 +3114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3008,6 +3138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3031,6 +3162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3054,6 +3186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3077,6 +3210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3100,6 +3234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3123,6 +3258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3146,6 +3282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3169,6 +3306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3192,6 +3330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3215,6 +3354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3238,6 +3378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3261,6 +3402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3284,6 +3426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3307,6 +3450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3330,6 +3474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3353,6 +3498,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3376,6 +3522,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3399,6 +3546,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3422,6 +3570,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3445,6 +3594,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3468,6 +3618,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3491,6 +3642,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3514,6 +3666,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3537,6 +3690,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3560,6 +3714,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3583,6 +3738,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3606,6 +3762,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3629,6 +3786,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3652,6 +3810,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3675,6 +3834,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3698,6 +3858,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3721,6 +3882,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3744,6 +3906,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3767,6 +3930,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3790,6 +3954,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3813,6 +3978,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3836,6 +4002,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3859,6 +4026,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3882,6 +4050,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3905,6 +4074,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3928,6 +4098,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3951,6 +4122,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3974,6 +4146,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3997,6 +4170,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4020,6 +4194,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4043,6 +4218,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4066,6 +4242,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4089,6 +4266,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4112,6 +4290,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4135,6 +4314,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4158,6 +4338,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4181,6 +4362,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4204,6 +4386,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4227,6 +4410,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4250,6 +4434,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4273,6 +4458,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4296,6 +4482,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4319,6 +4506,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4342,6 +4530,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4365,6 +4554,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4388,6 +4578,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4411,6 +4602,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4434,6 +4626,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4457,6 +4650,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4480,6 +4674,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4503,6 +4698,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4526,6 +4722,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4549,6 +4746,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4572,6 +4770,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4595,6 +4794,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4618,6 +4818,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4641,6 +4842,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4664,6 +4866,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4687,6 +4890,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4710,6 +4914,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4733,6 +4938,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4756,6 +4962,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4779,6 +4986,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4802,6 +5010,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4825,6 +5034,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4848,6 +5058,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4871,6 +5082,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4894,6 +5106,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4917,6 +5130,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4940,6 +5154,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4963,6 +5178,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -4986,6 +5202,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5009,6 +5226,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5032,6 +5250,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5055,6 +5274,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5078,6 +5298,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5101,6 +5322,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5124,6 +5346,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5147,6 +5370,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5170,6 +5394,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5193,6 +5418,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5216,6 +5442,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5239,6 +5466,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5262,6 +5490,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5285,6 +5514,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5308,6 +5538,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5331,6 +5562,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5354,6 +5586,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5377,6 +5610,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5400,6 +5634,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5423,6 +5658,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5446,6 +5682,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -5469,6 +5706,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/s3/Silent-Giant-(1).pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/s3/Silent-Giant-(1).pdf.json
@@ -18,6 +18,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -41,6 +42,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -64,6 +66,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -87,6 +90,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -110,6 +114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -133,6 +138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -156,6 +162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -179,6 +186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -202,6 +210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -225,6 +234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -248,6 +258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -271,6 +282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -294,6 +306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -317,6 +330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -340,6 +354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -363,6 +378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -386,6 +402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -409,6 +426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -432,6 +450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -455,6 +474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -478,6 +498,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -501,6 +522,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -524,6 +546,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -547,6 +570,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -570,6 +594,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -593,6 +618,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -616,6 +642,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -639,6 +666,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -662,6 +690,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -685,6 +714,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -708,6 +738,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -731,6 +762,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -754,6 +786,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -777,6 +810,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -800,6 +834,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -823,6 +858,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -846,6 +882,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -869,6 +906,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -892,6 +930,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -915,6 +954,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -938,6 +978,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -961,6 +1002,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -984,6 +1026,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1007,6 +1050,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1030,6 +1074,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1053,6 +1098,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1076,6 +1122,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1099,6 +1146,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1122,6 +1170,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1145,6 +1194,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1168,6 +1218,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1191,6 +1242,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1214,6 +1266,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1237,6 +1290,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1260,6 +1314,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1283,6 +1338,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1306,6 +1362,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1329,6 +1386,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1352,6 +1410,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1375,6 +1434,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1398,6 +1458,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1421,6 +1482,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1444,6 +1506,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1467,6 +1530,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1490,6 +1554,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1513,6 +1578,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1536,6 +1602,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1559,6 +1626,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1582,6 +1650,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1605,6 +1674,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1628,6 +1698,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1651,6 +1722,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1674,6 +1746,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1697,6 +1770,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1720,6 +1794,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1743,6 +1818,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1766,6 +1842,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1789,6 +1866,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1812,6 +1890,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1835,6 +1914,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1858,6 +1938,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1881,6 +1962,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1904,6 +1986,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1927,6 +2010,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1950,6 +2034,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1973,6 +2058,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1996,6 +2082,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2019,6 +2106,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2042,6 +2130,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2065,6 +2154,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2088,6 +2178,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2111,6 +2202,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2134,6 +2226,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2157,6 +2250,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2180,6 +2274,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2203,6 +2298,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2226,6 +2322,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2249,6 +2346,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2272,6 +2370,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2295,6 +2394,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2318,6 +2418,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2341,6 +2442,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2364,6 +2466,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2387,6 +2490,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2410,6 +2514,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2433,6 +2538,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2456,6 +2562,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2479,6 +2586,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2502,6 +2610,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2525,6 +2634,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2548,6 +2658,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2571,6 +2682,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2594,6 +2706,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2617,6 +2730,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2640,6 +2754,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2663,6 +2778,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2686,6 +2802,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2709,6 +2826,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2732,6 +2850,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2755,6 +2874,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2778,6 +2898,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2801,6 +2922,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2824,6 +2946,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2847,6 +2970,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2870,6 +2994,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2893,6 +3018,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2916,6 +3042,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2939,6 +3066,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2962,6 +3090,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2985,6 +3114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3008,6 +3138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3031,6 +3162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3054,6 +3186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3077,6 +3210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3100,6 +3234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3123,6 +3258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3146,6 +3282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3169,6 +3306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3192,6 +3330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3215,6 +3354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3238,6 +3378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3261,6 +3402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3284,6 +3426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3307,6 +3450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3330,6 +3474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3353,6 +3498,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3376,6 +3522,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3399,6 +3546,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3422,6 +3570,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3445,6 +3594,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3468,6 +3618,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3491,6 +3642,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3514,6 +3666,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3537,6 +3690,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3560,6 +3714,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3583,6 +3738,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3606,6 +3762,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3629,6 +3786,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3652,6 +3810,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3675,6 +3834,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3698,6 +3858,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3721,6 +3882,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3744,6 +3906,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3767,6 +3930,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3790,6 +3954,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3813,6 +3978,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3836,6 +4002,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3859,6 +4026,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3882,6 +4050,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3905,6 +4074,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3928,6 +4098,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3951,6 +4122,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3974,6 +4146,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -3997,6 +4170,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4020,6 +4194,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4043,6 +4218,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4066,6 +4242,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4089,6 +4266,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4112,6 +4290,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4135,6 +4314,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4158,6 +4338,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4181,6 +4362,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4204,6 +4386,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4227,6 +4410,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4250,6 +4434,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4273,6 +4458,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4296,6 +4482,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4319,6 +4506,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4342,6 +4530,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4365,6 +4554,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4388,6 +4578,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4411,6 +4602,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4434,6 +4626,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4457,6 +4650,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4480,6 +4674,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -4503,6 +4698,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/s3/page-with-formula.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/s3/page-with-formula.pdf.json
@@ -25,6 +25,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -48,6 +49,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -71,6 +73,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -94,6 +97,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -117,6 +121,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -140,6 +145,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -163,6 +169,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -186,6 +193,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -209,6 +217,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -232,6 +241,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -255,6 +265,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -278,6 +289,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -301,6 +313,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -324,6 +337,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -364,6 +378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -387,6 +402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -417,6 +433,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -440,6 +457,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -463,6 +481,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -486,6 +505,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -509,6 +529,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -532,6 +553,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -555,6 +577,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -585,6 +608,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -608,6 +632,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -631,6 +656,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }

--- a/test_e2e/expected-structured-output/pdf-fast-reprocess/s3/recalibrating-risk-report.pdf.json
+++ b/test_e2e/expected-structured-output/pdf-fast-reprocess/s3/recalibrating-risk-report.pdf.json
@@ -18,6 +18,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -41,6 +42,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -64,6 +66,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -87,6 +90,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -110,6 +114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -133,6 +138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -156,6 +162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -179,6 +186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -202,6 +210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -225,6 +234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -248,6 +258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -271,6 +282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -294,6 +306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -317,6 +330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -340,6 +354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -363,6 +378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -386,6 +402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -409,6 +426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -432,6 +450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -455,6 +474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -478,6 +498,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -501,6 +522,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -524,6 +546,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -547,6 +570,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -570,6 +594,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -593,6 +618,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -616,6 +642,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -639,6 +666,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -662,6 +690,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -685,6 +714,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -708,6 +738,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -731,6 +762,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -754,6 +786,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -777,6 +810,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -800,6 +834,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -823,6 +858,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -846,6 +882,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -869,6 +906,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -892,6 +930,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -915,6 +954,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -938,6 +978,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -961,6 +1002,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -984,6 +1026,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1007,6 +1050,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1030,6 +1074,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1053,6 +1098,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1076,6 +1122,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1099,6 +1146,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1122,6 +1170,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1145,6 +1194,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1168,6 +1218,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1191,6 +1242,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1214,6 +1266,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1237,6 +1290,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1260,6 +1314,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1283,6 +1338,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1306,6 +1362,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1329,6 +1386,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1352,6 +1410,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1375,6 +1434,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1398,6 +1458,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1421,6 +1482,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1444,6 +1506,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1467,6 +1530,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1490,6 +1554,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1513,6 +1578,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1536,6 +1602,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1559,6 +1626,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1582,6 +1650,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1605,6 +1674,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1628,6 +1698,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1651,6 +1722,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1674,6 +1746,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1697,6 +1770,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1720,6 +1794,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1743,6 +1818,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1766,6 +1842,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1789,6 +1866,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1812,6 +1890,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1835,6 +1914,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1858,6 +1938,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1881,6 +1962,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1904,6 +1986,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1927,6 +2010,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1950,6 +2034,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1973,6 +2058,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1996,6 +2082,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2019,6 +2106,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2042,6 +2130,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2065,6 +2154,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2088,6 +2178,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2111,6 +2202,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2134,6 +2226,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2157,6 +2250,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2180,6 +2274,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2203,6 +2298,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2226,6 +2322,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2249,6 +2346,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2272,6 +2370,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2295,6 +2394,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2318,6 +2418,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2341,6 +2442,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2364,6 +2466,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2387,6 +2490,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2410,6 +2514,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2433,6 +2538,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2456,6 +2562,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2479,6 +2586,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2502,6 +2610,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2525,6 +2634,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2548,6 +2658,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2571,6 +2682,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2594,6 +2706,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2617,6 +2730,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2640,6 +2754,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2663,6 +2778,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2686,6 +2802,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2709,6 +2826,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2732,6 +2850,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2755,6 +2874,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2778,6 +2898,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2801,6 +2922,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2824,6 +2946,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2847,6 +2970,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2870,6 +2994,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2893,6 +3018,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2916,6 +3042,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2939,6 +3066,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2962,6 +3090,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2985,6 +3114,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3008,6 +3138,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3031,6 +3162,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3054,6 +3186,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3077,6 +3210,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3100,6 +3234,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3123,6 +3258,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3146,6 +3282,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3169,6 +3306,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3192,6 +3330,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3215,6 +3354,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3238,6 +3378,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3261,6 +3402,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3284,6 +3426,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3307,6 +3450,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -3330,6 +3474,7 @@
             "mode": 33188
           }
         ],
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }

--- a/test_e2e/expected-structured-output/s3/2023-Jan-economic-outlook.pdf.json
+++ b/test_e2e/expected-structured-output/s3/2023-Jan-economic-outlook.pdf.json
@@ -23,6 +23,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -51,6 +52,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -79,6 +81,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -106,6 +109,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -134,6 +138,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -162,6 +167,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -190,6 +196,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -218,6 +225,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -246,6 +254,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -274,6 +283,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -302,6 +312,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -330,6 +341,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -358,6 +370,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -386,6 +399,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -414,6 +428,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -441,6 +456,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -469,6 +485,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -497,6 +514,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -525,6 +543,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -552,6 +571,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -579,6 +599,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -606,6 +627,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -634,6 +656,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -662,6 +685,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -690,6 +714,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -718,6 +743,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -745,6 +771,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -773,6 +800,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -801,6 +829,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -829,6 +858,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -857,6 +887,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -885,6 +916,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -913,6 +945,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -941,6 +974,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -969,6 +1003,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -997,6 +1032,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1025,6 +1061,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1053,6 +1090,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1081,6 +1119,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1109,6 +1148,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1137,6 +1177,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1165,6 +1206,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1193,6 +1235,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1221,6 +1264,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1249,6 +1293,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1277,6 +1322,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1305,6 +1351,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1332,6 +1379,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1360,6 +1408,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1388,6 +1437,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1416,6 +1466,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1444,6 +1495,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1472,6 +1524,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1500,6 +1553,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1528,6 +1582,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1556,6 +1611,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1583,6 +1639,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1611,6 +1668,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1639,6 +1697,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1668,6 +1727,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1696,6 +1756,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1724,6 +1785,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1752,6 +1814,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1780,6 +1843,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1808,6 +1872,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1836,6 +1901,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1864,6 +1930,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1892,6 +1959,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1920,6 +1988,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1948,6 +2017,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -1976,6 +2046,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2004,6 +2075,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2032,6 +2104,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2060,6 +2133,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2088,6 +2162,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2116,6 +2191,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2144,6 +2220,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2172,6 +2249,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2200,6 +2278,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2228,6 +2307,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2256,6 +2336,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2284,6 +2365,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2312,6 +2394,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2340,6 +2423,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2368,6 +2452,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2396,6 +2481,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2424,6 +2510,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2452,6 +2539,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2480,6 +2568,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2508,6 +2597,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2536,6 +2626,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2564,6 +2655,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2592,6 +2684,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2620,6 +2713,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2648,6 +2742,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2676,6 +2771,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2704,6 +2800,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2732,6 +2829,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2760,6 +2858,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2788,6 +2887,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2816,6 +2916,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2844,6 +2945,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2872,6 +2974,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2900,6 +3003,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2928,6 +3032,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2956,6 +3061,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -2983,6 +3089,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3011,6 +3118,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3039,6 +3147,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3067,6 +3176,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3095,6 +3205,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3123,6 +3234,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3151,6 +3263,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3179,6 +3292,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3206,6 +3320,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3234,6 +3349,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3262,6 +3378,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3290,6 +3407,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3317,6 +3435,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3345,6 +3464,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3373,6 +3493,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3401,6 +3522,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3429,6 +3551,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3457,6 +3580,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }
@@ -3485,6 +3609,7 @@
         "date_created": "1720544414.0",
         "date_modified": "1720544414.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 2215938
       }
     }

--- a/test_e2e/expected-structured-output/s3/Silent-Giant-(1).pdf.json
+++ b/test_e2e/expected-structured-output/s3/Silent-Giant-(1).pdf.json
@@ -19,6 +19,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -43,6 +44,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -68,6 +70,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -93,6 +96,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -118,6 +122,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -143,6 +148,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -168,6 +174,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -193,6 +200,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -218,6 +226,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -243,6 +252,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -268,6 +278,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -293,6 +304,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -318,6 +330,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -343,6 +356,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -368,6 +382,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -392,6 +407,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -417,6 +433,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -442,6 +459,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -467,6 +485,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -492,6 +511,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -516,6 +536,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -541,6 +562,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -566,6 +588,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -591,6 +614,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -615,6 +639,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -640,6 +665,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -665,6 +691,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -690,6 +717,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -714,6 +742,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -739,6 +768,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -763,6 +793,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -787,6 +818,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -811,6 +843,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -836,6 +869,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -861,6 +895,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -886,6 +921,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -911,6 +947,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -936,6 +973,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -961,6 +999,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -986,6 +1025,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1011,6 +1051,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1035,6 +1076,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1059,6 +1101,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1084,6 +1127,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1109,6 +1153,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1134,6 +1179,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1159,6 +1205,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1184,6 +1231,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1208,6 +1256,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1233,6 +1282,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1258,6 +1308,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1283,6 +1334,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1307,6 +1359,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1332,6 +1385,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1357,6 +1411,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1382,6 +1437,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1406,6 +1462,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1431,6 +1488,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1455,6 +1513,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1480,6 +1539,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1505,6 +1565,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1529,6 +1590,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1554,6 +1616,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1579,6 +1642,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1604,6 +1668,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1629,6 +1694,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1654,6 +1720,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1679,6 +1746,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1704,6 +1772,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1728,6 +1797,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1753,6 +1823,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1777,6 +1848,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1802,6 +1874,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1826,6 +1899,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1851,6 +1925,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1876,6 +1951,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1901,6 +1977,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1926,6 +2003,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1951,6 +2029,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -1976,6 +2055,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2001,6 +2081,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2026,6 +2107,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2051,6 +2133,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2076,6 +2159,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2101,6 +2185,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }
@@ -2126,6 +2211,7 @@
         "date_created": "1676196636.0",
         "date_modified": "1676196636.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 6164777
       }
     }

--- a/test_e2e/expected-structured-output/s3/page-with-formula.pdf.json
+++ b/test_e2e/expected-structured-output/s3/page-with-formula.pdf.json
@@ -27,6 +27,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -52,6 +53,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -77,6 +79,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -102,6 +105,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -127,6 +131,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -152,6 +157,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -177,6 +183,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -219,6 +226,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -244,6 +252,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -276,6 +285,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -301,6 +311,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -326,6 +337,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -351,6 +363,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -376,6 +389,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -401,6 +415,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -433,6 +448,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }
@@ -458,6 +474,7 @@
         "date_created": "1697584841.0",
         "date_modified": "1697584841.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 138124
       }
     }

--- a/test_e2e/expected-structured-output/s3/recalibrating-risk-report.pdf.json
+++ b/test_e2e/expected-structured-output/s3/recalibrating-risk-report.pdf.json
@@ -19,6 +19,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -43,6 +44,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -68,6 +70,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -93,6 +96,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -118,6 +122,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -143,6 +148,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -168,6 +174,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -193,6 +200,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -218,6 +226,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -243,6 +252,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -268,6 +278,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -293,6 +304,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -317,6 +329,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -342,6 +355,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -367,6 +381,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -392,6 +407,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -417,6 +433,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -442,6 +459,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -467,6 +485,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -493,6 +512,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -518,6 +538,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -543,6 +564,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -568,6 +590,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -593,6 +616,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -618,6 +642,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -642,6 +667,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -667,6 +693,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -692,6 +719,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -717,6 +745,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -741,6 +770,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -766,6 +796,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -791,6 +822,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -816,6 +848,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -841,6 +874,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -866,6 +900,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -891,6 +926,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -916,6 +952,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -941,6 +978,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -966,6 +1004,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -991,6 +1030,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1016,6 +1056,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1040,6 +1081,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1065,6 +1107,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1090,6 +1133,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1115,6 +1159,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1140,6 +1185,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1165,6 +1211,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1189,6 +1236,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1214,6 +1262,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1239,6 +1288,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1264,6 +1314,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1289,6 +1340,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1314,6 +1366,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1339,6 +1392,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1364,6 +1418,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1389,6 +1444,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1413,6 +1469,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1437,6 +1494,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1462,6 +1520,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1486,6 +1545,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1511,6 +1571,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1536,6 +1597,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1561,6 +1623,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1585,6 +1648,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1610,6 +1674,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1635,6 +1700,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1660,6 +1726,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1685,6 +1752,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1710,6 +1778,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1735,6 +1804,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1760,6 +1830,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1785,6 +1856,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1810,6 +1882,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1835,6 +1908,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1860,6 +1934,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1885,6 +1960,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1910,6 +1986,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1935,6 +2012,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1960,6 +2038,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -1985,6 +2064,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2010,6 +2090,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2035,6 +2116,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2060,6 +2142,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }
@@ -2085,6 +2168,7 @@
         "date_created": "1676196572.0",
         "date_modified": "1676196572.0",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 806335
       }
     }

--- a/test_e2e/expected-structured-output/slack/cce82000be81b105.xml.json
+++ b/test_e2e/expected-structured-output/slack/cce82000be81b105.xml.json
@@ -20,6 +20,7 @@
         "date_created": "1719844959.236409",
         "date_modified": "1719845122.687169",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 333
       }
     }
@@ -45,6 +46,7 @@
         "date_created": "1719844959.236409",
         "date_modified": "1719845122.687169",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 333
       }
     }
@@ -70,6 +72,7 @@
         "date_created": "1719844959.236409",
         "date_modified": "1719845122.687169",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 333
       }
     }
@@ -95,6 +98,7 @@
         "date_created": "1719844959.236409",
         "date_modified": "1719845122.687169",
         "permissions_data": null,
+        "denied_permissions_data": null,
         "filesize_bytes": 333
       }
     }

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.2"  # pragma: no cover
+__version__ = "1.6.3"  # pragma: no cover

--- a/unstructured_ingest/data_types/file_data.py
+++ b/unstructured_ingest/data_types/file_data.py
@@ -30,6 +30,7 @@ class FileDataSourceMetadata(BaseModel):
     date_modified: Optional[str] = None
     date_processed: Optional[str] = None
     permissions_data: Optional[list[dict[str, Any]]] = None
+    denied_permissions_data: Optional[list[dict[str, Any]]] = None
     filesize_bytes: Optional[int] = None
 
 


### PR DESCRIPTION
## Summary

- Adds `denied_permissions_data: Optional[list[dict[str, Any]]] = None` to `FileDataSourceMetadata` in `unstructured_ingest/data_types/file_data.py`
- Patch bump `1.6.2` → `1.6.3` (additive optional field; matches the 1.6.1 precedent for "add an optional field")
- CHANGELOG entry under `### Enhancements`

## Why

Mirror of [Unstructured-IO/utic-public-libs#49](https://github.com/Unstructured-IO/utic-public-libs/pull/49). The `FileDataSourceMetadata` model exists in two places — once in `utic-public-types` (used by platform plugins) and once here (used by the OSS connectors). The two copies need to stay in sync because pipeline stages may re-parse FileData JSON through either model; if only one side knows about a field, Pydantic silently drops it on re-parse.

Needed by [PLU-180](https://linear.app/unstructured/issue/PLU-180) — the FileNet connector ACL passthrough work. FileNet is the first source connector with first-class DENY ACL semantics (Drive, SharePoint, Box, Confluence don't expose deny in their APIs). The new field surfaces those DENY entries in a parallel typed list with the same shape as `permissions_data`.

Existing connectors leave `denied_permissions_data` as `None`. No behavior change for them.

## Test plan

- [x] Existing tests still pass (no schema-shape test exists in this repo; the change is one optional field with a `None` default)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional denied_permissions_data to FileDataSourceMetadata for explicit DENY ACLs (same shape as permissions_data). Supports PLU-180, syncs with `utic-public-types`, bumps to 1.6.3; backfills expected fixtures with denied_permissions_data: null so existing connectors remain unchanged.

<sup>Written for commit be0bf76f590b4df9b73d94fa43815a3dc4b92614. Summary will update on new commits. <a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/711?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

