### PR TITLE
fix(teradata): classify driver errors and surface user-fault TD messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.6.8]
+
+### BREAKING
+
+- **`UserError.status_code` changed from `401` to `422`.** `401` is HTTP "Unauthorized" (unauthenticated) — that's what `UserAuthError` covers. `UserError` is for invalid user input / config, which is HTTP `422` (Unprocessable Entity). Subclasses that override `status_code` (`UserAuthError=401`, `RateLimitError=429`) are unaffected. `QuotaError` inherits without override and now reports `422` — callers matching on `status_code == 401` for quota errors must update.
+
+### Fixes
+
+- **fix(teradata): classify driver errors and surface user-fault TD messages.** Adds `_raise_classified_teradata_error` that inspects `[Error NNNN]` codes in `teradatasql` exceptions and re-raises recognised user-fault codes (`3807` object-missing-or-no-privilege, `3523` / `5612` / `5315` no privilege, `3706` / `3707` SQL syntax, `3753` / `3754` implicit type conversion) as `UserError` with the original Teradata message preserved via `"Teradata reported: …"`. Wraps `cursor.execute` in `TeradataUploader.get_table_columns`, `delete_by_record_id`, `upload_dataframe`, `create_destination`, and the `TeradataIndexer.precheck` table probe. Non-`teradatasql` exceptions (e.g. `MemoryError`, `OSError`) re-raise unchanged; unrecognised TD codes fall through to the existing `DestinationConnectionError` / `SourceConnectionError` wrapping so retry behaviour is preserved. (PLU-377)
+  - **Source-side behavior change:** The classification applies to both directions. `TeradataIndexer.precheck` previously always raised `SourceConnectionError` when its table probe failed; it now raises `UserError` for codes in the recognised map (3807, 3523, 5612, 5315, etc.) and `SourceConnectionError` only for unrecognised codes / network failures. Source-side callers that catch `SourceConnectionError` will no longer catch those cases.
+
 ## [1.6.7]
 
 ### Enhancements

