### PR TITLE
fix(google_drive): exclude trashed items from indexer queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.11]
+
+### Fixes
+
+- **fix(google-drive): exclude trashed items from indexer queries.** The Google Drive connector's `files.list` calls filtered by parent id only, so items the user had moved to Drive's trash were pulled and ingested like live content — "delete in Drive UI" did not remove the file from the corpus on the next ingest. Each list-query call site (`count_files_recursively`, the non-recursive precheck empty-folder probe, and `get_paginated_results`) now appends `and trashed = false`, matching the Drive v3 query semantics that exclude trash explicitly.
+
 ## [1.6.10]
 
 ### Fixes

--- a/test/integration/connectors/test_google_drive.py
+++ b/test/integration/connectors/test_google_drive.py
@@ -86,14 +86,20 @@ def google_drive_folder_with_trashed_file(google_drive_connection_config):
     creds = service_account.Credentials.from_service_account_info(access_config.service_account_key)
     service = build("drive", "v3", credentials=creds)
 
+    # Nest the fixture folder under the env-provided drive id so it inherits
+    # that parent's storage quota. Service accounts have no My Drive quota of
+    # their own, so a parentless folder.create raises storageQuotaExceeded.
+    parent_id = google_drive_connection_config.drive_id
     folder = (
         service.files()
         .create(
             body={
                 "name": f"utic-trashed-fixture-{uuid.uuid4()}",
                 "mimeType": "application/vnd.google-apps.folder",
+                "parents": [parent_id],
             },
             fields="id",
+            supportsAllDrives=True,
         )
         .execute()
     )
@@ -107,6 +113,7 @@ def google_drive_folder_with_trashed_file(google_drive_connection_config):
                 body={"name": name, "parents": [folder_id], "mimeType": "text/plain"},
                 media_body=media,
                 fields="id",
+                supportsAllDrives=True,
             )
             .execute()
         )
@@ -114,13 +121,15 @@ def google_drive_folder_with_trashed_file(google_drive_connection_config):
 
     live_id = _upload("live.txt")
     trashed_id = _upload("trashed.txt")
-    service.files().update(fileId=trashed_id, body={"trashed": True}).execute()
+    service.files().update(
+        fileId=trashed_id, body={"trashed": True}, supportsAllDrives=True
+    ).execute()
 
     try:
         yield {"folder_id": folder_id, "live_id": live_id, "trashed_id": trashed_id}
     finally:
         # Permanently delete fixture folder (and its children, trashed or not).
-        service.files().delete(fileId=folder_id).execute()
+        service.files().delete(fileId=folder_id, supportsAllDrives=True).execute()
 
 
 @pytest.mark.tags("google-drive", "integration")

--- a/test/integration/connectors/test_google_drive.py
+++ b/test/integration/connectors/test_google_drive.py
@@ -70,6 +70,91 @@ def google_drive_empty_folder(google_drive_connection_config):
         service.files().delete(fileId=folder_id).execute()
 
 
+@pytest.fixture
+def google_drive_folder_with_trashed_file(google_drive_connection_config):
+    """
+    Creates a temporary folder with two files; trashes one. Yields a dict with
+    the folder id, the trashed file id, and the live file id. Cleans up on exit.
+    """
+    import io
+
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
+    from googleapiclient.http import MediaIoBaseUpload
+
+    access_config = google_drive_connection_config.access_config.get_secret_value()
+    creds = service_account.Credentials.from_service_account_info(access_config.service_account_key)
+    service = build("drive", "v3", credentials=creds)
+
+    folder = (
+        service.files()
+        .create(
+            body={
+                "name": f"utic-trashed-fixture-{uuid.uuid4()}",
+                "mimeType": "application/vnd.google-apps.folder",
+            },
+            fields="id",
+        )
+        .execute()
+    )
+    folder_id = folder["id"]
+
+    def _upload(name: str) -> str:
+        media = MediaIoBaseUpload(io.BytesIO(b"hello"), mimetype="text/plain")
+        created = (
+            service.files()
+            .create(
+                body={"name": name, "parents": [folder_id], "mimeType": "text/plain"},
+                media_body=media,
+                fields="id",
+            )
+            .execute()
+        )
+        return created["id"]
+
+    live_id = _upload("live.txt")
+    trashed_id = _upload("trashed.txt")
+    service.files().update(fileId=trashed_id, body={"trashed": True}).execute()
+
+    try:
+        yield {"folder_id": folder_id, "live_id": live_id, "trashed_id": trashed_id}
+    finally:
+        # Permanently delete fixture folder (and its children, trashed or not).
+        service.files().delete(fileId=folder_id).execute()
+
+
+@pytest.mark.tags("google-drive", "integration")
+@requires_env("GOOGLE_DRIVE_ID", "GOOGLE_DRIVE_SERVICE_KEY")
+def test_google_drive_indexer_excludes_trashed_files(
+    google_drive_connection_config, google_drive_folder_with_trashed_file
+):
+    """
+    Regression test for the connector silently ingesting Drive items the user
+    has moved to trash. Without `trashed = false` on `files.list`, the indexer
+    returns both files in the fixture folder; with it, only the live one.
+    """
+    fixture = google_drive_folder_with_trashed_file
+    connection_config = GoogleDriveConnectionConfig(
+        drive_id=fixture["folder_id"],
+        access_config=google_drive_connection_config.access_config,
+    )
+    indexer = GoogleDriveIndexer(
+        connection_config=connection_config,
+        index_config=GoogleDriveIndexerConfig(recursive=True),
+    )
+
+    with connection_config.get_client() as client:
+        results = indexer.get_paginated_results(
+            files_client=client,
+            object_id=fixture["folder_id"],
+            recursive=True,
+        )
+
+    returned_ids = {r["id"] for r in results}
+    assert fixture["live_id"] in returned_ids
+    assert fixture["trashed_id"] not in returned_ids
+
+
 @requires_env("GOOGLE_DRIVE_SERVICE_KEY")
 @pytest.mark.tags(SOURCE_TAG, CONNECTOR_TYPE)
 def test_google_drive_source(temp_dir):

