### PR TITLE
feat(slack): populate permalink URLs and auto-join channels with actionable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.17]
+
+### Enhancements
+
+- **feat(slack): auto-join public channels and include url in metadata.** Have slack connector attempt to join public channels automatically and verbosly report in an error when channel cannot be accessed for any reason. Include a permalink to the file or channel message in `FileData`
+
 ## [1.6.16]
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ test = [
     "beautifulsoup4",
     "pandas",
     # Connector specific deps
+    "slack_sdk",
     "cryptography",
     "fsspec",
     "vertexai",

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -7,16 +7,16 @@ from unstructured_ingest.data_types.file_data import (
     FileDataSourceMetadata,
     SourceIdentifiers,
 )
-from unstructured_ingest.error import ValueError as IngestValueError
 from unstructured_ingest.error import SourceConnectionError
+from unstructured_ingest.error import ValueError as IngestValueError
 from unstructured_ingest.processes.connectors.slack import (
     PRIVATE_FILE_DOWNLOAD_TIMEOUT_SECONDS,
     SlackAccessConfig,
     SlackDownloader,
     SlackIndexer,
     SlackIndexerConfig,
-    _NoRedirectHandler,
     _channel_join_error_msg,
+    _NoRedirectHandler,
 )
 
 
@@ -91,9 +91,7 @@ def test_messages_to_file_data_includes_permalink():
     assert file_data.metadata.url == (
         "https://my-workspace.slack.com/archives/C123/p1710000000000100"
     )
-    client.chat_getPermalink.assert_called_once_with(
-        channel="C123", message_ts="1710000000.000100"
-    )
+    client.chat_getPermalink.assert_called_once_with(channel="C123", message_ts="1710000000.000100")
 
 
 def test_messages_to_file_data_uses_oldest_ts_for_permalink():
@@ -110,9 +108,7 @@ def test_messages_to_file_data_uses_oldest_ts_for_permalink():
         client=client,
     )
 
-    client.chat_getPermalink.assert_called_once_with(
-        channel="C123", message_ts="1710000001.000000"
-    )
+    client.chat_getPermalink.assert_called_once_with(channel="C123", message_ts="1710000001.000000")
 
 
 def test_messages_to_file_data_omits_url_without_client():
@@ -351,7 +347,6 @@ def test_validate_and_join_channels_missing_scope_succeeds_if_already_member():
 
 
 def test_validate_and_join_channels_missing_scope_fails_if_not_member():
-    from slack_sdk.errors import SlackApiError
 
     def history_side_effect(**_):
         raise _make_slack_api_error("not_in_channel")
@@ -362,9 +357,7 @@ def test_validate_and_join_channels_missing_scope_fails_if_not_member():
     indexer = _make_indexer(channels=["C1"])
 
     with pytest.raises(SourceConnectionError, match="channels:join"):
-        indexer._validate_and_join_channels(
-            client, granted_scopes={"channels:history"}
-        )
+        indexer._validate_and_join_channels(client, granted_scopes={"channels:history"})
 
 
 def test_validate_and_join_channels_archived_always_fails():

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -8,6 +8,7 @@ from unstructured_ingest.data_types.file_data import (
     SourceIdentifiers,
 )
 from unstructured_ingest.error import ValueError as IngestValueError
