### PR TITLE
feat(box-source): OAuth support for Box source connector 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.7]
+
+### Enhancements
+
+- **feat(box): OAuth 2.0 access token support on the Box source.** `BoxAccessConfig` now accepts `access_token` (with optional `refresh_token`) alongside the existing `box_app_config` JWT field, and a validator enforces exactly one auth method. When `access_token` is set, `BoxConnectionConfig.get_access_config()` returns a `boxsdk.OAuth2` client. `refresh_token` is stored as a carrier for external refresh flows (e.g. orchestrator-side rotation) and is not consumed in-process.
+
 ## [1.6.6]
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-- **feat(box): OAuth 2.0 access token support on the Box source.** `BoxAccessConfig` now accepts `access_token` (with optional `refresh_token`) alongside the existing `box_app_config` JWT field, and a validator enforces exactly one auth method. When `access_token` is set, `BoxConnectionConfig.get_access_config()` returns a `boxsdk.OAuth2` client. `refresh_token` is stored as a carrier for external refresh flows (e.g. orchestrator-side rotation) and is not consumed in-process.
+- **feat(box): OAuth 2.0 access token support on the Box source.** `BoxAccessConfig` now accepts `access_token` (with optional `refresh_token`) alongside the existing `box_app_config` field, and a validator enforces exactly one auth method. When `access_token` is set, `BoxConnectionConfig.get_access_config()` returns a `boxsdk.OAuth2` client. `refresh_token` is stored as a carrier for external refresh flows (e.g. orchestrator-side rotation) and is not consumed in-process.
 
 ## [1.6.6]
 

--- a/test/unit/connectors/fsspec/test_box.py
+++ b/test/unit/connectors/fsspec/test_box.py
@@ -6,7 +6,6 @@ import pytest
 
 from unstructured_ingest.processes.connectors.fsspec.box import (
     BoxAccessConfig,
-    BoxConnectionConfig,
 )
 
 
@@ -57,48 +56,3 @@ class TestBoxAccessConfigValidation:
         )
         assert ac.box_app_config is None
         assert ac.access_token == "ya29.access"
-
-
-class TestBoxConnectionConfigGetAccessConfig:
-    def test_access_token_branch_returns_oauth_kwarg(self):
-        cc = BoxConnectionConfig(
-            access_config=BoxAccessConfig(access_token="live-token"),
-        )
-        kwargs = cc.get_access_config()
-        assert "oauth" in kwargs
-        assert kwargs["oauth"].access_token == "live-token"
-        # secret fields stripped from the kwargs dict
-        for k in ("access_token", "refresh_token", "box_app_config"):
-            assert k not in kwargs
-
-    def test_access_token_with_refresh_token_still_uses_access_token(self):
-        cc = BoxConnectionConfig(
-            access_config=BoxAccessConfig(
-                access_token="live-token",
-                refresh_token="long-lived-rt",
-            ),
-        )
-        kwargs = cc.get_access_config()
-        assert kwargs["oauth"].access_token == "live-token"
-
-    def test_jwt_branch_unchanged(self, monkeypatch):
-        from boxsdk import JWTAuth
-
-        class _FakeJWT:
-            def authenticate_instance(self):
-                pass
-
-        monkeypatch.setattr(
-            JWTAuth,
-            "from_settings_dictionary",
-            staticmethod(lambda _settings: _FakeJWT()),
-        )
-
-        cc = BoxConnectionConfig(
-            access_config=BoxAccessConfig(
-                box_app_config={"boxAppSettings": {"clientID": "x"}},
-            ),
-        )
-        kwargs = cc.get_access_config()
-        assert "oauth" in kwargs
-        assert "box_app_config" not in kwargs

--- a/test/unit/connectors/fsspec/test_box.py
+++ b/test/unit/connectors/fsspec/test_box.py
@@ -49,6 +49,15 @@ class TestBoxAccessConfigValidation:
                 refresh_token="long-lived-rt",
             )
 
+    def test_model_validate_accepts_explicit_null_box_app_config(self):
+        """The platform serializes optional fields as JSON null. The BeforeValidator
+        on box_app_config must pass None through rather than raising."""
+        ac = BoxAccessConfig.model_validate(
+            {"box_app_config": None, "access_token": "ya29.access", "refresh_token": "rt"},
+        )
+        assert ac.box_app_config is None
+        assert ac.access_token == "ya29.access"
+
 
 class TestBoxConnectionConfigGetAccessConfig:
     def test_access_token_branch_returns_oauth_kwarg(self):