--- a/test/unit/connectors/test_google_drive.py
+++ b/test/unit/connectors/test_google_drive.py
@@ -9,6 +9,7 @@ from unstructured_ingest.processes.connectors.google_drive import (
     GOOGLE_DRIVE_SKIP_MIME_TYPES,
     GOOGLE_EXPORT_MIME_MAP,
     GoogleDriveAccessConfig,
+    GoogleDriveConnectionConfig,
     GoogleDriveDownloader,
     GoogleDriveDownloaderConfig,
     GoogleDriveIndexer,
@@ -206,9 +207,10 @@ class TestGoogleDriveNativeExports:
             }
         ]
         direct_download.assert_not_called()
-        assert file_data.additional_metadata["export_mime_type"] == GOOGLE_EXPORT_MIME_MAP[
-            source_mime_type
-        ]
+        assert (
+            file_data.additional_metadata["export_mime_type"]
+            == GOOGLE_EXPORT_MIME_MAP[source_mime_type]
+        )
         assert file_data.additional_metadata["export_extension"] == expected_extension
         assert file_data.additional_metadata["download_method"] == "google_workspace_export"
 
@@ -353,6 +355,95 @@ class TestGoogleDriveSkipFiles:
 
         # pdf-1 + doc = 2; shortcut, form, empty are all skipped
         assert count == 2
+
+
+class TestGoogleDriveExcludesTrashed:
+    """The indexer must filter out trashed Drive items by passing `trashed = false`
+    in its `files.list` queries. Without it, Drive returns trashed items in
+    shared-drive corpora and the bug fires."""
+
+    def test_get_paginated_results_query_excludes_trashed(self):
+        files_client = MagicMock()
+        files_client.list.return_value.execute.return_value = {"files": []}
+        indexer = GoogleDriveIndexer(
+            connection_config=MagicMock(),
+            index_config=GoogleDriveIndexerConfig(),
+        )
+
+        indexer.get_paginated_results(files_client=files_client, object_id="folder-id")
+
+        query = files_client.list.call_args.kwargs["q"]
+        assert "trashed = false" in query
+
+    def test_get_paginated_results_query_excludes_trashed_with_extensions(self):
+        files_client = MagicMock()
+        files_client.list.return_value.execute.return_value = {"files": []}
+        indexer = GoogleDriveIndexer(
+            connection_config=MagicMock(),
+            index_config=GoogleDriveIndexerConfig(),
+        )
+
+        indexer.get_paginated_results(
+            files_client=files_client,
+            object_id="folder-id",
+            extensions=["pdf"],
+        )
+
+        query = files_client.list.call_args.kwargs["q"]
+        assert "trashed = false" in query
+
+    def test_count_files_recursively_query_excludes_trashed(self):
+        files_client = _FakeGoogleDriveFilesClient(responses=[{"files": []}])
+
+        GoogleDriveIndexer.count_files_recursively(
+            files_client=files_client,
+            folder_id="folder-id",
+        )
+
+        assert len(files_client.list_calls) == 1
+        assert "trashed = false" in files_client.list_calls[0]["q"]
+
+    def test_precheck_non_recursive_empty_folder_query_excludes_trashed(self, monkeypatch):
+        connection_config = GoogleDriveConnectionConfig(
+            drive_id="drive-id",
+            access_config=GoogleDriveAccessConfig(oauth_token="t"),
+        )
+        indexer = GoogleDriveIndexer(
+            connection_config=connection_config,
+            index_config=GoogleDriveIndexerConfig(recursive=False),
+        )
+
+        files_client = MagicMock()
+        files_client.list.return_value.execute.return_value = {"files": []}
+
+        class _FakeClientCtx:
+            def __enter__(self_inner):
+                return files_client
+
+            def __exit__(self_inner, *args):
+                return False
+
+        monkeypatch.setattr(
+            GoogleDriveConnectionConfig, "get_client", lambda self: _FakeClientCtx()
+        )
+        monkeypatch.setattr(
+            GoogleDriveIndexer, "verify_drive_api_enabled", staticmethod(lambda client: None)
+        )
+        monkeypatch.setattr(
+            indexer,
+            "get_root_info",
+            lambda files_client, object_id: {
+                "id": object_id,
+                "name": "root",
+                "mimeType": "application/vnd.google-apps.folder",
+            },
+        )
+
+        indexer.precheck()
+
+        # First list call after the precheck path enters the non-recursive branch.
+        empty_folder_call = files_client.list.call_args
+        assert "trashed = false" in empty_folder_call.kwargs["q"]
 
 
 class TestGoogleDriveExtensionFiltering:

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.10"  # pragma: no cover
+__version__ = "1.6.11"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -297,7 +297,9 @@ class GoogleDriveIndexer(Indexer):
         while stack:
             current_folder = stack.pop()
             # Always list all items under the current folder.