+from unstructured_ingest.error import SourceConnectionError
 from unstructured_ingest.processes.connectors.slack import (
     PRIVATE_FILE_DOWNLOAD_TIMEOUT_SECONDS,
     SlackAccessConfig,
@@ -15,6 +16,7 @@ from unstructured_ingest.processes.connectors.slack import (
     SlackIndexer,
     SlackIndexerConfig,
     _NoRedirectHandler,
+    _channel_join_error_msg,
 )
 
 
@@ -271,3 +273,181 @@ async def test_slack_downloader_rejects_non_slack_private_download_url(tmp_path,
         await downloader._download_file(file_data, tmp_path / "F123-report.pdf")
 
     build_opener.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Auto-join / channel validation tests
+# ---------------------------------------------------------------------------
+
+
+def _make_slack_api_error(error_code: str):
+    from slack_sdk.errors import SlackApiError
+
+    response = Mock()
+    response.get.return_value = error_code
+    return SlackApiError(message=error_code, response=response)
+
+
+def test_validate_and_join_channels_succeeds_when_all_joins_succeed():
+    client = Mock()
+    indexer = _make_indexer(channels=["C1", "C2"])
+
+    indexer._validate_and_join_channels(client, granted_scopes=set())
+
+    assert client.conversations_join.call_count == 2
+
+
+def test_validate_and_join_channels_raises_for_failed_channel():
+    client = Mock()
+    client.conversations_join.side_effect = _make_slack_api_error("channel_not_found")
+    indexer = _make_indexer(channels=["C1"])
+
+    with pytest.raises(SourceConnectionError, match="C1"):
+        indexer._validate_and_join_channels(client, granted_scopes=set())
+
+
+def test_validate_and_join_channels_groups_same_error_across_channels():
+    client = Mock()
+    client.conversations_join.side_effect = _make_slack_api_error("is_archived")
+    indexer = _make_indexer(channels=["C1", "C2"])
+
+    with pytest.raises(SourceConnectionError) as exc_info:
+        indexer._validate_and_join_channels(client, granted_scopes=set())
+
+    msg = str(exc_info.value)
+    assert "C1, C2" in msg
+    # Both channels grouped onto one bullet, not one line per channel
+    assert msg.count("  - ") == 1
+
+
+def test_validate_and_join_channels_reports_all_failures_together():
+    def join_side_effect(channel, **_):
+        if channel == "C1":
+            raise _make_slack_api_error("channel_not_found")
+        if channel == "C2":
+            raise _make_slack_api_error("is_archived")
+
+    client = Mock()
+    client.conversations_join.side_effect = join_side_effect
+    indexer = _make_indexer(channels=["C1", "C2"])
+
+    with pytest.raises(SourceConnectionError) as exc_info:
+        indexer._validate_and_join_channels(client, granted_scopes=set())
+
+    msg = str(exc_info.value)
+    assert "C1" in msg
+    assert "C2" in msg
+    assert "2 channel" in msg
+
+
+def test_validate_and_join_channels_missing_scope_succeeds_if_already_member():
+    client = Mock()
+    client.conversations_join.side_effect = _make_slack_api_error("missing_scope")
+    indexer = _make_indexer(channels=["C1"])
+
+    indexer._validate_and_join_channels(client, granted_scopes=set())
+
+    client.conversations_history.assert_called_once_with(channel="C1", limit=1)
+
+
+def test_validate_and_join_channels_missing_scope_fails_if_not_member():
+    from slack_sdk.errors import SlackApiError
+
+    def history_side_effect(**_):
+        raise _make_slack_api_error("not_in_channel")
+
+    client = Mock()
+    client.conversations_join.side_effect = _make_slack_api_error("missing_scope")
+    client.conversations_history.side_effect = history_side_effect
+    indexer = _make_indexer(channels=["C1"])
+
+    with pytest.raises(SourceConnectionError, match="channels:join"):
+        indexer._validate_and_join_channels(
+            client, granted_scopes={"channels:history"}
+        )
+
+
+def test_validate_and_join_channels_archived_always_fails():
+    client = Mock()
+    client.conversations_join.side_effect = _make_slack_api_error("is_archived")
+    indexer = _make_indexer(channels=["C1"])
+
+    with pytest.raises(SourceConnectionError, match="archived"):
+        indexer._validate_and_join_channels(client, granted_scopes=set())
+
+    client.conversations_history.assert_not_called()
+
+
+def test_validate_and_join_channels_private_succeeds_if_already_invited():
+    client = Mock()
+    client.conversations_join.side_effect = _make_slack_api_error(
+        "method_not_supported_for_channel_type"
+    )
+    indexer = _make_indexer(channels=["C1"])
+
+    indexer._validate_and_join_channels(client, granted_scopes=set())
+
+    client.conversations_history.assert_called_once_with(channel="C1", limit=1)
+
+
+def test_validate_and_join_channels_private_fails_if_not_invited():
+    client = Mock()
+    client.conversations_join.side_effect = _make_slack_api_error(
+        "method_not_supported_for_channel_type"
+    )
+    client.conversations_history.side_effect = _make_slack_api_error("not_in_channel")
+    indexer = _make_indexer(channels=["C1"])
+
+    with pytest.raises(SourceConnectionError, match="private"):
+        indexer._validate_and_join_channels(client, granted_scopes=set())
+
+
+def test_channel_join_error_msg_private_channel_hint_when_join_scope_present():
+    msg = _channel_join_error_msg("channel_not_found", ["C1"], granted_scopes={"channels:join"})
+    assert "private" in msg.lower()
+    assert "invite" in msg.lower()
+
+
+def test_channel_join_error_msg_groups_multiple_archived_channels():
+    msg = _channel_join_error_msg("is_archived", ["C1", "C2"], granted_scopes=set())
+    assert "C1, C2" in msg
+    assert "are archived" in msg
+
+
+def test_channel_join_error_msg_private_channel_not_invited():
+    msg = _channel_join_error_msg(
+        "method_not_supported_for_channel_type", ["C1"], granted_scopes=set()
+    )
+    assert "private" in msg.lower()
+    assert "invite" in msg.lower()
+
+
+def test_run_joins_channels_before_yielding():
+    client = Mock()
+    client.conversations_history.return_value = []
+    client.conversations_join.side_effect = _make_slack_api_error("channel_not_found")
+    connection_config = Mock()
+    connection_config.get_client.return_value = client
+    indexer = SlackIndexer(
+        index_config=SlackIndexerConfig(channels=["C1"]),
+        connection_config=connection_config,
+    )
+
+    with pytest.raises(SourceConnectionError):
+        list(indexer.run())
+
+    client.conversations_join.assert_called_once_with(channel="C1")
+
+
+def test_precheck_uses_channel_validation():
+    client = Mock()
+    client.conversations_join.side_effect = _make_slack_api_error("is_archived")
+    connection_config = Mock()
+    connection_config.get_client.return_value = client
+    indexer = SlackIndexer(
+        index_config=SlackIndexerConfig(channels=["C1"]),
+        connection_config=connection_config,
+    )
+
+    with pytest.raises(SourceConnectionError, match="archived"):
+        indexer.precheck()

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -25,6 +25,13 @@ def test_slack_access_config_accepts_refresh_token():
     assert config.refresh_token == "xoxe-slack-refresh-token"
 
 
+def _make_indexer(channels=None):
+    return SlackIndexer(
+        index_config=SlackIndexerConfig(channels=channels or ["C123"]),
+        connection_config=Mock(),
+    )
+
+
 def test_slack_indexer_emits_file_data_for_message_files():
     client = Mock()
     client.conversations_history.return_value = [
@@ -44,6 +51,7 @@ def test_slack_indexer_emits_file_data_for_message_files():
             ]
         }
     ]