--- a/test/unit/connectors/fsspec/test_box.py
+++ b/test/unit/connectors/fsspec/test_box.py
@@ -1,0 +1,95 @@
+"""Unit tests for the Box source connector's auth model."""
+
+from __future__ import annotations
+
+import pytest
+
+from unstructured_ingest.processes.connectors.fsspec.box import (
+    BoxAccessConfig,
+    BoxConnectionConfig,
+)
+
+
+class TestBoxAccessConfigValidation:
+    def test_jwt_only_is_valid(self):
+        ac = BoxAccessConfig(box_app_config={"boxAppSettings": {"clientID": "x"}})
+        assert ac.access_token is None
+        assert ac.refresh_token is None
+
+    def test_access_token_only_is_valid(self):
+        ac = BoxAccessConfig(access_token="ya29.access")
+        assert ac.box_app_config is None
+        assert ac.refresh_token is None
+
+    def test_access_token_and_refresh_token_is_valid(self):
+        ac = BoxAccessConfig(access_token="ya29.access", refresh_token="long-lived-rt")
+        assert ac.box_app_config is None
+        assert ac.access_token == "ya29.access"
+        assert ac.refresh_token == "long-lived-rt"
+
+    def test_no_auth_method_rejected(self):
+        with pytest.raises(ValueError, match="requires either"):
+            BoxAccessConfig()
+
+    def test_refresh_token_without_access_token_rejected(self):
+        with pytest.raises(ValueError, match="requires either"):
+            BoxAccessConfig(refresh_token="long-lived-rt")
+
+    def test_box_app_config_with_access_token_rejected(self):
+        with pytest.raises(ValueError, match="exactly one auth method"):
+            BoxAccessConfig(
+                box_app_config={"boxAppSettings": {}},
+                access_token="ya29.access",
+            )
+
+    def test_box_app_config_with_refresh_token_rejected(self):
+        with pytest.raises(ValueError, match="exactly one auth method"):
+            BoxAccessConfig(
+                box_app_config={"boxAppSettings": {}},
+                refresh_token="long-lived-rt",
+            )
+
+
+class TestBoxConnectionConfigGetAccessConfig:
+    def test_access_token_branch_returns_oauth_kwarg(self):
+        cc = BoxConnectionConfig(
+            access_config=BoxAccessConfig(access_token="live-token"),
+        )
+        kwargs = cc.get_access_config()
+        assert "oauth" in kwargs
+        assert kwargs["oauth"].access_token == "live-token"
+        # secret fields stripped from the kwargs dict
+        for k in ("access_token", "refresh_token", "box_app_config"):
+            assert k not in kwargs
+
+    def test_access_token_with_refresh_token_still_uses_access_token(self):
+        cc = BoxConnectionConfig(
+            access_config=BoxAccessConfig(
+                access_token="live-token",
+                refresh_token="long-lived-rt",
+            ),
+        )
+        kwargs = cc.get_access_config()
+        assert kwargs["oauth"].access_token == "live-token"
+
+    def test_jwt_branch_unchanged(self, monkeypatch):
+        from boxsdk import JWTAuth
+
+        class _FakeJWT:
+            def authenticate_instance(self):
+                pass
+
+        monkeypatch.setattr(
+            JWTAuth,
+            "from_settings_dictionary",
+            staticmethod(lambda _settings: _FakeJWT()),
+        )
+
+        cc = BoxConnectionConfig(
+            access_config=BoxAccessConfig(
+                box_app_config={"boxAppSettings": {"clientID": "x"}},
+            ),
+        )
+        kwargs = cc.get_access_config()
+        assert "oauth" in kwargs
+        assert "box_app_config" not in kwargs

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.6"  # pragma: no cover
+__version__ = "1.6.7"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/processes/connectors/fsspec/box.py
@@ -193,9 +193,31 @@ class BoxIndexerConfig(FsspecIndexerConfig):
 
 
 class BoxAccessConfig(FsspecAccessConfig):