-            query = f"'{current_folder}' in parents"
+            # `trashed = false` excludes items the user has moved to Drive's trash;
+            # without it, files.list returns trashed items in shared-drive corpora.
+            query = f"'{current_folder}' in parents and trashed = false"
             page_token = None
             while True:
                 response = files_client.list(
@@ -371,7 +373,7 @@ class GoogleDriveIndexer(Indexer):
                         spaces="drive",
                         fields="files(id)",
                         pageSize=1,
-                        q=f"'{self.connection_config.drive_id}' in parents",
+                        q=f"'{self.connection_config.drive_id}' in parents and trashed = false",
                     ).execute()
                     if not response.get("files"):
                         logger.warning(
@@ -454,7 +456,9 @@ class GoogleDriveIndexer(Indexer):
         previous_path: Optional[str] = None,
     ) -> list[dict]:
         fields_input = "nextPageToken, files({})".format(",".join(self.fields))
-        q = f"'{object_id}' in parents"
+        # `trashed = false` excludes items the user has moved to Drive's trash;
+        # without it, files.list returns trashed items in shared-drive corpora.
+        q = f"'{object_id}' in parents and trashed = false"
         # Filter by extension but still include any directories
         if extensions:
             q = f"{q} and ({_build_extension_query_filter(extensions)})"


### PR DESCRIPTION
## Why It Matters

The Google Drive connector pulls files the user has moved to Drive's trash and ingests them like live content. "Delete in Drive UI" does not remove the file from the corpus on the next ingest — the user has to permanently delete (Shift+Delete) to actually purge. Two adjacent ingests of the same drive, one before and one after a UI-delete, return identical corpus state.

Verified independently against Drive v3: a recent shared-drive ingest landed 10 trashed files alongside 10 live files, all surfacing full SDE artifacts (partition → chunk → summary → topics → NER) downstream. Indexing completed clean — the connector never knew anything was wrong.

The cause is the indexer's `files.list` queries filter by parent id only. Drive v3 returns trashed items in shared-drive corpora unless the query says otherwise; without `trashed = false`, trash gets indexed by default.

## Summary

Adds `and trashed = false` to every `files.list` query the indexer issues. After this change, items the user has moved to trash are excluded from indexing, count checks, and precheck empty-folder probes.

No new config knob. The connector has never honored trash; if a migration ever needs trashed-item re-index, we'll add an opt-in field then.

## Changes

- `unstructured_ingest/processes/connectors/google_drive.py`: append `and trashed = false` to the three list-query call sites — `count_files_recursively`, the non-recursive precheck empty-folder probe in `precheck`, and `get_paginated_results` (the main indexing path).
- `test/unit/connectors/test_google_drive.py`: new `TestGoogleDriveExcludesTrashed` with four query-shape assertions covering `get_paginated_results` (with and without extension filter), `count_files_recursively`, and `precheck`.
- `test/integration/connectors/test_google_drive.py`: new `google_drive_folder_with_trashed_file` fixture creates a temp folder with one live and one trashed file; new `test_google_drive_indexer_excludes_trashed_files` asserts the indexer returns only the live one. Gated on `GOOGLE_DRIVE_SERVICE_KEY`; fixture cleans up.

## Validation

Unit tests:

```
uv run --no-sync pytest test/unit/connectors/test_google_drive.py -q
```

```
..............................................                           [100%]
46 passed in 0.23s
```

Integration test requires `GOOGLE_DRIVE_SERVICE_KEY` + `GOOGLE_DRIVE_ID` and creates / cleans up its own folder — not exercised locally; runs in the connector integration suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude trashed Google Drive items from indexing by adding `trashed = false` to all `files.list` queries. Fixes the bug where files moved to Drive trash were still ingested and counted.

- **Bug Fixes**
  - Added `and trashed = false` to indexer queries in `count_files_recursively`, the non-recursive precheck probe, and `get_paginated_results`.
  - Tests: unit assertions for each query; integration test creates a folder with one live and one trashed file and confirms only the live file is returned. The fixture nests under the provided drive ID and uses `supportsAllDrives` to match shared-drive behavior.

- **Dependencies**
  - Bumped `unstructured_ingest` to `1.6.11` and added a `CHANGELOG.md` entry for this fix.

<sup>Written for commit 76d5991df5d6001bc6c40576a176f69d1176e620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