+    client.chat_getPermalink.return_value.get.return_value = None
     connection_config = Mock()
     connection_config.get_client.return_value = client
     indexer = SlackIndexer(
@@ -63,6 +71,105 @@ def test_slack_indexer_emits_file_data_for_message_files():
         "message_ts": "1710000000.000100",
         "file_id": "F123",
     }
+
+
+def test_messages_to_file_data_includes_permalink():
+    client = Mock()
+    client.chat_getPermalink.return_value.get.return_value = (
+        "https://my-workspace.slack.com/archives/C123/p1710000000000100"
+    )
+    indexer = _make_indexer()
+
+    file_data = indexer._messages_to_file_data(
+        messages=[{"ts": "1710000000.000100", "text": "hello"}],
+        channel="C123",
+        client=client,
+    )
+
+    assert file_data.metadata.url == (
+        "https://my-workspace.slack.com/archives/C123/p1710000000000100"
+    )
+    client.chat_getPermalink.assert_called_once_with(
+        channel="C123", message_ts="1710000000.000100"
+    )
+
+
+def test_messages_to_file_data_uses_oldest_ts_for_permalink():
+    client = Mock()
+    client.chat_getPermalink.return_value.get.return_value = "https://example.slack.com/p"
+    indexer = _make_indexer()
+
+    indexer._messages_to_file_data(
+        messages=[
+            {"ts": "1710000002.000000", "text": "newer"},
+            {"ts": "1710000001.000000", "text": "older"},
+        ],
+        channel="C123",
+        client=client,
+    )
+
+    client.chat_getPermalink.assert_called_once_with(
+        channel="C123", message_ts="1710000001.000000"
+    )
+
+
+def test_messages_to_file_data_omits_url_without_client():
+    file_data = _make_indexer()._messages_to_file_data(
+        messages=[{"ts": "1710000000.000100", "text": "hello"}],
+        channel="C123",
+    )
+
+    assert file_data.metadata.url is None
+
+
+def test_messages_to_file_data_omits_url_when_permalink_fetch_fails():
+    client = Mock()
+    client.chat_getPermalink.side_effect = Exception("API error")
+    indexer = _make_indexer()
+
+    file_data = indexer._messages_to_file_data(
+        messages=[{"ts": "1710000000.000100", "text": "hello"}],
+        channel="C123",
+        client=client,
+    )
+
+    assert file_data.metadata.url is None
+
+
+def test_message_files_to_file_data_includes_permalink():
+    messages = [
+        {
+            "ts": "1710000000.000100",
+            "files": [
+                {
+                    "id": "F123",
+                    "name": "report.pdf",
+                    "permalink": "https://my-workspace.slack.com/files/U123/F123/report.pdf",
+                }
+            ],
+        }
+    ]
+
+    file_data_list = list(_make_indexer()._message_files_to_file_data(messages, "C123"))
+
+    assert len(file_data_list) == 1
+    assert file_data_list[0].metadata.url == (
+        "https://my-workspace.slack.com/files/U123/F123/report.pdf"
+    )
+
+
+def test_message_files_to_file_data_omits_url_when_no_permalink():
+    messages = [
+        {
+            "ts": "1710000000.000100",
+            "files": [{"id": "F123", "name": "report.pdf"}],
+        }
+    ]
+
+    file_data_list = list(_make_indexer()._message_files_to_file_data(messages, "C123"))
+
+    assert len(file_data_list) == 1
+    assert file_data_list[0].metadata.url is None
 
 
 @pytest.mark.asyncio

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.16"  # pragma: no cover
+__version__ = "1.6.17"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -7,6 +7,7 @@ import time
 import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -111,9 +112,7 @@ def _channel_join_error_msg(error_code: str, channels: list, granted_scopes: set
             "Open the channel in Slack and use /invite @<bot-name>."
         )
     if error_code == "missing_scope":
