### PR TITLE
DTPL-398: Add Bedrock embedder AssumeRole runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,8 @@ bedrock = [
     "boto3",
     "aioboto3",
     "aiobotocore[boto3]!=2.24.2",
-    "utic-auth[aws]>=0.1.0,<1.0.0",
-    "utic-types>=1.4.0,<2.0.0",
+    "utic-auth[aws]==0.1.0.dev202606051418",
+    "utic-types==1.4.0.dev202606051418",
 ]
 huggingface = ["sentence-transformers"]
 mixedbreadai = ["mixedbread"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ wikipedia = ["wikipedia"]
 zendesk = ["httpx", "aiofiles", "beautifulsoup4"]
 
 # Embedders
-bedrock = ["boto3", "aioboto3", "aiobotocore[boto3]!=2.24.2"]
+bedrock = ["boto3", "aioboto3", "aiobotocore[boto3]!=2.24.2", "utic-aws-auth>=0.1.0,<1.0.0"]
 huggingface = ["sentence-transformers"]
 mixedbreadai = ["mixedbread"]
 octoai = ["openai", "tiktoken"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,13 @@ wikipedia = ["wikipedia"]
 zendesk = ["httpx", "aiofiles", "beautifulsoup4"]
 
 # Embedders
-bedrock = ["boto3", "aioboto3", "aiobotocore[boto3]!=2.24.2", "utic-auth[aws]>=0.1.0,<1.0.0"]
+bedrock = [
+    "boto3",
+    "aioboto3",
+    "aiobotocore[boto3]!=2.24.2",
+    "utic-auth[aws]>=0.1.0,<1.0.0",
+    "utic-types>=1.4.0,<2.0.0",
+]
 huggingface = ["sentence-transformers"]
 mixedbreadai = ["mixedbread"]
 octoai = ["openai", "tiktoken"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ wikipedia = ["wikipedia"]
 zendesk = ["httpx", "aiofiles", "beautifulsoup4"]
 
 # Embedders
-bedrock = ["boto3", "aioboto3", "aiobotocore[boto3]!=2.24.2", "utic-aws-auth>=0.1.0,<1.0.0"]
+bedrock = ["boto3", "aioboto3", "aiobotocore[boto3]!=2.24.2", "utic-auth[aws]>=0.1.0,<1.0.0"]
 huggingface = ["sentence-transformers"]
 mixedbreadai = ["mixedbread"]
 octoai = ["openai", "tiktoken"]

--- a/test/unit/embedders/test_bedrock.py
+++ b/test/unit/embedders/test_bedrock.py
@@ -56,3 +56,55 @@ def test_inference_profile_manual():
         inference_profile_id="manual-profile",
     )
     assert config.inference_profile_id == "manual-profile"
+
+
+def test_iam_access_method_uses_ambient_credentials():
+    config = BedrockEmbeddingConfig(access_method="iam", region_name="us-west-2")
+
+    assert config.get_client_kwargs() == {"region_name": "us-west-2"}
+
+
+def test_missing_access_method_without_fields_uses_ambient_credentials():
+    config = BedrockEmbeddingConfig(region_name="us-west-2")
+
+    assert config.get_client_kwargs() == {"region_name": "us-west-2"}
+
+
+def test_missing_access_method_rejects_ambiguous_shapes():
+    config = BedrockEmbeddingConfig(
+        role_arn="arn:aws:iam::123456789012:role/bedrock-access",
+        external_id="external-id",
+        aws_access_key_id="access-key",
+        aws_secret_access_key="secret-key",
+        region_name="us-west-2",
+    )
+
+    with pytest.raises(ValueError, match="access_method is required"):
+        config.get_client_kwargs()
+
+
+def test_assume_role_requires_role_fields():
+    config = BedrockEmbeddingConfig(access_method="assume_role", region_name="us-west-2")
+
+    with pytest.raises(ValueError, match="AssumeRole access method requires"):
+        config.run_precheck()
+
+
+def test_assume_role_ignores_stale_static_credentials():
+    config = BedrockEmbeddingConfig(
+        access_method="assume_role",
+        role_arn="arn:aws:iam::123456789012:role/bedrock-access",
+        external_id="external-id",
+        aws_access_key_id="stale",
+        aws_secret_access_key="stale",
+        region_name="us-west-2",
+    )
+
+    assert config.get_client_kwargs() == {"region_name": "us-west-2"}
+
+
+def test_credentials_requires_static_keys():
+    config = BedrockEmbeddingConfig(access_method="credentials", region_name="us-west-2")
+
+    with pytest.raises(ValueError, match="Credentials access method requires"):
+        config.get_client_kwargs()

--- a/test/unit/embedders/test_bedrock.py
+++ b/test/unit/embedders/test_bedrock.py
@@ -70,6 +70,17 @@ def test_missing_access_method_without_fields_uses_ambient_credentials():
     assert config.get_client_kwargs() == {"region_name": "us-west-2"}
 
 
+def test_credentials_include_session_token():
+    config = BedrockEmbeddingConfig(
+        region_name="us-west-2",
+        aws_access_key_id="access-key",
+        aws_secret_access_key="secret-key",
+        aws_session_token="session-token",
+    )
+
+    assert config.get_client_kwargs()["aws_session_token"] == "session-token"
+
+
 def test_missing_access_method_rejects_ambiguous_shapes():
     config = BedrockEmbeddingConfig(
         role_arn="arn:aws:iam::123456789012:role/bedrock-access",

--- a/test/unit/embedders/test_bedrock.py
+++ b/test/unit/embedders/test_bedrock.py
@@ -86,7 +86,7 @@ def test_missing_access_method_rejects_ambiguous_shapes():
 def test_assume_role_requires_role_fields():
     config = BedrockEmbeddingConfig(access_method="assume_role", region_name="us-west-2")
 
-    with pytest.raises(ValueError, match="AssumeRole access method requires"):
+    with pytest.raises(ValueError, match="Bedrock assume_role auth requires"):
         config.run_precheck()
 
 
@@ -106,5 +106,5 @@ def test_assume_role_ignores_stale_static_credentials():
 def test_credentials_requires_static_keys():
     config = BedrockEmbeddingConfig(access_method="credentials", region_name="us-west-2")
 
-    with pytest.raises(ValueError, match="Credentials access method requires"):
+    with pytest.raises(ValueError, match="Bedrock credentials auth requires"):
         config.get_client_kwargs()

--- a/test/unit/embedders/test_bedrock.py
+++ b/test/unit/embedders/test_bedrock.py
@@ -111,7 +111,8 @@ def test_assume_role_ignores_stale_static_credentials():
         region_name="us-west-2",
     )
 
-    assert config.get_client_kwargs() == {"region_name": "us-west-2"}
+    with pytest.raises(ValueError, match="requires a client factory"):
+        config.get_client_kwargs()
 
 
 def test_credentials_requires_static_keys():

--- a/unstructured_ingest/embed/bedrock.py
+++ b/unstructured_ingest/embed/bedrock.py
@@ -80,6 +80,9 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
     aws_secret_access_key: SecretStr | None = Field(
         description="aws secret access key", default=None
     )
+    aws_session_token: SecretStr | None = Field(
+        description="aws session token", default=None
+    )
     region_name: str = Field(
         description="aws region name",
         default_factory=lambda: (
@@ -159,12 +162,31 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
             endpoint_url=self.endpoint_url,
         )
 
+    def _selected_access_method(self) -> Literal["credentials", "iam", "assume_role"] | None:
+        if self.access_method is not None:
+            return self.access_method
+        if not any(
+            (
+                self.aws_access_key_id,
+                self.aws_secret_access_key,
+                self.aws_session_token,
+                self.role_arn,
+                self.external_id,
+            )
+        ):
+            # Preserve the legacy embedder behavior where omitted credentials
+            # mean "use the deployment's ambient AWS identity".
+            return "iam"
+        return None
+
     def _provider_connection(self) -> dict:
+
         return bedrock_provider_connection_config(
             region=self.region_name,
             access_key_id=self.aws_access_key_id,
             secret_access_key=self.aws_secret_access_key,
-            access_method=self.access_method,
+            session_token=self.aws_session_token,
+            access_method=self._selected_access_method(),
             role_arn=self.role_arn,
             external_id=self.external_id,
         )

--- a/unstructured_ingest/embed/bedrock.py
+++ b/unstructured_ingest/embed/bedrock.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, AsyncIterable, Literal
 
 from pydantic import Field, SecretStr
-from utic_aws_auth.aws.bedrock import (
+from utic_auth.aws.bedrock import (
     bedrock_async_client_kwargs_from_provider_connection,
     bedrock_client_kwargs_from_provider_connection,
     bedrock_provider_connection_from_auth_fields,

--- a/unstructured_ingest/embed/bedrock.py
+++ b/unstructured_ingest/embed/bedrock.py
@@ -9,9 +9,9 @@ from pydantic import Field, SecretStr
 from utic_auth.aws.bedrock import (
     bedrock_async_client_kwargs_from_provider_connection,
     bedrock_client_kwargs_from_provider_connection,
-    bedrock_provider_connection_from_auth_fields,
     create_bedrock_client_from_provider_connection,
 )
+from utic_types import bedrock_provider_connection_config
 
 from unstructured_ingest.embed.interfaces import (
     EMBEDDINGS_KEY,
@@ -160,7 +160,7 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
         )
 
     def _provider_connection(self) -> dict:
-        return bedrock_provider_connection_from_auth_fields(
+        return bedrock_provider_connection_config(
             region=self.region_name,
             access_key_id=self.aws_access_key_id,
             secret_access_key=self.aws_secret_access_key,

--- a/unstructured_ingest/embed/bedrock.py
+++ b/unstructured_ingest/embed/bedrock.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, AsyncIterable, Literal
 
 from pydantic import Field, SecretStr
+from utic_aws_auth.aws.bedrock import (
+    bedrock_async_client_kwargs_from_provider_connection,
+    bedrock_client_kwargs_from_provider_connection,
+    bedrock_provider_connection_from_auth_fields,
+    create_bedrock_client_from_provider_connection,
+)
 
 from unstructured_ingest.embed.interfaces import (
     EMBEDDINGS_KEY,
@@ -129,15 +135,14 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
         return e
 
     def run_precheck(self) -> None:
-        # Validate access method and credentials configuration
-        self._effective_access_method()
+        self._provider_connection()
 
         client = self.get_bedrock_client()
         try:
             model_info = client.list_foundation_models(byOutputModality="EMBEDDING")
             summaries = model_info.get("modelSummaries", [])
             model_ids = [m["modelId"] for m in summaries]
-            arns = [":".join(m["modelArn"]) for m in summaries]
+            arns = [m["modelArn"] for m in summaries]
 
             if self.embedder_model_name not in model_ids and self.embedder_model_name not in arns:
                 raise UserError(
@@ -149,134 +154,42 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
             raise self.wrap_error(e=e)
 
     def get_client_kwargs(self) -> dict:
-        kwargs = {
-            "region_name": self.region_name,
-        }
-
-        if self.endpoint_url:
-            kwargs["endpoint_url"] = self.endpoint_url
-
-        method = self._effective_access_method()
-
-        if method == "credentials":
-            if self.aws_access_key_id and self.aws_secret_access_key:
-                kwargs["aws_access_key_id"] = self.aws_access_key_id.get_secret_value()
-                kwargs["aws_secret_access_key"] = self.aws_secret_access_key.get_secret_value()
-            else:
-                raise ValueError(
-                    "Credentials access method requires aws_access_key_id and aws_secret_access_key"
-                )
-        elif method == "iam":
-            # For IAM, boto3 will use default credential chain (IAM roles, environment, etc.)
-            pass
-        elif method == "assume_role":
-            if not (self.role_arn and self.external_id):
-                raise ValueError(
-                    "AssumeRole access method requires role_arn and external_id"
-                )
-        else:
-            raise ValueError(
-                f"Invalid access_method: {self.access_method}. Must be "
-                "'credentials', 'iam', or 'assume_role'"
-            )
-
-        return kwargs
-
-    def _effective_access_method(self) -> Literal["credentials", "iam", "assume_role"]:
-        if self.access_method is not None:
-            method = self.access_method
-        else:
-            has_credentials = bool(self.aws_access_key_id) and bool(self.aws_secret_access_key)
-            has_partial_credentials = bool(self.aws_access_key_id) != bool(
-                self.aws_secret_access_key
-            )
-            has_role = bool(self.role_arn) and bool(self.external_id)
-            has_partial_role = bool(self.role_arn) != bool(self.external_id)
-            if has_partial_credentials:
-                raise ValueError(
-                    "Credentials auth requires aws_access_key_id and aws_secret_access_key"
-                )
-            if has_partial_role:
-                raise ValueError("AssumeRole auth requires role_arn and external_id")
-            if has_credentials and has_role:
-                raise ValueError("access_method is required when multiple Bedrock auth shapes exist")
-            if has_credentials:
-                method = "credentials"
-            elif has_role:
-                method = "assume_role"
-            else:
-                method = "iam"
-
-        if method == "credentials" and not (self.aws_access_key_id and self.aws_secret_access_key):
-            raise ValueError(
-                "Credentials access method requires aws_access_key_id and aws_secret_access_key"
-            )
-        if method == "assume_role" and not (self.role_arn and self.external_id):
-            raise ValueError("AssumeRole access method requires role_arn and external_id")
-        return method
-
-    def _external_id_secret(self) -> str:
-        if self.external_id is None:
-            raise ValueError("AssumeRole access method requires external_id")
-        return self.external_id.get_secret_value()
-
-    def _assume_role_client_kwargs(self) -> dict:
-        from utic_aws_auth.aws.sts import assume_role, build_session_name
-
-        creds = assume_role(
-            role_arn=self.role_arn,
-            external_id=self._external_id_secret(),
-            session_name=build_session_name(),
+        return bedrock_client_kwargs_from_provider_connection(
+            self._provider_connection(),
+            endpoint_url=self.endpoint_url,
         )
-        kwargs = {
-            "region_name": self.region_name,
-            "aws_access_key_id": creds["access_key"],
-            "aws_secret_access_key": creds["secret_key"],
-            "aws_session_token": creds["token"],
-        }
-        if self.endpoint_url:
-            kwargs["endpoint_url"] = self.endpoint_url
-        return kwargs
+
+    def _provider_connection(self) -> dict:
+        return bedrock_provider_connection_from_auth_fields(
+            region=self.region_name,
+            access_key_id=self.aws_access_key_id,
+            secret_access_key=self.aws_secret_access_key,
+            access_method=self.access_method,
+            role_arn=self.role_arn,
+            external_id=self.external_id,
+        )
 
     @requires_dependencies(
         ["boto3"],
         extras="bedrock",
     )
     def get_bedrock_client(self) -> "BedrockClient":
-        import boto3
-
-        if self._effective_access_method() == "assume_role":
-            from utic_aws_auth.aws.sts import create_role_arn_session
-
-            session = create_role_arn_session(
-                role_arn=self.role_arn,
-                external_id=self._external_id_secret(),
-            )
-            return session.client(service_name="bedrock", **self.get_client_kwargs())
-
-        bedrock_client = boto3.client(service_name="bedrock", **self.get_client_kwargs())
-
-        return bedrock_client
+        return create_bedrock_client_from_provider_connection(
+            self._provider_connection(),
+            service_name="bedrock",
+            endpoint_url=self.endpoint_url,
+        )
 
     @requires_dependencies(
         ["boto3", "numpy", "botocore"],
         extras="bedrock",
     )
     def get_client(self) -> "BedrockRuntimeClient":
-        import boto3
-
-        if self._effective_access_method() == "assume_role":
-            from utic_aws_auth.aws.sts import create_role_arn_session
-
-            session = create_role_arn_session(
-                role_arn=self.role_arn,
-                external_id=self._external_id_secret(),
-            )
-            return session.client(service_name="bedrock-runtime", **self.get_client_kwargs())
-
-        bedrock_client = boto3.client(service_name="bedrock-runtime", **self.get_client_kwargs())
-
-        return bedrock_client
+        return create_bedrock_client_from_provider_connection(
+            self._provider_connection(),
+            service_name="bedrock-runtime",
+            endpoint_url=self.endpoint_url,
+        )
 
     @requires_dependencies(
         ["aioboto3"],
@@ -287,10 +200,9 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
         import aioboto3
 
         session = aioboto3.Session()
-        client_kwargs = (
-            self._assume_role_client_kwargs()
-            if self._effective_access_method() == "assume_role"
-            else self.get_client_kwargs()
+        client_kwargs = bedrock_async_client_kwargs_from_provider_connection(
+            self._provider_connection(),
+            endpoint_url=self.endpoint_url,
         )
         async with session.client("bedrock-runtime", **client_kwargs) as aws_bedrock:
             yield aws_bedrock

--- a/unstructured_ingest/embed/bedrock.py
+++ b/unstructured_ingest/embed/bedrock.py
@@ -3,7 +3,7 @@ import json
 import os
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, AsyncIterable
+from typing import TYPE_CHECKING, AsyncIterable, Literal
 
 from pydantic import Field, SecretStr
 
@@ -81,9 +81,15 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
         ),
     )
     endpoint_url: str | None = Field(description="custom bedrock endpoint url", default=None)
-    access_method: str = Field(
-        description="authentication method", default="credentials"
-    )  # "credentials" or "iam"
+    access_method: Literal["credentials", "iam", "assume_role"] | None = Field(
+        description="authentication method", default=None
+    )
+    role_arn: str | None = Field(
+        description="IAM role ARN for cross-account Bedrock access", default=None
+    )
+    external_id: SecretStr | None = Field(
+        description="External ID for cross-account Bedrock role assumption", default=None
+    )
     embedder_model_name: str = Field(
         default="amazon.titan-embed-text-v1",
         alias="model_name",
@@ -124,18 +130,7 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
 
     def run_precheck(self) -> None:
         # Validate access method and credentials configuration
-        if self.access_method == "credentials":
-            if not (self.aws_access_key_id and self.aws_secret_access_key):
-                raise ValueError(
-                    "Credentials access method requires aws_access_key_id and aws_secret_access_key"
-                )
-        elif self.access_method == "iam":
-            # For IAM, credentials are handled by AWS SDK
-            pass
-        else:
-            raise ValueError(
-                f"Invalid access_method: {self.access_method}. Must be 'credentials' or 'iam'"
-            )
+        self._effective_access_method()
 
         client = self.get_bedrock_client()
         try:
@@ -161,7 +156,9 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
         if self.endpoint_url:
             kwargs["endpoint_url"] = self.endpoint_url
 
-        if self.access_method == "credentials":
+        method = self._effective_access_method()
+
+        if method == "credentials":
             if self.aws_access_key_id and self.aws_secret_access_key:
                 kwargs["aws_access_key_id"] = self.aws_access_key_id.get_secret_value()
                 kwargs["aws_secret_access_key"] = self.aws_secret_access_key.get_secret_value()
@@ -169,14 +166,76 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
                 raise ValueError(
                     "Credentials access method requires aws_access_key_id and aws_secret_access_key"
                 )
-        elif self.access_method == "iam":
+        elif method == "iam":
             # For IAM, boto3 will use default credential chain (IAM roles, environment, etc.)
             pass
+        elif method == "assume_role":
+            if not (self.role_arn and self.external_id):
+                raise ValueError(
+                    "AssumeRole access method requires role_arn and external_id"
+                )
         else:
             raise ValueError(
-                f"Invalid access_method: {self.access_method}. Must be 'credentials' or 'iam'"
+                f"Invalid access_method: {self.access_method}. Must be "
+                "'credentials', 'iam', or 'assume_role'"
             )
 
+        return kwargs
+
+    def _effective_access_method(self) -> Literal["credentials", "iam", "assume_role"]:
+        if self.access_method is not None:
+            method = self.access_method
+        else:
+            has_credentials = bool(self.aws_access_key_id) and bool(self.aws_secret_access_key)
+            has_partial_credentials = bool(self.aws_access_key_id) != bool(
+                self.aws_secret_access_key
+            )
+            has_role = bool(self.role_arn) and bool(self.external_id)
+            has_partial_role = bool(self.role_arn) != bool(self.external_id)
+            if has_partial_credentials:
+                raise ValueError(
+                    "Credentials auth requires aws_access_key_id and aws_secret_access_key"
+                )
+            if has_partial_role:
+                raise ValueError("AssumeRole auth requires role_arn and external_id")
+            if has_credentials and has_role:
+                raise ValueError("access_method is required when multiple Bedrock auth shapes exist")
+            if has_credentials:
+                method = "credentials"
+            elif has_role:
+                method = "assume_role"
+            else:
+                method = "iam"
+
+        if method == "credentials" and not (self.aws_access_key_id and self.aws_secret_access_key):
+            raise ValueError(
+                "Credentials access method requires aws_access_key_id and aws_secret_access_key"
+            )
+        if method == "assume_role" and not (self.role_arn and self.external_id):
+            raise ValueError("AssumeRole access method requires role_arn and external_id")
+        return method
+
+    def _external_id_secret(self) -> str:
+        if self.external_id is None:
+            raise ValueError("AssumeRole access method requires external_id")
+        return self.external_id.get_secret_value()
+
+    def _assume_role_client_kwargs(self) -> dict:
+        from utic_aws_auth.aws.sts import assume_role, build_session_name
+
+        creds = assume_role(
+            role_arn=self.role_arn,
+            external_id=self._external_id_secret(),
+            session_name=build_session_name(),
+        )
+        kwargs = {
+            "region_name": self.region_name,
+            "aws_access_key_id": creds["access_key"],
+            "aws_secret_access_key": creds["secret_key"],
+            "aws_session_token": creds["token"],
+        }
+        if self.endpoint_url:
+            kwargs["endpoint_url"] = self.endpoint_url
         return kwargs
 
     @requires_dependencies(
@@ -185,6 +244,15 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
     )
     def get_bedrock_client(self) -> "BedrockClient":
         import boto3
+
+        if self._effective_access_method() == "assume_role":
+            from utic_aws_auth.aws.sts import create_role_arn_session
+
+            session = create_role_arn_session(
+                role_arn=self.role_arn,
+                external_id=self._external_id_secret(),
+            )
+            return session.client(service_name="bedrock", **self.get_client_kwargs())
 
         bedrock_client = boto3.client(service_name="bedrock", **self.get_client_kwargs())
 
@@ -196,6 +264,15 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
     )
     def get_client(self) -> "BedrockRuntimeClient":
         import boto3
+
+        if self._effective_access_method() == "assume_role":
+            from utic_aws_auth.aws.sts import create_role_arn_session
+
+            session = create_role_arn_session(
+                role_arn=self.role_arn,
+                external_id=self._external_id_secret(),
+            )
+            return session.client(service_name="bedrock-runtime", **self.get_client_kwargs())
 
         bedrock_client = boto3.client(service_name="bedrock-runtime", **self.get_client_kwargs())
 
@@ -210,7 +287,12 @@ class BedrockEmbeddingConfig(EmbeddingConfig):
         import aioboto3
 
         session = aioboto3.Session()
-        async with session.client("bedrock-runtime", **self.get_client_kwargs()) as aws_bedrock:
+        client_kwargs = (
+            self._assume_role_client_kwargs()
+            if self._effective_access_method() == "assume_role"
+            else self.get_client_kwargs()
+        )
+        async with session.client("bedrock-runtime", **client_kwargs) as aws_bedrock:
             yield aws_bedrock
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4913,6 +4913,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygithub"
 version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5478,6 +5492,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -6383,6 +6409,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7001,6 +7036,8 @@ bedrock = [
     { name = "aioboto3" },
     { name = "aiobotocore" },
     { name = "boto3" },
+    { name = "utic-auth", extra = ["aws"] },
+    { name = "utic-types" },
 ]
 biomed = [
     { name = "beautifulsoup4" },
@@ -7430,6 +7467,8 @@ requires-dist = [
     { name = "unstructured", extras = ["xlsx"], marker = "extra == 'xlsx'" },
     { name = "unstructured-client", marker = "extra == 'remote'", specifier = ">=0.30.0" },
     { name = "urllib3", marker = "extra == 'hubspot'" },
+    { name = "utic-auth", extras = ["aws"], marker = "extra == 'bedrock'", specifier = "==0.1.0.dev202606051418" },
+    { name = "utic-types", marker = "extra == 'bedrock'", specifier = "==1.4.0.dev202606051418" },
     { name = "vastdb", marker = "extra == 'vastdb'" },
     { name = "vertexai", marker = "extra == 'vertexai'" },
     { name = "voyageai", marker = "extra == 'voyageai'" },
@@ -7512,6 +7551,53 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "utic-auth"
+version = "0.1.0.dev202606051418"
+source = { registry = "https://pkgs.dev.azure.com/unstructured/_packaging/unstructured/pypi/simple/" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://pkgs.dev.azure.com/unstructured/_packaging/aa52cea6-240c-4a8e-8608-5e743a9d3711/pypi/download/utic-auth/0.1.dev202606051418/utic_auth-0.1.0.dev202606051418.tar.gz", hash = "sha256:ffac044dc21195c7a3ea013d984871d47b133f4c313d8e7b97e5b544617214f6" }
+wheels = [
+    { url = "https://pkgs.dev.azure.com/unstructured/_packaging/aa52cea6-240c-4a8e-8608-5e743a9d3711/pypi/download/utic-auth/0.1.dev202606051418/utic_auth-0.1.0.dev202606051418-py3-none-any.whl", hash = "sha256:82fb95d8349fb00e67d4c6cb73fe54d1f882abb24e355a9e49f8ffff6d354bef" },
+]
+
+[package.optional-dependencies]
+aws = [
+    { name = "boto3" },
+    { name = "botocore" },
+]
+
+[[package]]
+name = "utic-model-registry-schema"
+version = "2.3.1"
+source = { registry = "https://pkgs.dev.azure.com/unstructured/_packaging/unstructured/pypi/simple/" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "python-slugify" },
+]
+wheels = [
+    { url = "https://pkgs.dev.azure.com/unstructured/_packaging/aa52cea6-240c-4a8e-8608-5e743a9d3711/pypi/download/utic-model-registry-schema/2.3.1/utic_model_registry_schema-2.3.1-py3-none-any.whl", hash = "sha256:5e16eab3b915cc51734b4fdd0a0b00cb8f25db0220c6d7a835eeea6a1e52b669" },
+]
+
+[[package]]
+name = "utic-types"
+version = "1.4.0.dev202606051418"
+source = { registry = "https://pkgs.dev.azure.com/unstructured/_packaging/unstructured/pypi/simple/" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "unstructured-ingest" },
+    { name = "utic-model-registry-schema" },
+]
+sdist = { url = "https://pkgs.dev.azure.com/unstructured/_packaging/aa52cea6-240c-4a8e-8608-5e743a9d3711/pypi/download/utic-types/1.4.dev202606051418/utic_types-1.4.0.dev202606051418.tar.gz", hash = "sha256:b3b2d64264828bf9294a5a114fb205a4c722f2b1874658201bf6e39f3b72cd20" }
+wheels = [
+    { url = "https://pkgs.dev.azure.com/unstructured/_packaging/aa52cea6-240c-4a8e-8608-5e743a9d3711/pypi/download/utic-types/1.4.dev202606051418/utic_types-1.4.0.dev202606051418-py3-none-any.whl", hash = "sha256:f2fc47fa516e0aabaef3ab08c2b74577f9f21dacfcdca0789a6df9433a7f8377" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\n- add Bedrock embedder access_method support for credentials, IAM, and assume_role\n- use shared utic-aws-auth STS helpers for sync Bedrock clients\n- add async-client AssumeRole credential handling and selected-mode tests\n\n## Validation\n- Python compile passed for touched Bedrock embedder source/tests\n- Full package-resolution tests are blocked until utic-aws-auth is published\n\n## Stack notes\n- Depends on platform-libs shared utic-aws-auth package\n- Feeds platform-plugins embed package wiring

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AssumeRole support to the Bedrock embedder across sync and async clients, with explicit auth modes and stricter validation. Preserves legacy ambient IAM auth by default, aligns with DTPL-398, and fixes model ARN parsing in precheck.

- **New Features**
  - Add `access_method`: `credentials`, `iam`, `assume_role` (requires `role_arn` + `external_id`); support `aws_session_token`; default to ambient IAM when unset; reject ambiguous configs; ignore stale static keys for `assume_role`.
  - Centralize provider connection and client creation via `utic-types` + `utic-auth[aws]` for `bedrock` and `bedrock-runtime` (sync/async); add tests for each mode and validation errors.

- **Dependencies**
  - Pin `utic-auth[aws]==0.1.0.dev202606051418` and `utic-types==1.4.0.dev202606051418` in the `bedrock` extra.

<sup>Written for commit e781c5293cb88c3ea348787d74d1ac24250e9831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

