### PR TITLE
skip invalid file types for gdrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.5]
+
+### Fixes
+
+- **fix(google-drive): skip non-downloadable native files during indexing and download.** Google Drive shortcuts, forms, maps, sites, fusiontables, and jams are now silently filtered out during indexing rather than failing at download time. Empty placeholder files (`inode/x-empty` or zero-byte with no MIME type) are also skipped. The downloader returns `None` for these files instead of raising `SourceConnectionError`, and `count_files_recursively` excludes them from file counts.
+
 ## [1.6.4]
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.3]
+
+### Fixes
+
+- **fix(google-drive): skip non-downloadable files at crawl and download time.** Google Drive shortcuts, Forms, Maps, Sites, Jamboard, Fusion Tables, and `inode/x-empty` (zero-byte) files are now filtered out during indexing and silently skipped by the downloader instead of failing after 3 retries. Exportable native types (Docs, Sheets, Slides, Drawings) are unaffected.
+
 ## [1.6.2]
 
 ### Fixes

--- a/test/unit/connectors/test_google_drive.py
+++ b/test/unit/connectors/test_google_drive.py
@@ -6,6 +6,7 @@ import pytest
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
 from unstructured_ingest.error import SourceConnectionError, ValueError
 from unstructured_ingest.processes.connectors.google_drive import (
+    GOOGLE_DRIVE_SKIP_MIME_TYPES,
     GOOGLE_EXPORT_MIME_MAP,
     GoogleDriveAccessConfig,
     GoogleDriveDownloader,
@@ -13,6 +14,7 @@ from unstructured_ingest.processes.connectors.google_drive import (
     GoogleDriveIndexer,
     GoogleDriveIndexerConfig,
     _get_extension,
+    _should_skip_file,
 )
 
 
@@ -210,8 +212,25 @@ class TestGoogleDriveNativeExports:
         assert file_data.additional_metadata["export_extension"] == expected_extension
         assert file_data.additional_metadata["download_method"] == "google_workspace_export"
 
-    def test_downloader_rejects_unsupported_google_native_files(self, tmp_path):
-        file_data = _make_file_data("application/vnd.google-apps.form")
+    @pytest.mark.parametrize("mime_type", sorted(GOOGLE_DRIVE_SKIP_MIME_TYPES))
+    def test_downloader_skips_non_downloadable_native_files(self, tmp_path, mime_type):
+        file_data = _make_file_data(mime_type)
+        downloader = GoogleDriveDownloader(
+            connection_config=MagicMock(),
+            download_config=GoogleDriveDownloaderConfig(download_dir=tmp_path),
+        )
+        downloader._export_gdrive_native_file = MagicMock()
+        downloader._direct_download_file = MagicMock()
+
+        result = downloader._download_file(file_data)
+
+        assert result is None
+        downloader._export_gdrive_native_file.assert_not_called()
+        downloader._direct_download_file.assert_not_called()
+
+    def test_downloader_rejects_unknown_native_mime_types(self, tmp_path):
+        """Native types not in skip list and not exportable should still raise."""
+        file_data = _make_file_data("application/vnd.google-apps.unknown_future_type")
         downloader = GoogleDriveDownloader(
             connection_config=MagicMock(),
             download_config=GoogleDriveDownloaderConfig(download_dir=tmp_path),
@@ -226,6 +245,114 @@ class TestGoogleDriveNativeExports:
 
         downloader._export_gdrive_native_file.assert_not_called()
         downloader._direct_download_file.assert_not_called()
+
+
+class TestGoogleDriveSkipFiles:
+    """Tests for _should_skip_file and downloader skip behavior for non-downloadable files."""
+
+    @pytest.mark.parametrize("mime_type", sorted(GOOGLE_DRIVE_SKIP_MIME_TYPES))
+    def test_should_skip_file_returns_true_for_skip_mimes(self, mime_type):
+        assert _should_skip_file({"mimeType": mime_type}) is True
+
+    def test_should_skip_file_returns_true_for_inode_x_empty(self):
+        assert _should_skip_file({"mimeType": "inode/x-empty", "size": "0"}) is True
+
+    def test_should_skip_file_returns_true_for_zero_size_no_mime(self):
+        assert _should_skip_file({"mimeType": "", "size": "0"}) is True
+
+    def test_should_skip_file_returns_false_for_normal_file(self):
+        assert _should_skip_file({"mimeType": "application/pdf", "size": "1024"}) is False
+
+    def test_should_skip_file_returns_false_for_exportable_native(self):
+        assert (
+            _should_skip_file({"mimeType": "application/vnd.google-apps.document", "size": "0"})
+            is False
+        )
+
+    def test_downloader_skips_inode_x_empty(self, tmp_path):
+        file_data = _make_file_data("inode/x-empty")
+        downloader = GoogleDriveDownloader(
+            connection_config=MagicMock(),
+            download_config=GoogleDriveDownloaderConfig(download_dir=tmp_path),
+        )
+        downloader._export_gdrive_native_file = MagicMock()
+        downloader._direct_download_file = MagicMock()
+
+        result = downloader._download_file(file_data)
+
+        assert result is None
+        downloader._export_gdrive_native_file.assert_not_called()
+        downloader._direct_download_file.assert_not_called()
+
+    def test_downloader_run_returns_none_for_skipped_file(self, tmp_path):
+        file_data = _make_file_data("application/vnd.google-apps.shortcut")
+        downloader = GoogleDriveDownloader(
+            connection_config=MagicMock(),
+            download_config=GoogleDriveDownloaderConfig(download_dir=tmp_path),
+        )
+        downloader._export_gdrive_native_file = MagicMock()
+        downloader._direct_download_file = MagicMock()
+
+        result = downloader.run(file_data)
+
+        assert result is None
+
+    def test_indexer_filters_skip_mime_types_from_paginated_results(self):
+        files_client = MagicMock()
+        files_client.list.return_value.execute.return_value = {
+            "files": [
+                {"id": "pdf-1", "name": "doc.pdf", "mimeType": "application/pdf"},
+                {
+                    "id": "shortcut-1",
+                    "name": "alias",
+                    "mimeType": "application/vnd.google-apps.shortcut",
+                },
+                {"id": "form-1", "name": "survey", "mimeType": "application/vnd.google-apps.form"},
+                {"id": "pdf-2", "name": "doc2.pdf", "mimeType": "application/pdf"},
+                {"id": "empty-1", "name": "empty", "mimeType": "inode/x-empty", "size": "0"},
+            ]
+        }
+        indexer = GoogleDriveIndexer(
+            connection_config=MagicMock(),
+            index_config=GoogleDriveIndexerConfig(),
+        )
+
+        results = indexer.get_paginated_results(
+            files_client=files_client,
+            object_id="folder-id",
+        )
+
+        result_ids = [r["id"] for r in results]
+        assert result_ids == ["pdf-1", "pdf-2"]
+
+    def test_count_files_recursively_excludes_skip_mimes(self):
+        files_client = _FakeGoogleDriveFilesClient(
+            responses=[
+                {
+                    "files": [
+                        {"id": "pdf-1", "mimeType": "application/pdf", "fileExtension": "pdf"},
+                        {
+                            "id": "shortcut",
+                            "mimeType": "application/vnd.google-apps.shortcut",
+                        },
+                        {"id": "form", "mimeType": "application/vnd.google-apps.form"},
+                        {"id": "empty", "mimeType": "inode/x-empty", "size": "0"},
+                        {
+                            "id": "doc",
+                            "mimeType": "application/vnd.google-apps.document",
+                        },
+                    ]
+                }
+            ]
+        )
+
+        count = GoogleDriveIndexer.count_files_recursively(
+            files_client=files_client,
+            folder_id="folder-id",
+        )
+
+        # pdf-1 + doc = 2; shortcut, form, empty are all skipped
+        assert count == 2
 
 
 class TestGoogleDriveExtensionFiltering:

--- a/test/unit/connectors/test_google_drive.py
+++ b/test/unit/connectors/test_google_drive.py
@@ -284,7 +284,7 @@ class TestGoogleDriveSkipFiles:
         downloader._export_gdrive_native_file.assert_not_called()
         downloader._direct_download_file.assert_not_called()
 
-    def test_downloader_run_returns_none_for_skipped_file(self, tmp_path):
+    def test_downloader_run_returns_empty_list_for_skipped_file(self, tmp_path):
         file_data = _make_file_data("application/vnd.google-apps.shortcut")
         downloader = GoogleDriveDownloader(
             connection_config=MagicMock(),
@@ -295,7 +295,7 @@ class TestGoogleDriveSkipFiles:
 
         result = downloader.run(file_data)
 
-        assert result is None
+        assert result == []
 
     def test_indexer_filters_skip_mime_types_from_paginated_results(self):
         files_client = MagicMock()

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.2"  # pragma: no cover
+__version__ = "1.6.3"  # pragma: no cover

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.4"  # pragma: no cover
+__version__ = "1.6.5"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -35,6 +35,20 @@ CONNECTOR_TYPE = "google_drive"
 GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 GOOGLE_DRIVE_NATIVE_MIME_PREFIX = "application/vnd.google-apps."
 
+# Native Google MIME types that have no downloadable or exportable content.
+# Shortcuts are aliases to other files, forms/maps/sites are web-only apps.
+# These are silently skipped during indexing and downloading.
+GOOGLE_DRIVE_SKIP_MIME_TYPES = frozenset(
+    {
+        "application/vnd.google-apps.shortcut",
+        "application/vnd.google-apps.form",
+        "application/vnd.google-apps.map",
+        "application/vnd.google-apps.site",
+        "application/vnd.google-apps.fusiontable",
+        "application/vnd.google-apps.jam",
+    }
+)
+
 
 # Maps Google-native Drive MIME types → export MIME types
 GOOGLE_EXPORT_MIME_MAP = {
@@ -83,6 +97,17 @@ def _matches_extension_or_native_export(record: dict, extensions: Optional[list[
         return True
 
     return record.get("mimeType") in _native_mime_types_for_extensions(extensions)
+
+
+def _should_skip_file(record: dict) -> bool:
+    """Return True if a file record should be excluded from indexing."""
+    mime = record.get("mimeType", "")
+    if mime in GOOGLE_DRIVE_SKIP_MIME_TYPES:
+        return True
+    size = int(record.get("size", -1))
+    if mime == "inode/x-empty" or (size == 0 and not mime):
+        return True
+    return False
 
 
 def _build_extension_query_filter(extensions: list[str]) -> str:
@@ -288,8 +313,9 @@ class GoogleDriveIndexer(Indexer):
                 ).execute()
                 for item in response.get("files", []):
                     if item.get("mimeType") == GOOGLE_DRIVE_FOLDER_MIME_TYPE:
-                        # Always traverse sub-folders regardless of extension filter.
                         stack.append(item["id"])
+                    elif _should_skip_file(item):
+                        continue
                     else:
                         if not valid_exts or _matches_extension_or_native_export(item, extensions):
                             count += 1
@@ -450,7 +476,11 @@ class GoogleDriveIndexer(Indexer):
                 q=q,
             ).execute()
             if files := response.get("files", []):
-                fs = [f for f in files if not self.is_dir(record=f)]
+                fs = [
+                    f
+                    for f in files
+                    if not self.is_dir(record=f) and not _should_skip_file(f)
+                ]
                 for r in fs:
                     r["parent_path"] = previous_path
                 dirs = [f for f in files if self.is_dir(record=f)]
@@ -870,7 +900,7 @@ class GoogleDriveDownloader(Downloader):
             scopes=["https://www.googleapis.com/auth/drive.readonly"],
         )
 
-    def _download_file(self, file_data: FileData) -> Path:
+    def _download_file(self, file_data: FileData) -> Optional[Path]:
         """Downloads a file from Google Drive using either direct download or export based
         on the source file's MIME type.
 
@@ -890,6 +920,13 @@ class GoogleDriveDownloader(Downloader):
         mime_type = file_data.additional_metadata.get("mimeType", "")
         file_size = int(file_data.additional_metadata.get("size", 0))
         file_id = file_data.identifier
+
+        if mime_type == "inode/x-empty" or (file_size == 0 and not mime_type):
+            logger.info(
+                f"Skipping empty file {file_id} ({mime_type or 'unknown MIME'}, "
+                f"size=0): {file_data.source_identifiers.fullpath}"
+            )
+            return None
 
         download_path = self.get_download_path(file_data)
         if not download_path:
@@ -918,6 +955,12 @@ class GoogleDriveDownloader(Downloader):
                     "download_method": "google_workspace_export",
                 }
             )
+        elif mime_type in GOOGLE_DRIVE_SKIP_MIME_TYPES:
+            logger.info(
+                f"Skipping non-downloadable Google Drive file {file_id} "
+                f"({mime_type}): {file_data.source_identifiers.fullpath}"
+            )
+            return None
         elif mime_type.startswith(GOOGLE_DRIVE_NATIVE_MIME_PREFIX):
             raise SourceConnectionError(
                 f"Unsupported Google Drive native MIME type for file {file_id}: {mime_type}. "
@@ -935,7 +978,7 @@ class GoogleDriveDownloader(Downloader):
 
         return download_path
 
-    def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
+    def run(self, file_data: FileData, **kwargs: Any) -> Optional[DownloadResponse]:
         mime_type = file_data.additional_metadata.get("mimeType", "")
 
         logger.debug(
@@ -943,6 +986,8 @@ class GoogleDriveDownloader(Downloader):
         )
 
         download_path = self._download_file(file_data)
+        if download_path is None:
+            return None
 
         file_data.local_download_path = str(download_path.resolve())
 

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -19,7 +19,6 @@ from unstructured_ingest.interfaces import (
     ConnectionConfig,
     Downloader,
     DownloaderConfig,
-    DownloadResponse,
     Indexer,
     IndexerConfig,
     download_responses,

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -105,9 +105,7 @@ def _should_skip_file(record: dict) -> bool:
     if mime in GOOGLE_DRIVE_SKIP_MIME_TYPES:
         return True
     size = int(record.get("size", -1))
-    if mime == "inode/x-empty" or (size == 0 and not mime):
-        return True
-    return False
+    return mime == "inode/x-empty" or (size == 0 and not mime)
 
 
 def _build_extension_query_filter(extensions: list[str]) -> str:

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -22,6 +22,7 @@ from unstructured_ingest.interfaces import (
     DownloadResponse,
     Indexer,
     IndexerConfig,
+    download_responses,
 )
 from unstructured_ingest.logger import logger
 from unstructured_ingest.processes.connector_registry import SourceRegistryEntry
@@ -976,7 +977,7 @@ class GoogleDriveDownloader(Downloader):
 
         return download_path
 
-    def run(self, file_data: FileData, **kwargs: Any) -> Optional[DownloadResponse]:
+    def run(self, file_data: FileData, **kwargs: Any) -> download_responses:
         mime_type = file_data.additional_metadata.get("mimeType", "")
 
         logger.debug(
@@ -985,7 +986,7 @@ class GoogleDriveDownloader(Downloader):
 
         download_path = self._download_file(file_data)
         if download_path is None:
-            return None
+            return []
 
         file_data.local_download_path = str(download_path.resolve())
 


### PR DESCRIPTION
Skips invalid shortcut files in google drive downloader. Example:
```
Unexpected job failure after 3 retries : most recent error 400: Error in downloader - Unsupported Google Drive native MIME type for file 1Tk0By3CY-NXRlkbcWhgyVtJcnFRLItTX: application/vnd.google-apps.shortcut. Docs Editors files must be exported before download.
```

<img width="1568" height="1458" alt="image" src="https://github.com/user-attachments/assets/5b937538-dcbf-43fa-9491-c5480e038650" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip non-downloadable Google Drive files and empty files during indexing and downloading to prevent errors and reduce noise. Exportable Docs/Sheets/Slides still export; unknown native types still error.

- **Bug Fixes**
  - Added `GOOGLE_DRIVE_SKIP_MIME_TYPES` and `_should_skip_file` to drop shortcuts/forms/maps/sites/jam/fusiontable, plus `inode/x-empty` and zero-byte files with no MIME.
  - Indexer filters these in `get_paginated_results` and `count_files_recursively`.
  - Downloader logs and skips; `_download_file` returns `None` and `run` returns `[]` for skipped files.
  - Tests updated to cover skip behavior.

<sup>Written for commit 4e8cef5bdb3bdd2285252983df8245fce79696a1. Summary will update on new commits. <a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/715?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