-        scope_note = (
-            f" (granted: {', '.join(sorted(granted_scopes))})" if granted_scopes else ""
-        )
+        scope_note = f" (granted: {', '.join(sorted(granted_scopes))})" if granted_scopes else ""
         return (
             f"Bot token is missing the 'channels:join' scope{scope_note}. "
             f"Cannot auto-join {channel_list}. "
@@ -226,9 +225,7 @@ class SlackIndexer(Indexer):
                 raw = response.get("permalink")
                 permalink = raw if isinstance(raw, str) else None
             except Exception:
-                logger.debug(
-                    f"Could not retrieve permalink for channel={channel} ts={ts_oldest}."
-                )
+                logger.debug(f"Could not retrieve permalink for channel={channel} ts={ts_oldest}.")
 
         source_identifiers = SourceIdentifiers(
             filename=f"{filename}.xml", fullpath=f"{filename}.xml"
@@ -305,8 +302,6 @@ class SlackIndexer(Indexer):
             return set()
 
     def _validate_and_join_channels(self, client: "WebClient", granted_scopes: set) -> None:
-        from collections import defaultdict
-
         from slack_sdk.errors import SlackApiError
 
         issues: list[_ChannelIssue] = []
@@ -454,10 +449,13 @@ class SlackDownloader(Downloader):
     @staticmethod
     def _download_private_file(request: urllib.request.Request, download_path: Path) -> None:
         opener = urllib.request.build_opener(_NoRedirectHandler)
-        with opener.open(
-            request,
-            timeout=PRIVATE_FILE_DOWNLOAD_TIMEOUT_SECONDS,
-        ) as response, download_path.open("wb") as output_file:
+        with (
+            opener.open(
+                request,
+                timeout=PRIVATE_FILE_DOWNLOAD_TIMEOUT_SECONDS,
+            ) as response,
+            download_path.open("wb") as output_file,
+        ):
             shutil.copyfileobj(response, output_file)
 
     def _conversation_to_xml(self, conversation: list[list[dict]]) -> ET.ElementTree:

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -79,6 +79,56 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
         )
 
 
+@dataclass
+class _ChannelIssue:
+    channel: str
+    error_code: str
+
+
+def _channel_join_error_msg(error_code: str, channels: list, granted_scopes: set) -> str:
+    channel_list = ", ".join(channels)
+    are = "are" if len(channels) > 1 else "is"
+    if error_code == "channel_not_found":
+        if "channels:join" in granted_scopes:
+            return (
+                f"{channel_list}: not found or not accessible. "
+                "Private channels cannot be auto-joined — invite the bot directly."
+            )
+        return (
+            f"{channel_list}: not found or not accessible. "
+            "Possible causes: wrong channel ID, private channel (must invite bot manually), "
+            "or missing 'channels:join' scope to auto-join public channels."
+        )
+    if error_code == "is_archived":
+        return (
+            f"{channel_list} {are} archived. "
+            "Slack disables all app access on archival — archived channels cannot be indexed. "
+            "Unarchive the channel to index it."
+        )
+    if error_code == "method_not_supported_for_channel_type":
+        return (
+            f"{channel_list}: private channel — the bot must be invited directly before indexing. "
+            "Open the channel in Slack and use /invite @<bot-name>."
+        )
+    if error_code == "missing_scope":
+        scope_note = (
+            f" (granted: {', '.join(sorted(granted_scopes))})" if granted_scopes else ""
+        )
+        return (
+            f"Bot token is missing the 'channels:join' scope{scope_note}. "
+            f"Cannot auto-join {channel_list}. "
+            "Add the scope and reinstall the app, or invite the bot to each channel manually."
+        )
+    if error_code == "method_not_applicable":
+        return f"{channel_list} {are} not joinable (e.g. DMs or IMs)."
+    if error_code == "no_permission":
+        return (
+            f"Bot does not have permission to join {channel_list}. "
+            "Workspace restrictions may block app channel access."
+        )
+    return f"Failed to join {channel_list}: {error_code}."
+
+
 class SlackAccessConfig(AccessConfig):
     token: str = Field(
         description="Bot token used to access Slack API, must have channels:history scope for the"
@@ -130,6 +180,8 @@ class SlackIndexer(Indexer):
 
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
         client = self.connection_config.get_client()
+        granted_scopes = self._get_granted_scopes(client)
+        self._validate_and_join_channels(client, granted_scopes)
         for channel in self.index_config.channels:
             messages = []
             oldest = (
@@ -238,12 +290,58 @@ class SlackIndexer(Indexer):
                     display_name=source_identifiers.fullpath,
                 )
 
+    def _get_granted_scopes(self, client: "WebClient") -> set:
+        try:
+            response = client.auth_test()
+            # x-oauth-scopes is an HTTP response header present on every Slack API response.
+            # The SDK stores raw HTTP headers in response.headers as a plain dict whose keys
+            # preserve server casing, so use case-insensitive lookup.
+            scopes_header = next(
+                (v for k, v in response.headers.items() if k.lower() == "x-oauth-scopes"),
+                "",
+            )
+            return {s.strip() for s in scopes_header.split(",") if s.strip()}
+        except Exception:
+            return set()
+
+    def _validate_and_join_channels(self, client: "WebClient", granted_scopes: set) -> None:
+        from collections import defaultdict
+
+        from slack_sdk.errors import SlackApiError
+
+        issues: list[_ChannelIssue] = []
+        for channel in self.index_config.channels:
+            try:
+                client.conversations_join(channel=channel)
+            except SlackApiError as e:
+                error_code = e.response.get("error", "unknown")
+                if error_code in ("missing_scope", "method_not_supported_for_channel_type"):
+                    # Can't auto-join (missing scope or private channel); check if already a member.
+                    try:
+                        client.conversations_history(channel=channel, limit=1)
+                        continue
+                    except SlackApiError:
+                        pass
+                issues.append(_ChannelIssue(channel=channel, error_code=error_code))
+
+        if issues:
+            groups: dict[str, list] = defaultdict(list)
+            for issue in issues:
+                groups[issue.error_code].append(issue.channel)
+            lines = [
+                _channel_join_error_msg(error_code, channels, granted_scopes)
+                for error_code, channels in groups.items()
+            ]
+            raise SourceConnectionError(
+                f"Cannot access {len(issues)} channel(s):\n"
+                + "\n".join(f"  - {line}" for line in lines)
+            )
+
     @SourceConnectionError.wrap
     def precheck(self) -> None:
         client = self.connection_config.get_client()
-        for channel in self.index_config.channels:
-            # NOTE: Querying conversations history guarantees that the bot is in the channel
-            client.conversations_history(channel=channel, limit=1)
+        granted_scopes = self._get_granted_scopes(client)
+        self._validate_and_join_channels(client, granted_scopes)
 
 
 class SlackDownloaderConfig(DownloaderConfig):

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -150,7 +150,7 @@ class SlackIndexer(Indexer):
             ):
                 messages = conversation_history.get("messages", [])
                 if messages:
-                    yield self._messages_to_file_data(messages, channel)
+                    yield self._messages_to_file_data(messages, channel, client)
                     for file_data in self._message_files_to_file_data(messages, channel):
                         yield file_data
 
@@ -158,6 +158,7 @@ class SlackIndexer(Indexer):
         self,
         messages: list[dict],
         channel: str,
+        client: Optional["WebClient"] = None,
     ) -> FileData:
         ts_oldest = min((message["ts"] for message in messages), key=lambda m: float(m))
         ts_newest = max((message["ts"] for message in messages), key=lambda m: float(m))
