### PR TITLE
fix(notion): make database test row-order insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.3]
+
+### Fixes
+
+- **fix(notion): make `test_notion_source_database` row-order insensitive.** The integration test compared the downloaded HTML byte-for-byte, but Notion's database query endpoint doesn't guarantee a stable row order — every prior fixture refresh was just reshuffling the same rows. Compare table rows as a multiset of their text content and print the symmetric difference on mismatch so real regressions aren't silent.
+
 ## [1.6.2]
 
 ### Fixes

--- a/test/integration/connectors/test_notion.py
+++ b/test/integration/connectors/test_notion.py
@@ -3,6 +3,9 @@ import os
 import pytest
 
 from test.integration.connectors.utils.constants import SOURCE_TAG, UNCATEGORIZED_TAG
+from test.integration.connectors.utils.validation.equality import (
+    unordered_table_html_equality_check,
+)
 from test.integration.connectors.utils.validation.source import (
     SourceValidationConfigs,
     get_all_file_data,
@@ -59,6 +62,7 @@ def test_notion_source_database(temp_dir):
             exclude_fields_extend=["metadata.date_created", "metadata.date_modified"],
             predownload_file_data_check=source_filedata_display_name_set_check,
             postdownload_file_data_check=source_filedata_display_name_set_check,
+            file_equality_check=unordered_table_html_equality_check,
         ),
     )
 

--- a/test/integration/connectors/utils/validation/equality.py
+++ b/test/integration/connectors/utils/validation/equality.py
@@ -47,6 +47,49 @@ def html_equality_check(expected_filepath: Path, current_filepath: Path) -> bool
     return expected_soup.text == current_soup.text
 
 
+def unordered_table_html_equality_check(
+    expected_filepath: Path, current_filepath: Path
+) -> bool:
+    # Equality check for HTML files whose first <table> holds rows in an
+    # arbitrary order. Header (first <tr>) is compared positionally; remaining
+    # data rows are compared as a multiset of their text content. Used for
+    # connectors whose upstream API doesn't guarantee stable row ordering
+    # (e.g. Notion's database query response).
+    with expected_filepath.open() as expected_f:
+        expected_soup = BeautifulSoup(expected_f, "html.parser")
+    with current_filepath.open() as current_f:
+        current_soup = BeautifulSoup(current_f, "html.parser")
+
+    def split_rows(soup: BeautifulSoup) -> tuple[str, list[str]]:
+        rows = soup.find_all("tr")
+        if not rows:
+            return "", []
+        header = rows[0].get_text(" ", strip=True)
+        data = sorted(r.get_text(" ", strip=True) for r in rows[1:])
+        return header, data
+
+    expected_header, expected_data = split_rows(expected_soup)
+    current_header, current_data = split_rows(current_soup)
+
+    if expected_header != current_header:
+        print("table header differs:")
+        print(f"  expected: {expected_header}")
+        print(f"  current:  {current_header}")
+        return False
+    if expected_data != current_data:
+        expected_counts = {r: expected_data.count(r) for r in set(expected_data)}
+        current_counts = {r: current_data.count(r) for r in set(current_data)}
+        only_in_expected = [r for r in expected_counts if expected_counts[r] != current_counts.get(r, 0)]
+        only_in_current = [r for r in current_counts if current_counts[r] != expected_counts.get(r, 0)]
+        print("table rows differ (order-insensitive):")
+        for row in only_in_expected:
+            print(f"  only in expected (x{expected_counts[row]}): {row}")
+        for row in only_in_current:
+            print(f"  only in current  (x{current_counts[row]}): {row}")
+        return False
+    return True
+
+
 def txt_equality_check(expected_filepath: Path, current_filepath: Path) -> bool:
     with expected_filepath.open() as expected_f:
         expected_text_lines = expected_f.readlines()

--- a/test/integration/connectors/utils/validation/equality.py
+++ b/test/integration/connectors/utils/validation/equality.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter
 from pathlib import Path
 
 from bs4 import BeautifulSoup
@@ -77,15 +78,15 @@ def unordered_table_html_equality_check(
         print(f"  current:  {current_header}")
         return False
     if expected_data != current_data:
-        expected_counts = {r: expected_data.count(r) for r in set(expected_data)}
-        current_counts = {r: current_data.count(r) for r in set(current_data)}
-        only_in_expected = [r for r in expected_counts if expected_counts[r] != current_counts.get(r, 0)]
-        only_in_current = [r for r in current_counts if current_counts[r] != expected_counts.get(r, 0)]
+        expected_counts = Counter(expected_data)
+        current_counts = Counter(current_data)
+        only_in_expected = expected_counts - current_counts
+        only_in_current = current_counts - expected_counts
         print("table rows differ (order-insensitive):")
-        for row in only_in_expected:
-            print(f"  only in expected (x{expected_counts[row]}): {row}")
-        for row in only_in_current:
-            print(f"  only in current  (x{current_counts[row]}): {row}")
+        for row, n in only_in_expected.items():
+            print(f"  only in expected (x{n}): {row}")
+        for row, n in only_in_current.items():
+            print(f"  only in current  (x{n}): {row}")
         return False
     return True
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.2"  # pragma: no cover
+__version__ = "1.6.3"  # pragma: no cover


### PR DESCRIPTION
## Summary
- Notion's database query endpoint doesn't guarantee a stable row order, but the `test_notion_source_database` integration test compared the downloaded HTML byte-for-byte against a checked-in fixture. Every prior "fix" (#693, #605) was just reshuffling the same four rows.
- Add `unordered_table_html_equality_check` that compares table header positionally and data rows as a multiset of their text content, and wire it into the database test only (the page test isn't a table).
- On mismatch the new check prints the symmetric difference so the next real regression won't be a black box like https://github.com/Unstructured-IO/unstructured-ingest/actions/runs/26238030726/job/77216703553 was.

## Test plan
- [ ] `uncategorized_connectors_int_test` Notion tests pass (real verification — needs the CI's `NOTION_API_KEY`)
- [x] Smoke-tested locally against the real fixture: reordered rows compare equal, a tampered row fails with a readable diff

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Notion database integration test resilient to unstable row ordering by comparing table rows without relying on their sequence. This prevents flaky CI from nondeterministic Notion database query results.

- **Bug Fixes**
  - Added `unordered_table_html_equality_check` that compares the first table’s header positionally and treats data rows as a multiset of their text.
  - Wired this check into `test_notion_source_database` only; the page test is unchanged.
  - On mismatch, prints a readable diff showing header differences and row counts.

- **Dependencies**
  - Bumped `unstructured_ingest` to `1.6.3` and added a changelog entry.

<sup>Written for commit 4590c97db31a0f2e1ee2750d702e162b07bdde1f. Summary will update on new commits. <a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/713?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