-    box_app_config: Annotated[dict, BeforeValidator(conform_string_to_dict)] = Field(
-        description="Box app credentials as a JSON string."
+    box_app_config: Optional[
+        Annotated[dict, BeforeValidator(conform_string_to_dict)]
+    ] = Field(
+        default=None,
+        description="Box app credentials as a JSON string.",
     )
+    access_token: Optional[str] = Field(
+        default=None, description="Box OAuth 2.0 access token."
+    )
+    refresh_token: Optional[str] = Field(
+        default=None, description="Box OAuth 2.0 refresh token."
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        has_jwt = self.box_app_config is not None
+        has_oauth = self.access_token is not None
+        if not has_jwt and not has_oauth:
+            raise ValueError(
+                "BoxAccessConfig requires either box_app_config or access_token."
+            )
+        if has_jwt and (self.access_token is not None or self.refresh_token is not None):
+            raise ValueError(
+                "BoxAccessConfig must use exactly one auth method: "
+                "either box_app_config or access_token/refresh_token."
+            )
 
 
 class BoxConnectionConfig(FsspecConnectionConfig):
@@ -203,27 +225,37 @@ class BoxConnectionConfig(FsspecConnectionConfig):
     access_config: Secret[BoxAccessConfig]
     connector_type: str = Field(default=CONNECTOR_TYPE, init=False)
 
-    def get_access_config(self) -> dict[str, Any]:
+    @requires_dependencies(["boxsdk"], extras="box")
+    def _build_oauth_from_access_token(self, access_token: str):
+        from boxsdk import OAuth2
+
+        return OAuth2(
+            client_id="",
+            client_secret="",
+            access_token=access_token,
+        )
+
+    @requires_dependencies(["boxsdk"], extras="box")
+    def _build_jwt(self, ac: BoxAccessConfig):
         from boxsdk import JWTAuth
 
-        ac = self.access_config.get_secret_value()
-        settings_dict = ac.box_app_config
-
-        # Create and authenticate the JWTAuth object
-        oauth = JWTAuth.from_settings_dictionary(settings_dict)
+        oauth = JWTAuth.from_settings_dictionary(ac.box_app_config)
         oauth.authenticate_instance()
+        return oauth
 
-        # if not oauth.access_token:
-        #     raise SourceConnectionError("Authentication failed: No access token generated.")
+    def get_access_config(self) -> dict[str, Any]:
+        ac = self.access_config.get_secret_value()
 
-        # Prepare the access configuration with the authenticated oauth
-        access_kwargs_with_oauth: dict[str, Any] = {
-            "oauth": oauth,
-        }
+        if ac.access_token is not None:
+            oauth = self._build_oauth_from_access_token(ac.access_token)
+        else:
+            oauth = self._build_jwt(ac)
+
+        access_kwargs_with_oauth: dict[str, Any] = {"oauth": oauth}
         access_config: dict[str, Any] = ac.model_dump()
-        access_config.pop("box_app_config", None)
+        for k in ("box_app_config", "access_token", "refresh_token"):
+            access_config.pop(k, None)
         access_kwargs_with_oauth.update(access_config)
-
         return access_kwargs_with_oauth
 
     def wrap_error(self, e: Exception) -> Exception:

--- a/unstructured_ingest/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/processes/connectors/fsspec/box.py
@@ -192,9 +192,16 @@ class BoxIndexerConfig(FsspecIndexerConfig):
     )
 
 
+def _conform_optional_box_app_config(value: Any) -> Optional[dict]:
+    if value is None:
+        return None
+    return conform_string_to_dict(value)
+
+
 class BoxAccessConfig(FsspecAccessConfig):
-    box_app_config: Optional[
-        Annotated[dict, BeforeValidator(conform_string_to_dict)]
+    box_app_config: Annotated[
+        Optional[dict],
+        BeforeValidator(_conform_optional_box_app_config),
     ] = Field(
         default=None,
         description="Box app credentials as a JSON string.",

--- a/unstructured_ingest/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/processes/connectors/fsspec/box.py
@@ -285,11 +285,13 @@ class BoxConnectionConfig(FsspecConnectionConfig):
 
     @requires_dependencies(["boxsdk"], extras="box")
     def get_box_client(self):
-        from boxsdk import Client, JWTAuth
+        from boxsdk import Client
 
         ac = self.access_config.get_secret_value()
-        oauth = JWTAuth.from_settings_dictionary(ac.box_app_config)
-        oauth.authenticate_instance()
+        if ac.access_token is not None:
+            oauth = self._build_oauth_from_access_token(ac.access_token)
+        else:
+            oauth = self._build_jwt(ac)
         return Client(oauth)
 
     @requires_dependencies(["boxfs"], extras="box")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds OAuth 2.0 token auth to the Box source, alongside JWT. You can set an `access_token` (optional `refresh_token`) to build a `boxsdk.OAuth2` client; `refresh_token` is stored for external refresh and not used in-process.

- **New Features**
  - `BoxAccessConfig` supports either `box_app_config` (JWT) or `access_token`/`refresh_token`, with validation enforcing exactly one method; `get_access_config()` builds `boxsdk.OAuth2` when tokens are used.

- **Bug Fixes**
  - Accept `box_app_config: null` during validation and route `get_box_client` through the OAuth branch when `access_token` is set. Bumps version to `1.6.7`.

<sup>Written for commit d69448ca78bd173d3d65d975ea9293a705246d7b. Summary will update on new commits. <a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/719?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