@@ -165,6 +166,17 @@ class SlackIndexer(Indexer):
         identifier_base = f"{channel}-{ts_oldest}-{ts_newest}"
         identifier = hashlib.sha256(identifier_base.encode("utf-8")).hexdigest()
         filename = identifier[:16]
+
+        permalink = None
+        if client is not None:
+            try:
+                response = client.chat_getPermalink(channel=channel, message_ts=ts_oldest)
+                raw = response.get("permalink")
+                permalink = raw if isinstance(raw, str) else None
+            except Exception:
+                logger.debug(
+                    f"Could not retrieve permalink for channel={channel} ts={ts_oldest}."
+                )
 
         source_identifiers = SourceIdentifiers(
             filename=f"{filename}.xml", fullpath=f"{filename}.xml"
@@ -174,6 +186,7 @@ class SlackIndexer(Indexer):
             connector_type=CONNECTOR_TYPE,
             source_identifiers=source_identifiers,
             metadata=FileDataSourceMetadata(
+                url=permalink,
                 date_created=ts_oldest,
                 date_modified=ts_newest,
                 date_processed=str(time.time()),
@@ -209,6 +222,7 @@ class SlackIndexer(Indexer):
                     connector_type=CONNECTOR_TYPE,
                     source_identifiers=source_identifiers,
                     metadata=FileDataSourceMetadata(
+                        url=slack_file.get("permalink") or None,
                         date_created=(
                             str(slack_file.get("created")) if slack_file.get("created") else None
                         ),

--- a/uv.lock
+++ b/uv.lock
@@ -7296,6 +7296,7 @@ test = [
     { name = "pytest-tagging" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "slack-sdk" },
     { name = "universal-pathlib" },
     { name = "vertexai" },
 ]
@@ -7471,6 +7472,7 @@ test = [
     { name = "pytest-tagging" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "slack-sdk" },
     { name = "universal-pathlib" },
     { name = "vertexai" },
 ]


### PR DESCRIPTION
## Changes

**Commit 1 — Permalink URLs in `FileData`**

Populates `FileDataSourceMetadata.url` for every item the Slack indexer emits:
- Conversations (`.xml` batches): calls `chat.getPermalink` on the oldest message in each page. Failures are non-fatal — `url` is omitted rather than aborting indexing.
- File attachments: uses the `permalink` field already present on each file object returned by `conversations.history`.

**Commit 2 — Auto-join channels with actionable error reporting**

Before indexing begins (`run()` and `precheck()`), validates every configured channel by attempting `conversations.join`. All failures are collected and raised as a single `SourceConnectionError` so every issue surfaces in one go.

Error messages are grouped by error code — channels sharing the same root cause appear on a single line. Channel types handled:

- **Public channels**: auto-joined via `conversations.join`.
- **Private channels**: join returns `method_not_supported_for_channel_type`; falls back to `conversations.history` to check existing membership. Already-invited channels index normally; others report that the bot must be invited manually.
- **Missing `channels:join` scope**: same history fallback — channels the bot is already in proceed without error; others report the missing scope alongside the currently granted scopes.
- **Archived channels**: always a hard failure. Slack disables all app installations on archival regardless of prior membership.

Scopes are read from the `x-oauth-scopes` HTTP response header using case-insensitive lookup.

`slack_sdk` added to the test dependency group in `pyproject.toml`.