### PR TITLE
feat(PLU-384): flatten metadata in Weaviate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.9]
+
+### Enhancements
+
+- **feat(weaviate): add `flatten_metadata` option to the Weaviate uploader.** Opt-in, default off. When set, the stager flattens element `metadata` into top-level properties (lists pass through unmodified) and skips all default-mode coercions (date reformatting, JSON-stringification of `record_locator` / `coordinates.points` / `links` / `permissions_data` / `regex_metadata`, string casting of `version` / `page_number`). The uploader requires an explicit pre-created collection — `create_destination` no-ops, and `precheck` validates collection existence and the presence of `record_id_key` so re-run delete-by-record-id continues to work. Per-element, properties not declared on the user's schema are dropped and missing schema properties are filled with `None`. Default behavior (`flatten_metadata=False`) is unchanged.
+
 ## [1.6.8]
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.8]
+
+### Enhancements
+
+- **feat(weaviate): add `flatten_metadata` option to the Weaviate uploader.** Opt-in, default off. When set, the stager runs a pure flatten over element metadata (recursive dict flatten with `flatten_lists=False`, no opinionated coercion); the uploader queries the destination collection's schema, drops incoming fields not declared in the schema, and fills declared-but-absent fields with null. The destination collection must be pre-created — `create_destination` is a no-op in this mode and `precheck` enforces collection existence plus a `record_id` property for re-run dedup. Schema-shape (e.g. `OBJECT_ARRAY` with `nested_properties` for `links` / `permissions_data` / `regex_metadata_<pattern>`) is the user's call.
+
 ## [1.6.7]
 
 ### Enhancements

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -677,6 +677,7 @@ def test_delete_by_record_id_loops_until_no_more_results(
     """The delete loop re-runs until a response with failed=0 AND
     successful=0 is observed (Weaviate's QUERY_MAXIMUM_RESULTS limit
     means a single delete may not clear everything)."""
+    pytest.importorskip("weaviate")
     uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
     mock_client = MagicMock()
     delete_mock = mock_client.collections.get.return_value.data.delete_many
@@ -695,6 +696,7 @@ def test_delete_by_record_id_raises_on_failure_response(
 ):
     """A response with failed > 0 raises immediately, preserving the
     original record id in the message for debugging."""
+    pytest.importorskip("weaviate")
     uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
     mock_client = MagicMock()
     delete_mock = mock_client.collections.get.return_value.data.delete_many

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -615,22 +615,37 @@ def test_precheck_default_mode_collection_exists_passes(
     mock_client.collections.get.assert_not_called()
 
 
-@pytest.mark.parametrize("flatten_metadata", [True, False])
-def test_precheck_collection_none_skips_validation(
+def test_precheck_default_mode_collection_none_skips_validation(
     uploader: WeaviateUploader,
     connection_config: WeaviateConnectionConfigTest,
-    flatten_metadata: bool,
 ):
-    """If no collection name is set, precheck silently passes — the missing
-    name is a config error caught later in run_data."""
+    """In default mode, if no collection name is set precheck silently passes —
+    the missing name is resolved later in create_destination (fallback to
+    'Unstructuredautocreated')."""
     uploader.upload_config = WeaviateUploaderConfig(
-        collection=None, flatten_metadata=flatten_metadata
+        collection=None, flatten_metadata=False
     )
     mock_client = MagicMock()
     connection_config.set_mock_client(mock_client)
 
     uploader.precheck()
     mock_client.collections.exists.assert_not_called()
+
+
+def test_precheck_flatten_mode_collection_none_raises(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+):
+    """Flatten mode requires an explicit collection name because there is no
+    auto-create fallback — fail early with a clear message."""
+    uploader.upload_config = WeaviateUploaderConfig(
+        collection=None, flatten_metadata=True
+    )
+    mock_client = MagicMock()
+    connection_config.set_mock_client(mock_client)
+
+    with pytest.raises(DestinationConnectionError, match="requires an explicit collection name"):
+        uploader.precheck()
 
 
 def test_precheck_wraps_unexpected_exception_in_destination_error(

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -1,4 +1,6 @@
+import json
 from contextlib import contextmanager
+from copy import deepcopy
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -6,7 +8,7 @@ import pytest
 from pydantic import PrivateAttr, Secret
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
-from unstructured_ingest.error import DestinationConnectionError, ValueError
+from unstructured_ingest.error import DestinationConnectionError, ValueError, WriteError
 from unstructured_ingest.processes.connectors.weaviate.weaviate import (
     WeaviateAccessConfig,
     WeaviateConnectionConfig,
@@ -127,6 +129,9 @@ def test_format_destination_name_error(uploader: WeaviateUploader, destination_n
 
 
 def _sample_element() -> dict:
+    """Representative element shape covering every metadata branch the stager
+    transforms in default mode and flattens in flatten mode. Tests assert on
+    the keys they care about; extra keys are ignored."""
     return {
         "type": "NarrativeText",
         "element_id": "abc",
@@ -136,6 +141,7 @@ def _sample_element() -> dict:
             "filename": "smallfile.txt",
             "filetype": "text/plain",
             "page_number": 1,
+            "last_modified": "2025-01-08T22:45:32",
             "data_source": {
                 "url": "s3://bucket/key",
                 "version": 12345,
@@ -150,6 +156,10 @@ def _sample_element() -> dict:
                 "layout_width": 612,
                 "layout_height": 792,
                 "points": [[0, 0], [612, 0], [612, 792], [0, 792]],
+            },
+            "links": [{"text": "click", "url": "https://example.com", "start_index": 0}],
+            "regex_metadata": {
+                "phone": [{"text": "555-1234", "start": 0, "end": 8}],
             },
         },
     }
@@ -168,23 +178,33 @@ def test_conform_dict_default_keeps_metadata_nested(file_data: FileData):
 
 
 def test_conform_dict_flatten_produces_top_level_keys(file_data: FileData):
+    """Flatten mode is a pure flatten: dicts recurse, lists pass through raw, no
+    opinionated coercion (no str-casts, no json.dumps, no date reformatting)."""
     stager = WeaviateUploadStager(
         upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
     )
     out = stager.conform_dict(_sample_element(), file_data=file_data)
     assert "metadata" not in out
+
     assert out["filename"] == "smallfile.txt"
     assert out["filetype"] == "text/plain"
     assert out["languages"] == ["eng"]
-    assert out["page_number"] == "1"
+
+    assert out["page_number"] == 1
     assert out["data_source_url"] == "s3://bucket/key"
-    assert out["data_source_version"] == "12345"
-    assert isinstance(out["data_source_record_locator"], str)
-    assert isinstance(out["data_source_permissions_data"], str)
+    assert out["data_source_version"] == 12345
+
+    assert "data_source_record_locator" not in out
+    assert out["data_source_record_locator_protocol"] == "s3"
+    assert out["data_source_record_locator_remote_file_path"] == "s3://bucket/"
+
+    assert out["data_source_permissions_data"] == [{"role": "viewer"}]
     assert out["coordinates_system"] == "PixelSpace"
     assert out["coordinates_layout_width"] == 612
-    assert isinstance(out["coordinates_points"], str)
-    assert out["data_source_date_created"].endswith("Z")
+    assert out["coordinates_points"] == [[0, 0], [612, 0], [612, 792], [0, 792]]
+
+    assert out["data_source_date_created"] == "1778727504.0"
+
     assert out["record_id"] == "rec-123"
     assert out["element_id"] == "abc"
     assert out["text"] == "hello world"
@@ -227,12 +247,17 @@ def _make_property(name: str, nested_properties=None):
 def _make_collection_config(*property_names: str, with_nested: bool = False):
     collection = MagicMock()
     config = MagicMock()
+    properties = [_make_property(n) for n in property_names]
     if with_nested:
-        config.properties = [
-            _make_property("metadata", nested_properties=[_make_property("filename")]),
-        ]
-    else:
-        config.properties = [_make_property(n) for n in property_names]
+        # Mirrors what a user declares as OBJECT_ARRAY for list[dict] fields
+        # (e.g. permissions_data, links, regex_metadata_<pattern>).
+        properties.append(
+            _make_property(
+                "data_source_permissions_data",
+                nested_properties=[_make_property("role")],
+            )
+        )
+    config.properties = properties
     collection.config.get.return_value = config
     return collection
 
@@ -249,17 +274,21 @@ def test_precheck_flatten_mode_collection_missing(
         uploader.precheck()
 
 
-def test_precheck_flatten_mode_rejects_nested_schema(
+def test_precheck_flatten_mode_accepts_nested_schema(
     uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
 ):
+    """Schema-shape (e.g. OBJECT_ARRAY for list[dict] fields like permissions_data)
+    is the user's call. Precheck only enforces collection existence and that
+    record_id is declared, regardless of how other properties are typed."""
     uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=True)
     mock_client = MagicMock()
     mock_client.collections.exists.return_value = True
-    mock_client.collections.get.return_value = _make_collection_config(with_nested=True)
+    mock_client.collections.get.return_value = _make_collection_config(
+        "record_id", "text", with_nested=True
+    )
     connection_config.set_mock_client(mock_client)
 
-    with pytest.raises(DestinationConnectionError, match="nested object"):
-        uploader.precheck()
+    uploader.precheck()
 
 
 def test_precheck_flatten_mode_requires_record_id_property(
@@ -312,3 +341,619 @@ def test_get_schema_property_names_caches_across_calls(
     second = uploader.get_schema_property_names(mock_client)
     assert first == second == {"record_id", "text"}
     assert mock_client.collections.get.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Stager — nested (default) mode: deeper coverage of every transform branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_json_payload"),
+    [
+        # dict → JSON string
+        (
+            ("data_source", "record_locator"),
+            {"protocol": "s3", "remote_file_path": "s3://bucket/"},
+        ),
+        # list[list[*]] → JSON string (no native Weaviate scalar)
+        (
+            ("coordinates", "points"),
+            [[0, 0], [612, 0], [612, 792], [0, 792]],
+        ),
+        # list[dict] → JSON string
+        (
+            ("links",),
+            [{"text": "click", "url": "https://example.com", "start_index": 0}],
+        ),
+        # list[dict] → JSON string
+        (
+            ("data_source", "permissions_data"),
+            [{"role": "viewer"}],
+        ),
+        # dict-of-list-of-dict → JSON string
+        (
+            ("regex_metadata",),
+            {"phone": [{"text": "555-1234", "start": 0, "end": 8}]},
+        ),
+    ],
+)
+def test_conform_dict_default_json_dumps_complex_metadata(
+    file_data: FileData, path: tuple, expected_json_payload
+):
+    """Default mode applies json.dumps to dict / list[dict] / list[list[*]]
+    fields that don't map to a native Weaviate scalar type."""
+    stager = WeaviateUploadStager(upload_stager_config=WeaviateUploadStagerConfig())
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+    node = out["metadata"]
+    for key in path:
+        node = node[key]
+    assert isinstance(node, str)
+    assert json.loads(node) == expected_json_payload
+
+
+@pytest.mark.parametrize(
+    "ds_key",
+    ["date_created", "date_modified", "date_processed"],
+)
+def test_conform_dict_default_reformats_unix_timestamp_dates(
+    file_data: FileData, ds_key: str
+):
+    """Default mode parses unix-timestamp-strings ("1778727504.0") and
+    reformats them to Weaviate's RFC3339-Z form (YYYY-MM-DDTHH:MM:SS.fffZ)."""
+    stager = WeaviateUploadStager(upload_stager_config=WeaviateUploadStagerConfig())
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+    node = out["metadata"]["data_source"][ds_key]
+    assert isinstance(node, str)
+    assert node.endswith("Z")
+    # YYYY-MM-DDTHH:MM:SS.ffffffZ shape sanity check
+    assert node[4] == "-" and node[7] == "-" and node[10] == "T"
+
+
+def test_conform_dict_default_reformats_iso_dates_to_rfc3339(file_data: FileData):
+    """Default mode also parses ISO strings like "2025-01-08T22:45:32" via
+    dateutil and emits the same RFC3339-Z form."""
+    stager = WeaviateUploadStager(upload_stager_config=WeaviateUploadStagerConfig())
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+    last_modified = out["metadata"]["last_modified"]
+    assert last_modified.startswith("2025-01-08T22:45:32")
+    assert last_modified.endswith("Z")
+
+
+def test_conform_dict_default_str_casts_version_and_page_number(file_data: FileData):
+    """Default mode coerces ints to TEXT-compatible strings to match the
+    auto-created collection schema (which declares them as text)."""
+    stager = WeaviateUploadStager(upload_stager_config=WeaviateUploadStagerConfig())
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+    assert out["metadata"]["data_source"]["version"] == "12345"
+    assert out["metadata"]["page_number"] == "1"
+
+
+def test_conform_dict_default_handles_missing_metadata(file_data: FileData):
+    """Default mode tolerates elements with no metadata key — record_id is
+    still injected and no transforms blow up on missing nested paths."""
+    stager = WeaviateUploadStager(upload_stager_config=WeaviateUploadStagerConfig())
+    out = stager.conform_dict({"text": "hi"}, file_data=file_data)
+    assert out == {"text": "hi", "record_id": "rec-123"}
+
+
+# ---------------------------------------------------------------------------
+# Stager — flatten mode (pure flatten): edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_conform_dict_flatten_handles_missing_metadata_key(file_data: FileData):
+    """If an element has no metadata dict at all, flatten is a no-op and
+    record_id is still injected."""
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    out = stager.conform_dict({"text": "hi", "element_id": "x"}, file_data=file_data)
+    assert out == {"text": "hi", "element_id": "x", "record_id": "rec-123"}
+
+
+def test_conform_dict_flatten_handles_empty_metadata_dict(file_data: FileData):
+    """An element with an empty metadata dict produces no flattened keys."""
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    out = stager.conform_dict(
+        {"text": "hi", "element_id": "x", "metadata": {}}, file_data=file_data
+    )
+    assert out == {"text": "hi", "element_id": "x", "record_id": "rec-123"}
+
+
+def test_conform_dict_flatten_overwrites_record_id_from_element(file_data: FileData):
+    """If an element somehow already has a record_id at the top level, the
+    stager overrides it with file_data.identifier — record_id is the stager's
+    contract, not user-controlled."""
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    element = {"text": "hi", "record_id": "OLD-ID", "metadata": {}}
+    out = stager.conform_dict(element, file_data=file_data)
+    assert out["record_id"] == "rec-123"
+
+
+def test_conform_dict_flatten_preserves_falsy_primitive_values(file_data: FileData):
+    """Falsy primitives (0, "", False) must survive flatten; only None is
+    dropped (via remove_none=True)."""
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    element = {
+        "text": "hi",
+        "metadata": {
+            "page_number": 0,
+            "filename": "",
+            "is_continuation": False,
+            "languages": [],
+            "skipped": None,
+        },
+    }
+    out = stager.conform_dict(element, file_data=file_data)
+    assert out["page_number"] == 0
+    assert out["filename"] == ""
+    assert out["is_continuation"] is False
+    assert out["languages"] == []
+    assert "skipped" not in out
+
+
+def test_conform_dict_flatten_recursive_flatten_of_dynamic_keys(file_data: FileData):
+    """Dynamic dict keys (like regex_metadata pattern names) recursively flatten
+    into their own top-level keys; their list[dict] values pass through raw,
+    enabling users to declare them as OBJECT_ARRAY in Weaviate."""
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+    assert "regex_metadata" not in out
+    assert out["regex_metadata_phone"] == [
+        {"text": "555-1234", "start": 0, "end": 8}
+    ]
+
+
+def test_conform_dict_flatten_does_not_mutate_input(file_data: FileData):
+    """Flatten mode reads metadata via pop on a shallow copy and never mutates
+    the inner metadata dict — callers can safely keep references to the input."""
+    element = _sample_element()
+    snapshot = deepcopy(element)
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    stager.conform_dict(element, file_data=file_data)
+    assert element == snapshot
+
+
+def test_conform_dict_flatten_passthrough_lists_unmodified(file_data: FileData):
+    """list[primitive], list[dict], and list[list[*]] all pass through raw
+    (flatten_lists=False). No json.dumps, no element-level reshaping."""
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+    assert out["languages"] == ["eng"]
+    assert out["links"] == [
+        {"text": "click", "url": "https://example.com", "start_index": 0}
+    ]
+    assert out["data_source_permissions_data"] == [{"role": "viewer"}]
+    assert out["coordinates_points"] == [[0, 0], [612, 0], [612, 792], [0, 792]]
+
+
+# ---------------------------------------------------------------------------
+# Uploader — conform_to_schema: edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_conform_to_schema_empty_schema_returns_empty_dict():
+    """If the schema has no properties, every incoming key is dropped."""
+    out = WeaviateUploader.conform_to_schema(
+        {"a": 1, "b": 2}, schema_props=set()
+    )
+    assert out == {}
+
+
+def test_conform_to_schema_empty_properties_fills_all_with_none():
+    """If incoming properties is empty, every schema field is filled with None."""
+    out = WeaviateUploader.conform_to_schema(
+        {}, schema_props={"a", "b", "c"}
+    )
+    assert out == {"a": None, "b": None, "c": None}
+
+
+def test_conform_to_schema_preserves_falsy_values():
+    """Falsy values (0, "", False, []) must not be confused with missing keys."""
+    out = WeaviateUploader.conform_to_schema(
+        {"i": 0, "s": "", "b": False, "lst": []},
+        schema_props={"i", "s", "b", "lst", "missing"},
+    )
+    assert out == {"i": 0, "s": "", "b": False, "lst": [], "missing": None}
+
+
+def test_conform_to_schema_preserves_explicit_none():
+    """An explicit None in incoming and a missing key both produce None
+    in the output — Weaviate stores them identically as null."""
+    out = WeaviateUploader.conform_to_schema(
+        {"explicit": None}, schema_props={"explicit", "missing"}
+    )
+    assert out == {"explicit": None, "missing": None}
+
+
+# ---------------------------------------------------------------------------
+# Uploader — precheck: default mode + edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_precheck_default_mode_collection_missing_raises(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    uploader.upload_config = WeaviateUploaderConfig(
+        collection="MyColl", flatten_metadata=False
+    )
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = False
+    connection_config.set_mock_client(mock_client)
+
+    with pytest.raises(DestinationConnectionError, match="does not exist"):
+        uploader.precheck()
+
+
+def test_precheck_default_mode_collection_exists_passes(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    """Default mode is permissive: existence is enough — no schema-shape or
+    record_id checks are run because the connector may auto-create later."""
+    uploader.upload_config = WeaviateUploaderConfig(
+        collection="MyColl", flatten_metadata=False
+    )
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    connection_config.set_mock_client(mock_client)
+
+    uploader.precheck()
+    # In default mode we never read the schema config.
+    mock_client.collections.get.assert_not_called()
+
+
+@pytest.mark.parametrize("flatten_metadata", [True, False])
+def test_precheck_collection_none_skips_validation(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    flatten_metadata: bool,
+):
+    """If no collection name is set, precheck silently passes — the missing
+    name is a config error caught later in run_data."""
+    uploader.upload_config = WeaviateUploaderConfig(
+        collection=None, flatten_metadata=flatten_metadata
+    )
+    mock_client = MagicMock()
+    connection_config.set_mock_client(mock_client)
+
+    uploader.precheck()
+    mock_client.collections.exists.assert_not_called()
+
+
+def test_precheck_wraps_unexpected_exception_in_destination_error(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    """Any non-DestinationConnectionError exception bubbling from the client
+    is wrapped in a DestinationConnectionError so callers always see one."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
+    mock_client = MagicMock()
+    mock_client.collections.exists.side_effect = RuntimeError("network down")
+    connection_config.set_mock_client(mock_client)
+
+    with pytest.raises(DestinationConnectionError, match="failed to validate connection"):
+        uploader.precheck()
+
+
+# ---------------------------------------------------------------------------
+# Uploader — delete_by_record_id
+# ---------------------------------------------------------------------------
+
+
+def _delete_resp(failed: int, successful: int) -> MagicMock:
+    return MagicMock(failed=failed, successful=successful)
+
+
+def test_delete_by_record_id_loops_until_no_more_results(
+    uploader: WeaviateUploader, file_data: FileData
+):
+    """The delete loop re-runs until a response with failed=0 AND
+    successful=0 is observed (Weaviate's QUERY_MAXIMUM_RESULTS limit
+    means a single delete may not clear everything)."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
+    mock_client = MagicMock()
+    delete_mock = mock_client.collections.get.return_value.data.delete_many
+    delete_mock.side_effect = [
+        _delete_resp(failed=0, successful=10),
+        _delete_resp(failed=0, successful=5),
+        _delete_resp(failed=0, successful=0),
+    ]
+
+    uploader.delete_by_record_id(client=mock_client, file_data=file_data)
+    assert delete_mock.call_count == 3
+
+
+def test_delete_by_record_id_raises_on_failure_response(
+    uploader: WeaviateUploader, file_data: FileData
+):
+    """A response with failed > 0 raises immediately, preserving the
+    original record id in the message for debugging."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
+    mock_client = MagicMock()
+    delete_mock = mock_client.collections.get.return_value.data.delete_many
+    delete_mock.return_value = _delete_resp(failed=2, successful=0)
+
+    with pytest.raises(WriteError, match="failed to delete records"):
+        uploader.delete_by_record_id(client=mock_client, file_data=file_data)
+
+
+# ---------------------------------------------------------------------------
+# Uploader — check_for_errors
+# ---------------------------------------------------------------------------
+
+
+def test_check_for_errors_no_failures_passes(uploader: WeaviateUploader):
+    mock_client = MagicMock()
+    mock_client.batch.failed_objects = []
+
+    uploader.check_for_errors(client=mock_client)
+
+
+def test_check_for_errors_with_failures_raises_write_error(
+    uploader: WeaviateUploader, caplog: pytest.LogCaptureFixture
+):
+    mock_client = MagicMock()
+    mock_client.batch.failed_objects = [
+        MagicMock(original_uuid="uuid-1", message="rejected by collection"),
+        MagicMock(original_uuid="uuid-2", message="schema mismatch"),
+    ]
+
+    with pytest.raises(WriteError, match="Failed to upload to weaviate"):
+        uploader.check_for_errors(client=mock_client)
+    # Each failure produces an ERROR log line for operator visibility.
+    assert "uuid-1" in caplog.text
+    assert "uuid-2" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Uploader — run_data integration
+# ---------------------------------------------------------------------------
+
+
+def _make_run_data_client() -> MagicMock:
+    """Weaviate client mock fully wired for run_data:
+    - delete_by_record_id loop terminates on first iteration
+    - batch.dynamic() yields a batch_client (MagicMock context manager)
+    - check_for_errors sees no failures
+    """
+    mock_client = MagicMock()
+    mock_client.collections.get.return_value.data.delete_many.return_value = _delete_resp(
+        failed=0, successful=0
+    )
+    mock_client.batch.failed_objects = []
+    return mock_client
+
+
+def _batch_client_from(mock_client: MagicMock) -> MagicMock:
+    """The BatchClient yielded by `with client.batch.dynamic() as batch:`."""
+    return mock_client.batch.dynamic.return_value.__enter__.return_value
+
+
+def test_run_data_raises_when_no_collection_set(
+    uploader: WeaviateUploader, file_data: FileData
+):
+    uploader.upload_config = WeaviateUploaderConfig(collection=None)
+    with pytest.raises(ValueError, match="No collection specified"):
+        uploader.run_data(data=[{"text": "x"}], file_data=file_data)
+
+
+def test_run_data_default_mode_passes_unmodified_properties(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """In default mode, properties go to add_object exactly as the stager
+    produced them; only embeddings are popped into the vector arg."""
+    uploader.upload_config = WeaviateUploaderConfig(
+        collection="MyColl", flatten_metadata=False
+    )
+    mock_client = _make_run_data_client()
+    connection_config.set_mock_client(mock_client)
+    monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
+
+    uploader.run_data(
+        data=[
+            {
+                "text": "x",
+                "metadata": {"filename": "y"},
+                "embeddings": [1.0, 2.0],
+            }
+        ],
+        file_data=file_data,
+    )
+
+    batch_client = _batch_client_from(mock_client)
+    batch_client.add_object.assert_called_once_with(
+        collection="MyColl",
+        properties={"text": "x", "metadata": {"filename": "y"}},
+        vector=[1.0, 2.0],
+    )
+
+
+def test_run_data_default_mode_does_not_fetch_schema(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Default mode never reads the destination schema — no introspection
+    is performed because conform_to_schema isn't applied."""
+    uploader.upload_config = WeaviateUploaderConfig(
+        collection="MyColl", flatten_metadata=False
+    )
+    mock_client = _make_run_data_client()
+    connection_config.set_mock_client(mock_client)
+    monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
+
+    uploader.run_data(
+        data=[{"text": "x", "embeddings": [0.1]}], file_data=file_data
+    )
+
+    mock_client.collections.get.return_value.config.get.assert_not_called()
+
+
+def test_run_data_flatten_mode_applies_schema_conform(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Flatten mode runs each element through conform_to_schema:
+    unknown keys are dropped, missing schema keys are filled with None."""
+    uploader.upload_config = WeaviateUploaderConfig(
+        collection="MyColl", flatten_metadata=True
+    )
+    mock_client = _make_run_data_client()
+    config_mock = MagicMock()
+    config_mock.properties = [
+        _make_property("record_id"),
+        _make_property("text"),
+        _make_property("filename"),
+        _make_property("languages"),
+    ]
+    mock_client.collections.get.return_value.config.get.return_value = config_mock
+    connection_config.set_mock_client(mock_client)
+    monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
+
+    uploader.run_data(
+        data=[
+            {
+                "record_id": "r1",
+                "text": "x",
+                "filename": "y",
+                "junk_field": "drop me",
+                "embeddings": [1.0, 2.0, 3.0],
+            }
+        ],
+        file_data=file_data,
+    )
+
+    batch_client = _batch_client_from(mock_client)
+    batch_client.add_object.assert_called_once_with(
+        collection="MyColl",
+        properties={
+            "record_id": "r1",
+            "text": "x",
+            "filename": "y",
+            "languages": None,  # missing → null
+        },
+        vector=[1.0, 2.0, 3.0],
+    )
+
+
+def test_run_data_pops_embeddings_into_vector_arg_and_removes_from_properties(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Embeddings are always popped from properties so they go to add_object's
+    vector= argument, never as a regular property column."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
+    mock_client = _make_run_data_client()
+    connection_config.set_mock_client(mock_client)
+    monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
+
+    uploader.run_data(
+        data=[{"text": "x", "embeddings": [0.1, 0.2, 0.3]}],
+        file_data=file_data,
+    )
+
+    batch_client = _batch_client_from(mock_client)
+    call = batch_client.add_object.call_args
+    assert call.kwargs["vector"] == [0.1, 0.2, 0.3]
+    assert "embeddings" not in call.kwargs["properties"]
+
+
+def test_run_data_calls_delete_by_record_id_once_per_invocation(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Re-runs dedupe by deleting prior writes for this record_id before
+    the new batch lands."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
+    mock_client = _make_run_data_client()
+    connection_config.set_mock_client(mock_client)
+    delete_spy = MagicMock()
+    monkeypatch.setattr(uploader, "delete_by_record_id", delete_spy)
+
+    uploader.run_data(
+        data=[{"text": "a"}, {"text": "b"}, {"text": "c"}],
+        file_data=file_data,
+    )
+
+    delete_spy.assert_called_once()
+    # Same client instance is passed both to delete and to add_object
+    assert delete_spy.call_args.kwargs["client"] is mock_client
+
+
+def test_run_data_propagates_check_for_errors_failure(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If the batch produced any failed_objects, run_data raises WriteError
+    after the batch context manager closes."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
+    mock_client = _make_run_data_client()
+    mock_client.batch.failed_objects = [
+        MagicMock(original_uuid="uuid-1", message="rejected")
+    ]
+    connection_config.set_mock_client(mock_client)
+    monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
+
+    with pytest.raises(WriteError, match="Failed to upload to weaviate"):
+        uploader.run_data(
+            data=[{"text": "x"}], file_data=file_data
+        )
+
+
+# ---------------------------------------------------------------------------
+# WeaviateUploaderConfig — batch mode validation
+# ---------------------------------------------------------------------------
+
+
+def test_uploader_config_requires_at_least_one_batch_mode():
+    """All three batch flags off → init raises."""
+    with pytest.raises(ValueError, match="No batch mode enabled"):
+        WeaviateUploaderConfig(
+            collection="MyColl",
+            dynamic_batch=False,
+            batch_size=None,
+            requests_per_minute=None,
+        )
+
+
+def test_uploader_config_rejects_multiple_batch_modes():
+    """Setting two batch modes simultaneously is a config error."""
+    with pytest.raises(ValueError, match="Multiple batch modes enabled"):
+        WeaviateUploaderConfig(
+            collection="MyColl",
+            dynamic_batch=False,
+            batch_size=10,
+            requests_per_minute=60,
+        )
+
+
+def test_uploader_config_dynamic_default_alone_is_valid():
+    """The default config (dynamic_batch=True, sizes=None) passes validation."""
+    cfg = WeaviateUploaderConfig(collection="MyColl")
+    assert cfg.dynamic_batch is True
+    assert cfg.batch_size is None
+    assert cfg.requests_per_minute is None

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -637,7 +637,8 @@ def test_precheck_flatten_mode_collection_none_raises(
     connection_config: WeaviateConnectionConfigTest,
 ):
     """Flatten mode requires an explicit collection name because there is no
-    auto-create fallback — fail early with a clear message."""
+    auto-create fallback — fail early with a clear message, before even
+    opening a client connection."""
     uploader.upload_config = WeaviateUploaderConfig(
         collection=None, flatten_metadata=True
     )
@@ -646,6 +647,8 @@ def test_precheck_flatten_mode_collection_none_raises(
 
     with pytest.raises(DestinationConnectionError, match="requires an explicit collection name"):
         uploader.precheck()
+    # Config validation fires before the client is opened.
+    mock_client.collections.exists.assert_not_called()
 
 
 def test_precheck_wraps_unexpected_exception_in_destination_error(

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -1,20 +1,31 @@
+from contextlib import contextmanager
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import Secret
+from pydantic import PrivateAttr, Secret
 
-from unstructured_ingest.error import ValueError
+from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
+from unstructured_ingest.error import DestinationConnectionError, ValueError
 from unstructured_ingest.processes.connectors.weaviate.weaviate import (
     WeaviateAccessConfig,
     WeaviateConnectionConfig,
     WeaviateUploader,
     WeaviateUploaderConfig,
+    WeaviateUploadStager,
+    WeaviateUploadStagerConfig,
 )
 
 
 class WeaviateConnectionConfigTest(WeaviateConnectionConfig):
+    _mock_client: Any = PrivateAttr(default=None)
+
+    @contextmanager
     def get_client(self):
-        yield MagicMock()
+        yield self._mock_client if self._mock_client is not None else MagicMock()
+
+    def set_mock_client(self, mock_client: Any) -> None:
+        self._mock_client = mock_client
 
 
 @pytest.fixture
@@ -45,6 +56,15 @@ def uploader(
         connection_config=connection_config,
         upload_config=uploader_config,
         connector_type="weaviate",
+    )
+
+
+@pytest.fixture
+def file_data() -> FileData:
+    return FileData(
+        source_identifiers=SourceIdentifiers(fullpath="x.txt", filename="x.txt"),
+        connector_type="weaviate",
+        identifier="rec-123",
     )
 
 
@@ -104,3 +124,191 @@ def test_format_destination_name_success_no_logs(
 def test_format_destination_name_error(uploader: WeaviateUploader, destination_name: str):
     with pytest.raises(ValueError):
         uploader.format_destination_name(destination_name)
+
+
+def _sample_element() -> dict:
+    return {
+        "type": "NarrativeText",
+        "element_id": "abc",
+        "text": "hello world",
+        "metadata": {
+            "languages": ["eng"],
+            "filename": "smallfile.txt",
+            "filetype": "text/plain",
+            "page_number": 1,
+            "data_source": {
+                "url": "s3://bucket/key",
+                "version": 12345,
+                "record_locator": {"protocol": "s3", "remote_file_path": "s3://bucket/"},
+                "date_created": "1778727504.0",
+                "date_modified": "1778727504.0",
+                "date_processed": "1778731882.6001136",
+                "permissions_data": [{"role": "viewer"}],
+            },
+            "coordinates": {
+                "system": "PixelSpace",
+                "layout_width": 612,
+                "layout_height": 792,
+                "points": [[0, 0], [612, 0], [612, 792], [0, 792]],
+            },
+        },
+    }
+
+
+def test_conform_dict_default_keeps_metadata_nested(file_data: FileData):
+    stager = WeaviateUploadStager(upload_stager_config=WeaviateUploadStagerConfig())
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+    assert "metadata" in out
+    assert out["metadata"]["filename"] == "smallfile.txt"
+    assert out["metadata"]["page_number"] == "1"
+    assert out["metadata"]["data_source"]["version"] == "12345"
+    assert isinstance(out["metadata"]["data_source"]["record_locator"], str)
+    assert isinstance(out["metadata"]["coordinates"]["points"], str)
+    assert out["record_id"] == "rec-123"
+
+
+def test_conform_dict_flatten_produces_top_level_keys(file_data: FileData):
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+    assert "metadata" not in out
+    assert out["filename"] == "smallfile.txt"
+    assert out["filetype"] == "text/plain"
+    assert out["languages"] == ["eng"]
+    assert out["page_number"] == "1"
+    assert out["data_source_url"] == "s3://bucket/key"
+    assert out["data_source_version"] == "12345"
+    assert isinstance(out["data_source_record_locator"], str)
+    assert isinstance(out["data_source_permissions_data"], str)
+    assert out["coordinates_system"] == "PixelSpace"
+    assert out["coordinates_layout_width"] == 612
+    assert isinstance(out["coordinates_points"], str)
+    assert out["data_source_date_created"].endswith("Z")
+    assert out["record_id"] == "rec-123"
+    assert out["element_id"] == "abc"
+    assert out["text"] == "hello world"
+    assert out["type"] == "NarrativeText"
+
+
+def test_conform_dict_flatten_drops_none_metadata_values(file_data: FileData):
+    element = _sample_element()
+    element["metadata"]["sent_from"] = None
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True)
+    )
+    out = stager.conform_dict(element, file_data=file_data)
+    assert "sent_from" not in out
+
+
+def test_conform_to_schema_drops_unknown_and_fills_missing():
+    schema_props = {"record_id", "text", "filename", "languages", "page_number"}
+    row = {
+        "record_id": "rec-1",
+        "text": "hello",
+        "filename": "x.txt",
+        "languages": ["eng"],
+        "junk_field": "should be dropped",
+    }
+    out = WeaviateUploader.conform_to_schema(row, schema_props)
+    assert set(out.keys()) == schema_props
+    assert out["page_number"] is None
+    assert "junk_field" not in out
+    assert out["languages"] == ["eng"]
+
+
+def _make_property(name: str, nested_properties=None):
+    prop = MagicMock()
+    prop.name = name
+    prop.nested_properties = nested_properties
+    return prop
+
+
+def _make_collection_config(*property_names: str, with_nested: bool = False):
+    collection = MagicMock()
+    config = MagicMock()
+    if with_nested:
+        config.properties = [
+            _make_property("metadata", nested_properties=[_make_property("filename")]),
+        ]
+    else:
+        config.properties = [_make_property(n) for n in property_names]
+    collection.config.get.return_value = config
+    return collection
+
+
+def test_precheck_flatten_mode_collection_missing(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=True)
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = False
+    connection_config.set_mock_client(mock_client)
+
+    with pytest.raises(DestinationConnectionError, match="must be pre-created"):
+        uploader.precheck()
+
+
+def test_precheck_flatten_mode_rejects_nested_schema(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=True)
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    mock_client.collections.get.return_value = _make_collection_config(with_nested=True)
+    connection_config.set_mock_client(mock_client)
+
+    with pytest.raises(DestinationConnectionError, match="nested object"):
+        uploader.precheck()
+
+
+def test_precheck_flatten_mode_requires_record_id_property(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=True)
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    mock_client.collections.get.return_value = _make_collection_config("text", "filename")
+    connection_config.set_mock_client(mock_client)
+
+    with pytest.raises(DestinationConnectionError, match="missing required property"):
+        uploader.precheck()
+
+
+def test_precheck_flatten_mode_passes_with_flat_schema(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=True)
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    mock_client.collections.get.return_value = _make_collection_config(
+        "record_id", "text", "filename", "languages"
+    )
+    connection_config.set_mock_client(mock_client)
+
+    uploader.precheck()
+
+
+def test_create_destination_noop_in_flatten_mode(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=True)
+    mock_client = MagicMock()
+    connection_config.set_mock_client(mock_client)
+
+    created = uploader.create_destination(destination_name="ignored")
+    assert created is False
+    mock_client.collections.create_from_dict.assert_not_called()
+
+
+def test_get_schema_property_names_caches_across_calls(
+    uploader: WeaviateUploader,
+):
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=True)
+    mock_client = MagicMock()
+    mock_client.collections.get.return_value = _make_collection_config("record_id", "text")
+
+    first = uploader.get_schema_property_names(mock_client)
+    second = uploader.get_schema_property_names(mock_client)
+    assert first == second == {"record_id", "text"}
+    assert mock_client.collections.get.call_count == 1

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.7"  # pragma: no cover
+__version__ = "1.6.8"  # pragma: no cover

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.8"  # pragma: no cover
+__version__ = "1.6.9"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -267,13 +267,13 @@ class WeaviateUploader(VectorDBUploader, ABC):
         return {k: properties.get(k) for k in schema_props}
 
     def precheck(self) -> None:
+        if self.upload_config.flatten_metadata and not self.upload_config.collection:
+            raise DestinationConnectionError(
+                "flatten_metadata=true requires an explicit collection name."
+            )
+
         try:
             with self.connection_config.get_client() as weaviate_client:
-                if self.upload_config.flatten_metadata and not self.upload_config.collection:
-                    raise DestinationConnectionError(
-                        "flatten_metadata=true requires an explicit collection name."
-                    )
-
                 if self.upload_config.collection and not weaviate_client.collections.exists(
                     name=self.upload_config.collection
                 ):

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -89,6 +89,24 @@ class WeaviateUploadStager(UploadStager):
         """
         data = element_dict.copy()
         working_data = data.copy()
+
+        if self.upload_stager_config.flatten_metadata:
+            # Pure flatten: no opinionated transforms. The user owns the schema
+            # and is responsible for declaring data types compatible with the
+            # raw flattened values (e.g. OBJECT_ARRAY for list[dict] fields
+            # like links / permissions_data / regex_metadata_<pattern>).
+            metadata = working_data.pop("metadata", {})
+            working_data.update(
+                flatten_dict(
+                    metadata,
+                    separator="_",
+                    flatten_lists=False,
+                    remove_none=True,
+                )
+            )
+            working_data[RECORD_ID_LABEL] = file_data.identifier
+            return working_data
+
         # Dict as string formatting
         if (
             record_locator := working_data.get("metadata", {})
@@ -164,17 +182,6 @@ class WeaviateUploadStager(UploadStager):
 
         if regex_metadata := working_data.get("metadata", {}).get("regex_metadata"):
             working_data["metadata"]["regex_metadata"] = str(json.dumps(regex_metadata))
-
-        if self.upload_stager_config.flatten_metadata:
-            metadata = working_data.pop("metadata", {})
-            working_data.update(
-                flatten_dict(
-                    metadata,
-                    separator="_",
-                    flatten_lists=False,
-                    remove_none=True,
-                )
-            )
 
         working_data[RECORD_ID_LABEL] = file_data.identifier
         return working_data
@@ -259,10 +266,6 @@ class WeaviateUploader(VectorDBUploader, ABC):
         # query semantics see an explicit null instead of an absent property.
         return {k: properties.get(k, None) for k in schema_props}
 
-    @staticmethod
-    def _has_nested_object_properties(properties) -> bool:
-        return any(getattr(p, "nested_properties", None) for p in properties)
-
     def precheck(self) -> None:
         try:
             with self.connection_config.get_client() as weaviate_client:
@@ -280,14 +283,12 @@ class WeaviateUploader(VectorDBUploader, ABC):
                     )
 
                 if self.upload_config.flatten_metadata and self.upload_config.collection:
+                    # Schema-shape (e.g. OBJECT / OBJECT_ARRAY for nested fields like
+                    # permissions_data / links / regex_metadata_<pattern>) is the user's
+                    # call. We only enforce that record_id is declared so re-run
+                    # delete-by-record-id can find prior writes to remove.
                     collection = weaviate_client.collections.get(self.upload_config.collection)
                     config = collection.config.get()
-                    if self._has_nested_object_properties(config.properties):
-                        raise DestinationConnectionError(
-                            f"Collection {self.upload_config.collection!r} has nested object "
-                            "properties, which are incompatible with flatten_metadata=true. "
-                            "Pre-create the collection with a flat property schema."
-                        )
                     schema_props = {p.name for p in config.properties}
                     if self.upload_config.record_id_key not in schema_props:
                         raise DestinationConnectionError(
@@ -403,11 +404,10 @@ class WeaviateUploader(VectorDBUploader, ABC):
             with self.upload_config.get_batch_client(client=weaviate_client) as batch_client:
                 for e in data:
                     vector = e.pop("embeddings", None)
-                    properties = (
-                        self.conform_to_schema(e, schema_props)
-                        if schema_props is not None
-                        else e
-                    )
+                    if schema_props is not None:
+                        properties = self.conform_to_schema(e, schema_props)
+                    else:
+                        properties = e
                     batch_client.add_object(
                         collection=self.upload_config.collection,
                         properties=properties,

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -22,6 +22,7 @@ from unstructured_ingest.interfaces import (
 )
 from unstructured_ingest.logger import logger
 from unstructured_ingest.utils.constants import RECORD_ID_LABEL
+from unstructured_ingest.utils.data_prep import flatten_dict
 from unstructured_ingest.utils.dep_check import requires_dependencies
 
 if TYPE_CHECKING:
@@ -57,7 +58,14 @@ class WeaviateConnectionConfig(ConnectionConfig, ABC):
 
 
 class WeaviateUploadStagerConfig(UploadStagerConfig):
-    pass
+    flatten_metadata: bool = Field(
+        default=False,
+        description=(
+            "Flatten metadata into top-level properties. Destination collection "
+            "must already exist (no auto-create); unknown incoming fields are "
+            "dropped and missing schema fields are filled with null."
+        ),
+    )
 
 
 @dataclass
@@ -157,6 +165,17 @@ class WeaviateUploadStager(UploadStager):
         if regex_metadata := working_data.get("metadata", {}).get("regex_metadata"):
             working_data["metadata"]["regex_metadata"] = str(json.dumps(regex_metadata))
 
+        if self.upload_stager_config.flatten_metadata:
+            metadata = working_data.pop("metadata", {})
+            working_data.update(
+                flatten_dict(
+                    metadata,
+                    separator="_",
+                    flatten_lists=False,
+                    remove_none=True,
+                )
+            )
+
         working_data[RECORD_ID_LABEL] = file_data.identifier
         return working_data
 
@@ -171,6 +190,14 @@ class WeaviateUploaderConfig(UploaderConfig):
     record_id_key: str = Field(
         default=RECORD_ID_LABEL,
         description="searchable key to find entries for the same record on previous runs",
+    )
+    flatten_metadata: bool = Field(
+        default=False,
+        description=(
+            "Flatten metadata into top-level properties. Destination collection "
+            "must already exist (no auto-create); unknown incoming fields are "
+            "dropped and missing schema fields are filled with null."
+        ),
     )
 
     def model_post_init(self, __context: Any) -> None:
@@ -212,23 +239,64 @@ class WeaviateUploaderConfig(UploaderConfig):
 class WeaviateUploader(VectorDBUploader, ABC):
     upload_config: WeaviateUploaderConfig
     connection_config: WeaviateConnectionConfig
+    _schema_property_names: Optional[set[str]] = None
 
     def _collection_exists(self, collection_name: Optional[str] = None):
         collection_name = collection_name or self.upload_config.collection
         with self.connection_config.get_client() as weaviate_client:
             return weaviate_client.collections.exists(name=collection_name)
 
+    def get_schema_property_names(self, client: "WeaviateClient") -> set[str]:
+        if self._schema_property_names is None:
+            collection = client.collections.get(self.upload_config.collection)
+            config = collection.config.get()
+            self._schema_property_names = {p.name for p in config.properties}
+        return self._schema_property_names
+
+    @staticmethod
+    def conform_to_schema(properties: dict, schema_props: set[str]) -> dict:
+        # Drop unknown keys; fill missing schema keys with None so downstream
+        # query semantics see an explicit null instead of an absent property.
+        return {k: properties.get(k, None) for k in schema_props}
+
+    @staticmethod
+    def _has_nested_object_properties(properties) -> bool:
+        return any(getattr(p, "nested_properties", None) for p in properties)
+
     def precheck(self) -> None:
         try:
-            with self.connection_config.get_client():
-                # Connection test successful - client is available but not needed
-                pass
+            with self.connection_config.get_client() as weaviate_client:
+                if self.upload_config.collection and not weaviate_client.collections.exists(
+                    name=self.upload_config.collection
+                ):
+                    if self.upload_config.flatten_metadata:
+                        raise DestinationConnectionError(
+                            f"Collection {self.upload_config.collection!r} does not exist. "
+                            "With flatten_metadata=true, the destination collection must "
+                            "be pre-created."
+                        )
+                    raise DestinationConnectionError(
+                        f"collection '{self.upload_config.collection}' does not exist"
+                    )
 
-            # only if collection name populated should we check that it exists
-            if self.upload_config.collection and not self._collection_exists():
-                raise DestinationConnectionError(
-                    f"collection '{self.upload_config.collection}' does not exist"
-                )
+                if self.upload_config.flatten_metadata and self.upload_config.collection:
+                    collection = weaviate_client.collections.get(self.upload_config.collection)
+                    config = collection.config.get()
+                    if self._has_nested_object_properties(config.properties):
+                        raise DestinationConnectionError(
+                            f"Collection {self.upload_config.collection!r} has nested object "
+                            "properties, which are incompatible with flatten_metadata=true. "
+                            "Pre-create the collection with a flat property schema."
+                        )
+                    schema_props = {p.name for p in config.properties}
+                    if self.upload_config.record_id_key not in schema_props:
+                        raise DestinationConnectionError(
+                            f"Collection {self.upload_config.collection!r} is missing required "
+                            f"property {self.upload_config.record_id_key!r}; "
+                            "delete-by-record_id will not work."
+                        )
+        except DestinationConnectionError:
+            raise
         except Exception as e:
             logger.error(f"Failed to validate connection {e}", exc_info=True)
             raise DestinationConnectionError(f"failed to validate connection: {e}")
@@ -266,6 +334,9 @@ class WeaviateUploader(VectorDBUploader, ABC):
         vector_length: Optional[int] = None,
         **kwargs: Any,
     ) -> bool:
+        if self.upload_config.flatten_metadata:
+            # User manages the collection under flatten mode; precheck validates existence.
+            return False
         collection_name = self.upload_config.collection or destination_name
         collection_name = self.format_destination_name(collection_name)
         self.upload_config.collection = collection_name
@@ -326,12 +397,20 @@ class WeaviateUploader(VectorDBUploader, ABC):
 
         with self.connection_config.get_client() as weaviate_client:
             self.delete_by_record_id(client=weaviate_client, file_data=file_data)
+            schema_props: Optional[set[str]] = None
+            if self.upload_config.flatten_metadata:
+                schema_props = self.get_schema_property_names(weaviate_client)
             with self.upload_config.get_batch_client(client=weaviate_client) as batch_client:
                 for e in data:
                     vector = e.pop("embeddings", None)
+                    properties = (
+                        self.conform_to_schema(e, schema_props)
+                        if schema_props is not None
+                        else e
+                    )
                     batch_client.add_object(
                         collection=self.upload_config.collection,
-                        properties=e,
+                        properties=properties,
                         vector=vector,
                     )
             self.check_for_errors(client=weaviate_client)

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -91,10 +91,9 @@ class WeaviateUploadStager(UploadStager):
         working_data = data.copy()
 
         if self.upload_stager_config.flatten_metadata:
-            # Pure flatten: no opinionated transforms. The user owns the schema
-            # and is responsible for declaring data types compatible with the
-            # raw flattened values (e.g. OBJECT_ARRAY for list[dict] fields
-            # like links / permissions_data / regex_metadata_<pattern>).
+            # Pure flatten: no opinionated transforms. User owns the schema and
+            # declares types matching raw values (e.g. OBJECT_ARRAY for list[dict]
+            # fields like links, permissions_data, regex_metadata_<pattern>).
             metadata = working_data.pop("metadata", {})
             working_data.update(
                 flatten_dict(
@@ -262,8 +261,7 @@ class WeaviateUploader(VectorDBUploader, ABC):
 
     @staticmethod
     def conform_to_schema(properties: dict, schema_props: set[str]) -> dict:
-        # Drop unknown keys; fill missing schema keys with None so downstream
-        # query semantics see an explicit null instead of an absent property.
+        """Drop unknown keys; fill missing schema keys with None for explicit-null queries."""
         return {k: properties.get(k) for k in schema_props}
 
     def precheck(self) -> None:
@@ -274,31 +272,25 @@ class WeaviateUploader(VectorDBUploader, ABC):
 
         try:
             with self.connection_config.get_client() as weaviate_client:
-                if self.upload_config.collection and not weaviate_client.collections.exists(
-                    name=self.upload_config.collection
-                ):
-                    if self.upload_config.flatten_metadata:
-                        raise DestinationConnectionError(
-                            f"Collection {self.upload_config.collection!r} does not exist. "
-                            "With flatten_metadata=true, the destination collection must "
-                            "be pre-created."
-                        )
-                    raise DestinationConnectionError(
-                        f"collection '{self.upload_config.collection}' does not exist"
-                    )
+                if not self.upload_config.collection:
+                    return
 
-                if self.upload_config.flatten_metadata and self.upload_config.collection:
-                    # Schema-shape (e.g. OBJECT / OBJECT_ARRAY for nested fields like
-                    # permissions_data / links / regex_metadata_<pattern>) is the user's
-                    # call. We only enforce that record_id is declared so re-run
-                    # delete-by-record-id can find prior writes to remove.
+                if not weaviate_client.collections.exists(name=self.upload_config.collection):
+                    msg = f"collection '{self.upload_config.collection}' does not exist"
+                    if self.upload_config.flatten_metadata:
+                        msg += " (must be pre-created when flatten_metadata=true)"
+                    raise DestinationConnectionError(msg)
+
+                if self.upload_config.flatten_metadata:
+                    # Schema shape (OBJECT_ARRAY for nested fields, etc.) is the
+                    # user's call; we only enforce that record_id is declared so
+                    # re-run delete-by-record_id can find prior writes.
                     collection = weaviate_client.collections.get(self.upload_config.collection)
-                    config = collection.config.get()
-                    schema_props = {p.name for p in config.properties}
+                    schema_props = {p.name for p in collection.config.get().properties}
                     if self.upload_config.record_id_key not in schema_props:
                         raise DestinationConnectionError(
-                            f"Collection {self.upload_config.collection!r} is missing required "
-                            f"property {self.upload_config.record_id_key!r}; "
+                            f"Collection {self.upload_config.collection!r} is missing "
+                            f"required property {self.upload_config.record_id_key!r}; "
                             "delete-by-record_id will not work."
                         )
         except DestinationConnectionError:

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -246,7 +246,7 @@ class WeaviateUploaderConfig(UploaderConfig):
 class WeaviateUploader(VectorDBUploader, ABC):
     upload_config: WeaviateUploaderConfig
     connection_config: WeaviateConnectionConfig
-    _schema_property_names: Optional[set[str]] = None
+    _schema_property_names: Optional[set[str]] = field(init=False, repr=False, default=None)
 
     def _collection_exists(self, collection_name: Optional[str] = None):
         collection_name = collection_name or self.upload_config.collection
@@ -264,11 +264,16 @@ class WeaviateUploader(VectorDBUploader, ABC):
     def conform_to_schema(properties: dict, schema_props: set[str]) -> dict:
         # Drop unknown keys; fill missing schema keys with None so downstream
         # query semantics see an explicit null instead of an absent property.
-        return {k: properties.get(k, None) for k in schema_props}
+        return {k: properties.get(k) for k in schema_props}
 
     def precheck(self) -> None:
         try:
             with self.connection_config.get_client() as weaviate_client:
+                if self.upload_config.flatten_metadata and not self.upload_config.collection:
+                    raise DestinationConnectionError(
+                        "flatten_metadata=true requires an explicit collection name."
+                    )
+
                 if self.upload_config.collection and not weaviate_client.collections.exists(
                     name=self.upload_config.collection
                 ):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an opt-in `flatten_metadata` mode for the Weaviate uploader to flatten element metadata into top-level fields and write only schema-declared properties. Default behavior remains unchanged and permissive. Addresses PLU-384.

- **New Features**
  - `flatten_metadata`: pure flatten (recursive dict with "_" separator; lists untouched; `None` dropped; no coercion).
  - Precheck (flatten mode): requires an explicit, existing collection; verifies a `record_id` property; `create_destination` is a no-op; unexpected client errors are wrapped.
  - Writes (flatten mode): drops unknown keys and fills missing declared fields with `None`; schema property names are cached per run.
  - Default mode: if a collection is set, existence is checked; if not set, validation is skipped; schema is never read.

- **Migration**
  - Pre-create the destination collection and set its name explicitly.
  - Add a `record_id` property for re-run dedup.
  - Declare types for flattened fields (e.g., OBJECT_ARRAY for list[dict] like links/permissions/regex matches).
  - Enable with `flatten_metadata=true`.

<sup>Written for commit c5159c8275ce885db66b04820a9462abb527ff43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