--- a/test/unit/connectors/sql/test_teradata.py
+++ b/test/unit/connectors/sql/test_teradata.py
@@ -6,7 +6,11 @@ from pydantic import Secret
 from pytest_mock import MockerFixture
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
-from unstructured_ingest.error import DestinationConnectionError, SourceConnectionError
+from unstructured_ingest.error import (
+    DestinationConnectionError,
+    SourceConnectionError,
+    UserError,
+)
 from unstructured_ingest.processes.connectors.sql.teradata import (
     DEFAULT_TABLE_NAME,
     TeradataAccessConfig,
@@ -20,9 +24,24 @@ from unstructured_ingest.processes.connectors.sql.teradata import (
     TeradataUploadStager,
     TeradataUploadStagerConfig,
     _build_proxy_params,
+    _extract_teradata_error_code,
+    _is_teradata_driver_error,
+    _raise_classified_teradata_error,
     _resolve_db_column_case,
     _summarize_error,
 )
+
+
+# --- Test helper -------------------------------------------------------------
+# Many tests below need to raise an exception that the new
+# `_is_teradata_driver_error` filter accepts. Real `teradatasql.OperationalError`
+# isn't importable without the (optional) teradatasql package installed in the
+# test env, so we forge a stand-in by overriding ``__module__``.
+class _FakeTeradataDriverError(Exception):
+    """Stand-in for a teradatasql driver exception (same module signature)."""
+
+
+_FakeTeradataDriverError.__module__ = "teradatasql"
 
 
 @pytest.fixture
@@ -560,21 +579,40 @@ def test_teradata_downloader_query_db_no_duplicate_when_id_in_fields(
     assert select_part.count('"id"') == 1
 
 
-def test_teradata_indexer_precheck_table_not_found(
+def test_teradata_indexer_precheck_table_not_found_raises_user_error(
     mock_cursor: MagicMock,
     teradata_indexer: TeradataIndexer,
     mock_get_cursor: MagicMock,
 ):
-    """Test that precheck raises SourceConnectionError when table doesn't exist."""
+    """When Teradata returns [Error 3807] the indexer precheck raises a UserError
+    that names the table and forwards the raw TD message — so the customer can
+    self-serve the fix instead of seeing 'Failed to connect…'."""
     mock_cursor.execute.side_effect = [
         None,  # SELECT 1 succeeds
-        Exception("[Error 3807] Object 'year' does not exist"),
+        _FakeTeradataDriverError("[Error 3807] Object 'year' does not exist"),
     ]
 
-    with pytest.raises(SourceConnectionError, match="table 'year'.*not found or not accessible"):
+    with pytest.raises(UserError, match=r"3807.*does not exist or user has no privilege.*'year'"):
         teradata_indexer.precheck()
 
     assert mock_cursor.execute.call_count == 2
+
+
+def test_teradata_indexer_precheck_table_unknown_error_falls_back_to_source_error(
+    mock_cursor: MagicMock,
+    teradata_indexer: TeradataIndexer,
+    mock_get_cursor: MagicMock,
+):
+    """A table-probe failure with a teradatasql-shaped exception but no recognised
+    TD error code falls back to SourceConnectionError AND preserves the historical
+    "table 'X' not found or not accessible" context message."""
+    mock_cursor.execute.side_effect = [
+        None,  # SELECT 1 succeeds
+        _FakeTeradataDriverError("some unexpected driver error without a [Error N] tag"),
+    ]
+
+    with pytest.raises(SourceConnectionError, match=r"table 'year'.*not found or not accessible"):
+        teradata_indexer.precheck()
 
 
 def test_teradata_uploader_precheck_success(
@@ -1211,3 +1249,276 @@ def test_split_dataframe_no_empty_chunk_for_exact_multiples():
         chunks = list(split_dataframe(df, chunk_size=50))
         assert all(len(c) > 0 for c in chunks), f"empty chunk for n={n}"
         assert sum(len(c) for c in chunks) == n
+
+
+# ─── Teradata error-code classification ──────────────────────────────────────
+#
+# The legacy SQL connector used to swallow Teradata driver exceptions into a
+# generic "Failed to connect" / "Unexpected job failure" wrapper, hiding the
+# actual server message. These tests cover the new typed-error mapping so a
+# customer config mistake (missing table, missing privilege, bad SQL) surfaces
+# as a UserError carrying the raw TD message — matching the PLU-337 pattern
+# already in place for the teradata_vector_v2 connector.
+#
+# (See _FakeTeradataDriverError near the top of this file for why we forge a
+# module-name signature instead of importing teradatasql.OperationalError.)
+
+
+def test_is_teradata_driver_error_module_check():
+    """Module-name filter accepts teradatasql exceptions and rejects others."""
+    assert _is_teradata_driver_error(_FakeTeradataDriverError("x")) is True
+    assert _is_teradata_driver_error(MemoryError("oom")) is False
+    assert _is_teradata_driver_error(OSError("io")) is False
+    assert _is_teradata_driver_error(Exception("generic")) is False
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_code"),
+    [
+        ("[Error 3807] Object 'abc_123' does not exist", 3807),
+        ("[Version 20.0.0.54] [Session 11529] [Teradata Database] [Error 3807] x", 3807),
+        ("[Error 3523] User does not have CREATE TABLE privilege", 3523),
+        ("dial tcp 10.0.0.1:1025: i/o timeout", None),
+        ("", None),
+    ],
+)
+def test_extract_teradata_error_code(message: str, expected_code: int | None):
+    assert _extract_teradata_error_code(Exception(message)) == expected_code
+
+
+@pytest.mark.parametrize(
+    ("code", "fragment"),
+    [
+        (3807, "does not exist or user has no privilege"),
+        (3523, "user does not have the required privilege"),
+        (3706, "SQL syntax error"),
+        (3707, "SQL syntax error"),
+        (3753, "floating-point overflow during implicit conversion"),
+        (3754, "implicit type conversion failed"),
+        (5612, "user does not have any access to the object"),
+        (5315, "user does not have any access to the database"),
+    ],
+)
+def test_classified_teradata_error_user_fault_codes_raise_user_error(
+    code: int, fragment: str
+):
+    """Recognised user-fault codes → UserError with the descriptor and raw message."""
+    exc = _FakeTeradataDriverError(f"[Error {code}] something bad happened")
+    with pytest.raises(UserError) as excinfo:
+        _raise_classified_teradata_error(exc, host="td.example.com", table="my_table")
+    msg = str(excinfo.value)
+    assert str(code) in msg
+    assert fragment in msg
+    assert "'my_table'" in msg
+    assert "Teradata reported" in msg
+    # Original exception is chained so the driver traceback survives in logs.
+    assert excinfo.value.__cause__ is exc
+
+
+def test_classified_teradata_error_extract_picks_last_code_in_chain():
+    """When a driver message chains multiple [Error N] tags, the LAST (most
+    specific / innermost) is what gets classified."""
+    exc = _FakeTeradataDriverError("[Error 9999] outer wrapper; caused by [Error 3754] inner")
+    assert _extract_teradata_error_code(exc) == 3754
+
+
+def test_classified_teradata_error_unknown_code_destination_fallback():
+    """Unknown code on a destination path → DestinationConnectionError preserved."""
+    exc = _FakeTeradataDriverError("[Error 9999] something we don't classify yet")
+    with pytest.raises(DestinationConnectionError):
+        _raise_classified_teradata_error(exc, host="td.example.com", table="t")
+
+
+def test_classified_teradata_error_unknown_code_source_fallback():
+    """Unknown code on a source path → SourceConnectionError preserved."""
+    exc = _FakeTeradataDriverError("connection reset by peer")
+    with pytest.raises(SourceConnectionError):
+        _raise_classified_teradata_error(
+            exc, host="td.example.com", table="t", direction="source"
+        )
+
+
+def test_classified_teradata_error_no_code_falls_back():
+    """Driver exception without an [Error NNNN] tag (network blip etc.) falls back."""
+    exc = _FakeTeradataDriverError("dial tcp 10.0.0.1:1025: i/o timeout")
+    with pytest.raises(DestinationConnectionError):
+        _raise_classified_teradata_error(exc, host="td.example.com")
+
+
+def test_classified_teradata_error_rejects_invalid_direction():
+    """Runtime check on direction prevents Literal-only typos (e.g.
+    direction='DESTINATION' uppercase) from silently falling into the wrong path."""
+    exc = _FakeTeradataDriverError("[Error 9999]")
+    with pytest.raises(AssertionError, match="direction must be"):
+        _raise_classified_teradata_error(
+            exc, host="td.example.com", direction="DESTINATION"  # type: ignore[arg-type]
+        )
+
+
+def test_classified_teradata_error_fallback_context_is_forwarded():
+    """fallback_context flows into _summarize_error so callers can preserve
+    historical per-site messages (e.g. the indexer's 'table X not found')."""
+    exc = _FakeTeradataDriverError("[Error 9999] unknown code")
+    with pytest.raises(SourceConnectionError, match=r"table 'year'.*not found or not accessible"):
+        _raise_classified_teradata_error(
+            exc,
+            host="td.example.com",
+            table="year",
+            direction="source",
+            fallback_context="table 'year' not found or not accessible",
+        )
+
+
+def test_teradata_uploader_get_table_columns_missing_table_raises_user_error(
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """get_table_columns translates Teradata 3807 into a UserError instead of
+    letting the bare driver exception bubble through the etl-api retry wrapper."""
+    mock_cursor.execute.side_effect = _FakeTeradataDriverError(
+        "[Error 3807] Object 'test_table' does not exist"
+    )
+    teradata_uploader._columns = None
+
+    with pytest.raises(UserError, match="3807.*'test_table'"):
+        teradata_uploader.get_table_columns()
+
+
+def test_teradata_uploader_get_table_columns_non_teradata_error_is_reraised(
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """Non-teradata exceptions (e.g. OSError, MemoryError) must bubble up
+    unchanged — only teradatasql driver errors get reclassified."""
+    mock_cursor.execute.side_effect = MemoryError("simulated OOM during fetch")
+    teradata_uploader._columns = None
+
+    with pytest.raises(MemoryError):
+        teradata_uploader.get_table_columns()
+
+
+def test_teradata_uploader_delete_by_record_id_type_mismatch_raises_user_error(
+    mocker: MockerFixture,
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """Reproduces the production scenario: customer created abc_123 with record_id
+    BIGINT instead of VARCHAR. Connector sends a string identifier, Teradata returns
+    [Error 3754]. Without this mapping the customer sees 'Failed to connect…' (wrong);
+    with it they see the actual type-mismatch message."""
+    mocker.patch.object(
+        teradata_uploader, "_get_db_column_name", return_value="record_id"
+    )
+    mock_cursor.execute.side_effect = _FakeTeradataDriverError(
+        "[Error 3754] Precision error in FLOAT type constant or during implicit conversions."
+    )
+
+    file_data = FileData(
+        identifier="1xdNXwlv2yuGJyUMzQgmtdlAOesAP673T",  # Google Drive file id (string)
+        connector_type="google_drive",
+        source_identifiers=SourceIdentifiers(
+            filename="report.pdf", fullpath="ofc_data1/report.pdf"
+        ),
+    )
+
+    with pytest.raises(UserError, match="3754.*implicit type conversion failed.*'test_table'"):
+        teradata_uploader.delete_by_record_id(file_data)
+
+
+def test_teradata_uploader_delete_by_record_id_missing_table_raises_user_error(
+    mocker: MockerFixture,
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """delete_by_record_id surfaces a 3807 as UserError, not a swallowed driver error."""
+    # Skip the get_table_columns lookup that delete_by_record_id makes first.
+    mocker.patch.object(
+        teradata_uploader, "_get_db_column_name", return_value="record_id"
+    )
+    mock_cursor.execute.side_effect = _FakeTeradataDriverError(
+        "[Error 3807] Object 'test_table' does not exist"
+    )
+
+    file_data = FileData(
+        identifier="test_file.txt",
+        connector_type="local",
+        source_identifiers=SourceIdentifiers(
+            filename="test_file.txt", fullpath="/path/to/test_file.txt"
+        ),
+    )
+
+    with pytest.raises(UserError, match="3807.*'test_table'"):
+        teradata_uploader.delete_by_record_id(file_data)
+
+
+def test_teradata_uploader_upload_dataframe_no_privilege_raises_user_error(
+    mocker: MockerFixture,
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """An INSERT that hits 3523 (no INSERT privilege) surfaces as UserError so the
+    customer-visible message points at the privilege issue rather than retrying
+    3 times into a generic 'Unexpected job failure'."""
+    df = pd.DataFrame({"id": [1], "text": ["hi"], "record_id": ["f1"]})
+    teradata_uploader._columns = ["id", "text", "record_id"]
+    mocker.patch.object(teradata_uploader, "_fit_to_schema", return_value=df)
+    mocker.patch.object(teradata_uploader, "can_delete", return_value=False)
+    mock_cursor.executemany.side_effect = _FakeTeradataDriverError(
+        "[Error 3523] User test_user does not have INSERT privilege on test_table"
+    )
+
+    file_data = FileData(
+        identifier="test_file.txt",
+        connector_type="local",
+        source_identifiers=SourceIdentifiers(
+            filename="test_file.txt", fullpath="/path/to/test_file.txt"
+        ),
+    )
+
+    with pytest.raises(UserError, match="3523.*does not have the required privilege"):
+        teradata_uploader.upload_dataframe(df, file_data)
+
+
+def test_teradata_uploader_create_destination_no_privilege_raises_user_error(
+    mock_cursor: MagicMock,
+    teradata_connection_config: TeradataConnectionConfig,
+    mock_get_cursor: MagicMock,
+):
+    """When a customer's user lacks CREATE TABLE privilege, auto-creation surfaces
+    the privilege error as UserError instead of a bare driver exception.
+
+    Note: this test deliberately creates an uploader with table_name=None so that
+    create_destination()'s ``table_name = self.upload_config.table_name or
+    destination_name`` resolves to ``destination_name`` (the production code path
+    for opinionated writes). The shared fixture sets table_name='test_table' which
+    would short-circuit destination_name."""
+    uploader = TeradataUploader(
+        connection_config=teradata_connection_config,
+        upload_config=TeradataUploaderConfig(table_name=None, record_id_key="record_id"),
+    )
+    # cursor.execute side_effects, in call order:
+    #   1. SELECT DATABASE             → None (sets up fetchone for current_db)
+    #   2. SELECT 1 FROM DBC.TablesV   → None (table-exists check)
+    #   3. CREATE MULTISET TABLE ...   → raises driver error
+    # cursor.fetchone side_effects:
+    #   1. ('test_db',)  → current_db
+    #   2. None          → "table doesn't exist", proceed to CREATE
+    mock_cursor.fetchone.side_effect = [("test_db",), None]
+    mock_cursor.execute.side_effect = [
+        None,
+        None,
+        _FakeTeradataDriverError(
+            "[Error 3523] User test_user does not have CREATE TABLE privilege"
+        ),
+    ]
+
+    with pytest.raises(
+        UserError,
+        match=r"3523.*does not have the required privilege.*brand_new_table",
+    ):
+        uploader.create_destination(destination_name="brand_new_table")

--- a/test/unit/test_error.py
+++ b/test/unit/test_error.py
@@ -3,7 +3,11 @@ import pytest
 from unstructured_ingest.error import (
     DestinationConnectionError,
     PartitionError,
+    QuotaError,
+    RateLimitError,
     SourceConnectionError,
+    UserAuthError,
+    UserError,
 )
 
 
@@ -25,3 +29,25 @@ def test_custom_error_decorator(error_class, exception_type, error_message):
 
     expected_error_string = error_class.error_string.format(error_message)
     assert str(context.value) == expected_error_string
+
+
+# Status code contract — pinned so the deliberate 401 → 422 change in PLU-377
+# can't silently revert, and so the inheritance fan-out is explicit.
+@pytest.mark.parametrize(
+    ("error_class", "expected_status_code"),
+    [
+        # UserError changed from 401 to 422 in PLU-377: 422 (Unprocessable
+        # Entity) is the correct HTTP semantic for "your input is invalid"
+        # whereas 401 (Unauthorized) is for unauthenticated requests.
+        (UserError, 422),
+        # UserAuthError overrides and stays 401 — actual unauthenticated case.
+        (UserAuthError, 401),
+        # RateLimitError overrides with its own HTTP semantic (429).
+        (RateLimitError, 429),
+        # QuotaError inherits UserError without override and now reports 422
+        # (was 401 before PLU-377). Pin so the inheritance contract is explicit.
+        (QuotaError, 422),
+    ],
+)
+def test_error_status_codes(error_class, expected_status_code):
+    assert error_class("x").status_code == expected_status_code

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.7"  # pragma: no cover
+__version__ = "1.6.8"  # pragma: no cover

--- a/unstructured_ingest/error.py
+++ b/unstructured_ingest/error.py
@@ -53,8 +53,11 @@ class EmbeddingEncoderConnectionError(ConnectionError):
 
 
 class UserError(UnstructuredIngestError):
+    # 422 (Unprocessable Entity) is the correct HTTP semantic for "your input
+    # is invalid". The prior 401 (Unauthorized) was wrong: 401 specifically
+    # means unauthenticated, which is what UserAuthError covers below.
     error_string = "User error: {}"
-    status_code: Optional[int] = 401
+    status_code: Optional[int] = 422
 
 
 class UserAuthError(UserError):

--- a/unstructured_ingest/processes/connectors/sql/teradata.py
+++ b/unstructured_ingest/processes/connectors/sql/teradata.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Generator, Literal, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Generator, Literal, Mapping, NoReturn, Optional
 
 from pydantic import Field, Secret
 
@@ -108,7 +108,7 @@ def _raise_classified_teradata_error(
     table: Optional[str] = None,
     direction: Literal["source", "destination"] = "destination",
     fallback_context: str = "",
-) -> None:
+) -> NoReturn:
     """Re-raise a Teradata driver exception as a typed unstructured-ingest error.
 
     Classification rules:

--- a/unstructured_ingest/processes/connectors/sql/teradata.py
+++ b/unstructured_ingest/processes/connectors/sql/teradata.py
@@ -4,12 +4,17 @@ import re
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Optional
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Generator, Literal, Mapping, Optional
 
 from pydantic import Field, Secret
 
 from unstructured_ingest.data_types.file_data import FileData
-from unstructured_ingest.error import DestinationConnectionError, SourceConnectionError
+from unstructured_ingest.error import (
+    DestinationConnectionError,
+    SourceConnectionError,
+    UserError,
+)
 from unstructured_ingest.logger import logger
 from unstructured_ingest.processes.connector_registry import (
     DestinationRegistryEntry,
@@ -46,6 +51,108 @@ def _sanitize_table_name(name: str) -> str:
     if sanitized and sanitized[0].isdigit():
         sanitized = f"_{sanitized}"
     return sanitized
+
+
+_TERADATA_ERROR_CODE_RE = re.compile(r"\[Error (\d+)\]")
+
+# Teradata server error codes mapped to typed exceptions. UserError covers the
+# customer-fixable cases (missing object, missing privilege, SQL syntax, schema
+# mismatch); these never benefit from retry. Codes not listed here fall through
+# unchanged so the existing retry / wrapping behaviour is preserved.
+#
+# 3807 is overloaded: Teradata returns it for both "object does not exist" and
+# "user has no privilege on the object" (existence is hidden from unprivileged
+# users). The descriptor reflects both possibilities.
+#
+# 3753/3754 are implicit-conversion failures — most often hit when a table is
+# pre-created with the wrong column type for the value being inserted/queried,
+# but can also fire on arbitrary expression-level conversions; the descriptor
+# stays generic.
+_USER_FAULT_TERADATA_CODES: Mapping[int, str] = MappingProxyType({
+    3807: "object does not exist or user has no privilege on it",
+    3523: "user does not have the required privilege",
+    3706: "SQL syntax error",
+    3707: "SQL syntax error",
+    3753: "floating-point overflow during implicit conversion",
+    3754: "implicit type conversion failed",
+    5612: "user does not have any access to the object",
+    5315: "user does not have any access to the database",
+})
+
+
+def _is_teradata_driver_error(exc: BaseException) -> bool:
+    """True if exc comes from the teradatasql driver package.
+
+    Module name check avoids importing teradatasql at module load time
+    (it's an optional dependency).
+    """
+    module = type(exc).__module__
+    return module == "teradatasql" or module.startswith("teradatasql.")
+
+
+def _extract_teradata_error_code(exc: BaseException) -> Optional[int]:
+    """Return the most specific ``[Error NNNN]`` code in the driver exception, or None.
+
+    Teradata error messages may chain multiple ``[Error N]`` tags from different
+    layers (driver wrapper, server response, etc.). We return the LAST match,
+    which in practice is the innermost / most specific server-side code.
+    """
+    matches = _TERADATA_ERROR_CODE_RE.findall(str(exc))
+    return int(matches[-1]) if matches else None
+
+
+def _raise_classified_teradata_error(
+    exc: Exception,
+    *,
+    host: str,
+    table: Optional[str] = None,
+    direction: Literal["source", "destination"] = "destination",
+    fallback_context: str = "",
+) -> None:
+    """Re-raise a Teradata driver exception as a typed unstructured-ingest error.
+
+    Classification rules:
+      * Server-side codes listed in ``_USER_FAULT_TERADATA_CODES`` → ``UserError``
+        (status_code 422, with the raw TD message preserved via
+        ``"Teradata reported: …"``). Applies to BOTH source and destination
+        directions — this means indexer callers historically catching
+        ``SourceConnectionError`` will now see ``UserError`` for codes in the
+        map (e.g. 3523 no-privilege on the source-table probe).
+      * Anything else → ``DestinationConnectionError`` / ``SourceConnectionError``
+        with the existing one-line ``_summarize_error`` message. The optional
+        ``fallback_context`` is forwarded so callers can preserve historical
+        per-site message shapes (e.g. the indexer's
+        ``"table 'X' not found or not accessible"``).
+
+    Always raises; never returns. Original exception is chained via ``from exc``
+    so the full driver traceback remains available in logs.
+
+    :param exc: the original driver exception; chained via ``from exc``.
+    :param host: server hostname (used by _summarize_error for fallback message).
+    :param table: target table name (formatted into UserError message if given).
+    :param direction: 'source' or 'destination'. Validated at runtime.
+    :param fallback_context: passed to _summarize_error when the code is
+        unrecognised; preserves historical per-call-site message shapes.
+    """
+    if direction not in ("source", "destination"):
+        raise AssertionError(
+            f"direction must be 'source' or 'destination', got {direction!r}"
+        )
+    code = _extract_teradata_error_code(exc)
+    if code in _USER_FAULT_TERADATA_CODES:
+        descriptor = _USER_FAULT_TERADATA_CODES[code]
+        target = f" for '{table}'" if table else ""
+        raise UserError(
+            f"Teradata error {code} ({descriptor}){target}. "
+            f"Teradata reported: {exc}"
+        ) from exc
+
+    conn_error_cls = (
+        DestinationConnectionError if direction == "destination" else SourceConnectionError
+    )
+    raise conn_error_cls(
+        _summarize_error(host, exc, context=fallback_context)
+    ) from exc
 
 
 def _summarize_error(host: str, raw: Exception, context: str = "") -> str:
@@ -213,12 +320,19 @@ class TeradataIndexer(SQLIndexer):
                 f"Table '{table_name}' not found or not accessible: {e}",
                 exc_info=True,
             )
-            raise SourceConnectionError(
-                _summarize_error(
-                    self.connection_config.host,
-                    e,
-                    context=f"table '{table_name}' not found or not accessible",
-                )
+            if not _is_teradata_driver_error(e):
+                raise
+            # If Teradata returned a recognised user-fault code (3807 missing object,
+            # 5612/5315 no privilege, etc.) raise UserError so the platform can
+            # surface the actionable message; otherwise preserve the existing
+            # SourceConnectionError shape with the historical "table 'X' not found"
+            # context the source side has always emitted.
+            _raise_classified_teradata_error(
+                e,
+                host=self.connection_config.host,
+                table=table_name,
+                direction="source",
+                fallback_context=f"table '{table_name}' not found or not accessible",
             )
 
     def _get_doc_ids(self) -> list[str]:
@@ -391,8 +505,19 @@ class TeradataUploader(SQLUploader):
         schema_lines[0] = schema_lines[0].replace("elements", table_name)
         schema_sql = "".join(line.strip() for line in schema_lines)
         logger.info(f"creating table {table_name} for user")
-        with self.get_cursor() as cursor:
-            cursor.execute(schema_sql)
+        try:
+            with self.get_cursor() as cursor:
+                cursor.execute(schema_sql)
+        except Exception as e:
+            if not _is_teradata_driver_error(e):
+                raise
+            logger.error(
+                f"failed to create destination table '{table_name}': {e}",
+                exc_info=True,
+            )
+            _raise_classified_teradata_error(
+                e, host=self.connection_config.host, table=table_name
+            )
         return True
 
     def precheck(self) -> None:
@@ -405,9 +530,21 @@ class TeradataUploader(SQLUploader):
 
     def get_table_columns(self) -> list[str]:
         if self._columns is None:
-            with self.get_cursor() as cursor:
-                cursor.execute(f'SELECT TOP 1 * FROM "{self.upload_config.table_name}"')
-                self._columns = [desc[0] for desc in cursor.description]
+            table_name = self.upload_config.table_name
+            try:
+                with self.get_cursor() as cursor:
+                    cursor.execute(f'SELECT TOP 1 * FROM "{table_name}"')
+                    self._columns = [desc[0] for desc in cursor.description]
+            except Exception as e:
+                if not _is_teradata_driver_error(e):
+                    raise
+                logger.error(
+                    f"failed to read schema for table '{table_name}': {e}",
+                    exc_info=True,
+                )
+                _raise_classified_teradata_error(
+                    e, host=self.connection_config.host, table=table_name
+                )
         return self._columns
 
     def _get_db_column_name(self, name: str) -> str:
@@ -428,11 +565,27 @@ class TeradataUploader(SQLUploader):
             f'DELETE FROM "{self.upload_config.table_name}" '
             f'WHERE "{record_id_col}" = {self.values_delimiter}'
         )
-        with self.get_cursor() as cursor:
-            cursor.execute(stmt, [file_data.identifier])
-            rowcount = cursor.rowcount
-            if rowcount > 0:
-                logger.info(f"deleted {rowcount} rows from table {self.upload_config.table_name}")
+        try:
+            with self.get_cursor() as cursor:
+                cursor.execute(stmt, [file_data.identifier])
+                rowcount = cursor.rowcount
+                if rowcount > 0:
+                    logger.info(
+                        f"deleted {rowcount} rows from table {self.upload_config.table_name}"
+                    )
+        except Exception as e:
+            if not _is_teradata_driver_error(e):
+                raise
+            logger.error(
+                f"failed to delete record_id={file_data.identifier} from "
+                f"'{self.upload_config.table_name}': {e}",
+                exc_info=True,
+            )
+            _raise_classified_teradata_error(
+                e,
+                host=self.connection_config.host,
+                table=self.upload_config.table_name,
+            )
 
     def upload_dataframe(self, df: "DataFrame", file_data: FileData) -> None:
         import numpy as np
@@ -464,11 +617,32 @@ class TeradataUploader(SQLUploader):
             f" table named {self.upload_config.table_name}"
             f" with batch size {self.upload_config.batch_size}"
         )
+        # Each batch is committed independently via get_cursor's teardown. If a
+        # later batch fails after earlier batches have committed, those rows
+        # remain in the destination — the etl-api retry layer will reprocess
+        # the whole record, so as long as record_id_key is present on the table
+        # (can_delete() returns True) the DELETE-then-INSERT cycle scrubs them.
+        # If can_delete() is False, partial-write rows will accumulate on retry.
         for rows in split_dataframe(df=df, chunk_size=self.upload_config.batch_size):
-            with self.get_cursor() as cursor:
-                values = self.prepare_data(columns, tuple(rows.itertuples(index=False, name=None)))
-                logger.debug(f"running query: {stmt}")
-                cursor.executemany(stmt, values)
+            try:
+                with self.get_cursor() as cursor:
+                    values = self.prepare_data(
+                        columns, tuple(rows.itertuples(index=False, name=None))
+                    )
+                    logger.debug(f"running query: {stmt}")
+                    cursor.executemany(stmt, values)
+            except Exception as e:
+                if not _is_teradata_driver_error(e):
+                    raise
+                logger.error(
+                    f"failed to insert batch into '{self.upload_config.table_name}': {e}",
+                    exc_info=True,
+                )
+                _raise_classified_teradata_error(
+                    e,
+                    host=self.connection_config.host,
+                    table=self.upload_config.table_name,
+                )
 
 
 teradata_source_entry = SourceRegistryEntry(


### PR DESCRIPTION
## Summary

Customer-fixable Teradata SQL destination errors (missing object, missing privilege, SQL syntax, schema mismatch) were being swallowed into a generic `"Unexpected job failure after 3 retries"` wrapper in the platform UI, hiding the actual server message. Mirrors the PLU-337 pattern already shipped for `teradata_vector_v2`.

Replaces #721 — clean single commit off latest `main`.

Linear: [PLU-377](https://linear.app/unstructured/issue/PLU-377/port-plu-337-error-surfacing-pattern-to-legacy-teradata-sql)

## What this changes

### `unstructured_ingest/error.py`
- **BREAKING:** `UserError.status_code` `401` → `422`. `401` is HTTP "Unauthorized" (unauthenticated) which is what `UserAuthError` covers. `UserError` is for invalid user input/config (HTTP 422). `UserAuthError` (`401`) and `RateLimitError` (`429`) override and are unaffected; `QuotaError` inherits without override and now reports `422`.

### `unstructured_ingest/processes/connectors/sql/teradata.py`
- `_USER_FAULT_TERADATA_CODES` (frozen via `MappingProxyType`):
  - `3807` object missing or no privilege
  - `3523` / `5612` / `5315` no privilege
  - `3706` / `3707` SQL syntax
  - `3753` / `3754` implicit type conversion / schema mismatch
- `_is_teradata_driver_error(exc)` — module-name check; lets non-teradatasql exceptions (`MemoryError`, `OSError`, etc.) bubble up unchanged.
- `_extract_teradata_error_code(exc)` — `re.findall` + last-match-wins (innermost / most specific server-side code).
- `_raise_classified_teradata_error(exc, *, host, table=None, direction: Literal["source","destination"]="destination", fallback_context="")`:
  - recognised user-fault code → `UserError` with `"Teradata reported: …"` carrying the raw TD message
  - anything else → existing `DestinationConnectionError` / `SourceConnectionError`
  - `direction` validated at runtime to catch typos that mypy can't
  - `fallback_context` forwarded to `_summarize_error` so the indexer can preserve its `"table 'X' not found or not accessible"` message for unrecognised codes
- `cursor.execute` wrapped in `TeradataUploader.{get_table_columns, delete_by_record_id, upload_dataframe, create_destination}` and `TeradataIndexer.precheck` table-probe. Each site re-raises non-teradatasql exceptions unchanged.

### Tests
- `test_error.py` — pin status codes for `UserError` (422), `UserAuthError` (401), `RateLimitError` (429), `QuotaError` (422 by inheritance).
- `test_teradata.py` — +28 tests: code parsing (incl. last-wins for chained codes), every recognised user-fault code, fallback paths, fallback_context forwarding, runtime direction-assertion, non-teradata exceptions re-raising, per-call-site behavior. Forges a `_FakeTeradataDriverError` stand-in since `teradatasql` is an optional test dependency.

### CHANGELOG
- Separate `### BREAKING` and `### Fixes` sections; source-side behavior change called out explicitly.

## Source-side behavior change

The classification applies to both directions. `TeradataIndexer.precheck` previously always raised `SourceConnectionError` when its table probe failed; for codes in the recognised map it now raises `UserError` instead. Source-side callers catching `SourceConnectionError` will no longer catch those cases. Called out in the CHANGELOG.

## Reproducer

Cluster `teradata-dev`, job `6f2e840f-bb4d-4816-bea3-7be4d36771ca` (2026-05-26). Destination connector with `table_name=abc_123`. Plugin pod log (Loki):

```
[Version 20.0.0.54] [Session 11529] [Teradata Database] [Error 3807] Object 'abc_123' does not exist.
  File ".../unstructured_ingest/processes/connectors/sql/teradata.py", line 317, in get_table_columns
    cursor.execute(f'SELECT TOP 1 * FROM "{self.upload_config.table_name}"')
```

UI surfaced: `Unexpected job failure after 3 retries`. After this fix, raises:

```
UserError: Teradata error 3807 (object does not exist or user has no privilege on it)
for 'abc_123'. Teradata reported: [Teradata Database] [Error 3807] Object 'abc_123'
does not exist.
```

…which the `platform-plugins-uploader` `handle_exception` layer can render.

## Out of scope

- `platform-plugins-uploader` `handle_exception` change to map `UserError` → HTTP 422 in the response body. Different repo, separate PR.
- `etl-api` retry-summary loss (the outer `"Unexpected job failure after 3 retries"` wrapping in `etl_job_api.job_stats.publish_stats`). Separate fix.
- Porting the pattern to other SQL connectors. Taxonomy in `unstructured_ingest.error` is reusable; per-connector code mappings would follow this PR's pattern.

## Test plan

- [x] `pytest test/unit/connectors/sql/test_teradata.py test/unit/test_error.py` — **102** teradata + **4** new status-code tests passing
- [x] `pytest -n auto test/unit/ --ignore test/unit/unstructured` — **735** passing, no regressions
- [x] `ruff check` on modified files — clean
- [x] Manual verification on `teradata-dev` cluster with custom-built image overlay (3.0.81-plu377-test); production error `[Error 3754]` correctly surfaced as `UserError` instead of generic wrapper
- [ ] CI: Static Analysis, Pre Build Tests, build-and-push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies `teradatasql` errors so customer-fixable Teradata issues surface as clear `UserError` messages instead of a generic retry failure. Also updates `UserError.status_code` to 422 and bumps version to 1.6.8. Addresses PLU-377.

- **Bug Fixes**
  - Map Teradata codes to `UserError`: 3807 (missing object or no privilege), 3523/5612/5315 (no privilege), 3706/3707 (SQL syntax), 3753/3754 (implicit type conversion).
  - Add `_is_teradata_driver_error`, `_extract_teradata_error_code` (last match), and `_raise_classified_teradata_error` to emit `UserError` with “Teradata reported: …”. Unknown codes fall back to `DestinationConnectionError`/`SourceConnectionError`.
  - Wrap driver calls in `TeradataUploader.get_table_columns`, `delete_by_record_id`, `upload_dataframe`, `create_destination`, and `TeradataIndexer.precheck`. Non-`teradatasql` exceptions re-raise unchanged.
  - Preserve source-side fallback text via `fallback_context` when the code is unrecognized. Update CHANGELOG; version bumped to 1.6.8. Annotate `_raise_classified_teradata_error` as `NoReturn`.

- **Migration**
  - `UserError.status_code` is now 422; `QuotaError` inherits 422.
  - `TeradataIndexer.precheck` now raises `UserError` for known codes instead of `SourceConnectionError`. If you catch `SourceConnectionError`, also handle `UserError`.

<sup>Written for commit 23182bd9a8a35f6a22a869d71332a7526a7e98f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

