### PR TITLE
fix(google_drive): refresh OAuth access tokens via authorized_user credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.16]
+
+### Fixes
+
+- **fix(google_drive): refresh OAuth access tokens via authorized_user credentials.** The Google Drive connector authenticated with a raw OAuth access token that google-auth cannot refresh, so once the token expired (~1 hour) the indexer raised `RefreshError` and listed zero files. When `service_account_key` holds an `authorized_user` credential (carrying `refresh_token`, `client_id`, `client_secret`, and `token_uri`), the connector now builds it via `Credentials.from_authorized_user_info`, so google-auth mints a fresh access token automatically on expiry. The service-account and raw `oauth_token` paths are unchanged.
+
 ## [1.6.15]
 
 ### Fixes

--- a/test/unit/connectors/test_google_drive.py
+++ b/test/unit/connectors/test_google_drive.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
-from unstructured_ingest.error import SourceConnectionError, ValueError
+from unstructured_ingest.error import SourceConnectionError, UserAuthError, ValueError
 from unstructured_ingest.processes.connectors.google_drive import (
     GOOGLE_DRIVE_SKIP_MIME_TYPES,
     GOOGLE_EXPORT_MIME_MAP,
@@ -143,6 +143,238 @@ class TestGoogleDriveAccessConfig:
         )
         with pytest.raises(ValueError, match="both provided and have different values"):
             config.get_service_account_key()
+
+
+class TestGoogleDriveAuthorizedUserCredentials:
+    """The connector must build a self-refreshing google-auth credential when the key is an
+    ``authorized_user`` credential (the platform translates widget OAuth into this shape and
+    packs it into ``service_account_key``). Such a credential carries refresh_token, client_id,
+    client_secret, and token_uri, so google-auth mints a fresh access token on expiry instead of
+    raising RefreshError. The raw ``oauth_token`` and service-account paths must be untouched."""
+
+    AUTHORIZED_USER_KEY = {
+        "type": "authorized_user",
+        "client_id": "client-id.apps.googleusercontent.com",
+        "client_secret": "client-secret",
+        "refresh_token": "refresh-token-value",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+    def _downloader(self, access_config, tmp_path):
+        connection_config = GoogleDriveConnectionConfig(
+            drive_id="drive-id",
+            access_config=access_config,
+        )
+        return GoogleDriveDownloader(
+            connection_config=connection_config,
+            download_config=GoogleDriveDownloaderConfig(download_dir=tmp_path),
+        )
+
+    def test_get_credentials_authorized_user_is_refreshable(self, tmp_path):
+        """_get_credentials returns an OAuth credential carrying refresh material."""
+        from google.oauth2.credentials import Credentials as OAuthCredentials
+
+        downloader = self._downloader(
+            GoogleDriveAccessConfig(service_account_key=self.AUTHORIZED_USER_KEY), tmp_path
+        )
+
+        creds = downloader._get_credentials()
+
+        assert isinstance(creds, OAuthCredentials)
+        assert creds.refresh_token == "refresh-token-value"
+        assert creds.client_id == "client-id.apps.googleusercontent.com"
+        assert creds.client_secret == "client-secret"
+        assert creds.token_uri == "https://oauth2.googleapis.com/token"
+
+    def test_get_credentials_authorized_user_from_json_string(self, tmp_path):
+        """The authorized_user key also arrives as a JSON string from the platform."""
+        from google.oauth2.credentials import Credentials as OAuthCredentials
+
+        downloader = self._downloader(
+            GoogleDriveAccessConfig(service_account_key=json.dumps(self.AUTHORIZED_USER_KEY)),
+            tmp_path,
+        )
+
+        creds = downloader._get_credentials()
+
+        assert isinstance(creds, OAuthCredentials)
+        assert creds.refresh_token == "refresh-token-value"
+
+    def test_get_credentials_malformed_authorized_user_raises_user_auth_error(self, tmp_path):
+        """A malformed authorized_user key (missing OAuth fields) surfaces as UserAuthError,
+        matching how the service-account path reports invalid credentials, rather than leaking
+        a raw builtin ValueError."""
+        malformed = {"type": "authorized_user", "client_id": "only-client-id"}
+        downloader = self._downloader(
+            GoogleDriveAccessConfig(service_account_key=malformed), tmp_path
+        )
+
+        with pytest.raises(UserAuthError, match="authorized_user"):
+            downloader._get_credentials()
+
+    def test_get_credentials_oauth_token_is_not_refreshable(self, tmp_path):
+        """The raw oauth_token path is unchanged: a bare access token with no refresh material."""
+        from google.oauth2.credentials import Credentials as OAuthCredentials
+
+        downloader = self._downloader(
+            GoogleDriveAccessConfig(oauth_token="ya29.raw-access-token"), tmp_path
+        )
+
+        creds = downloader._get_credentials()
+
+        assert isinstance(creds, OAuthCredentials)
+        assert creds.token == "ya29.raw-access-token"
+        assert creds.refresh_token is None
+
+    def test_get_credentials_service_account_dispatches_to_service_account_info(
+        self, tmp_path, monkeypatch
+    ):
+        """A non-authorized_user key still routes to from_service_account_info (no regression)."""
+        from google.oauth2 import service_account
+
+        sa_key = {"type": "service_account", "project_id": "test", "private_key": "xxx"}
+        downloader = self._downloader(GoogleDriveAccessConfig(service_account_key=sa_key), tmp_path)
+
+        captured = {}
+
+        def fake_from_service_account_info(info, scopes=None):
+            captured["info"] = info
+            captured["scopes"] = scopes
+            return "SERVICE_ACCOUNT_CREDS"
+
+        monkeypatch.setattr(
+            service_account.Credentials,
+            "from_service_account_info",
+            staticmethod(fake_from_service_account_info),
+        )
+
+        creds = downloader._get_credentials()
+
+        assert creds == "SERVICE_ACCOUNT_CREDS"
+        assert captured["info"] == sa_key
+        assert captured["scopes"] == ["https://www.googleapis.com/auth/drive.readonly"]
+
+    def test_get_client_authorized_user_builds_refreshable_credential(self, monkeypatch):
+        """get_client builds a refreshable OAuth credential for an authorized_user key."""
+        from google.oauth2.credentials import Credentials as OAuthCredentials
+
+        connection_config = GoogleDriveConnectionConfig(
+            drive_id="drive-id",
+            access_config=GoogleDriveAccessConfig(service_account_key=self.AUTHORIZED_USER_KEY),
+        )
+
+        captured = {}
+
+        def fake_build(name, version, credentials=None):
+            captured["name"] = name
+            captured["credentials"] = credentials
+            return MagicMock()
+
+        monkeypatch.setattr("googleapiclient.discovery.build", fake_build)
+
+        with connection_config.get_client() as client:
+            assert client is not None
+
+        creds = captured["credentials"]
+        assert captured["name"] == "drive"
+        assert isinstance(creds, OAuthCredentials)
+        assert creds.refresh_token == "refresh-token-value"
+
+    def test_streaming_download_refreshes_authorized_user_credential(self, tmp_path, monkeypatch):
+        """The streaming downloader mints a fresh access token via refresh() for authorized_user,
+        rather than reusing a stale raw token."""
+        downloader = self._downloader(
+            GoogleDriveAccessConfig(service_account_key=self.AUTHORIZED_USER_KEY), tmp_path
+        )
+
+        fake_creds = MagicMock()
+        fake_creds.token = "fresh-access-token"
+        monkeypatch.setattr(downloader, "_get_credentials", lambda: fake_creds)
+
+        captured = {}
+
+        class _FakeStream:
+            status_code = 200
+
+            def iter_bytes(self):
+                return [b"file-bytes"]
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class _FakeHttpxClient:
+            def __init__(self, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def stream(self, method, url, headers=None):
+                captured["headers"] = headers
+                return _FakeStream()
+
+        monkeypatch.setattr("httpx.Client", _FakeHttpxClient)
+
+        out_path = tmp_path / "downloaded.bin"
+        result = downloader._raw_download_google_drive_file("https://drive/file", out_path)
+
+        fake_creds.refresh.assert_called_once()
+        assert captured["headers"]["Authorization"] == "Bearer fresh-access-token"
+        assert result == out_path
+        assert out_path.read_bytes() == b"file-bytes"
+
+    def test_streaming_download_uses_raw_oauth_token_without_refresh(self, tmp_path, monkeypatch):
+        """The raw oauth_token downloader path is unchanged: it uses the token directly and never
+        constructs/refreshes a credential."""
+        downloader = self._downloader(
+            GoogleDriveAccessConfig(oauth_token="ya29.raw-access-token"), tmp_path
+        )
+
+        def _fail_get_credentials():
+            raise AssertionError("raw oauth_token path must not build/refresh a credential")
+
+        monkeypatch.setattr(downloader, "_get_credentials", _fail_get_credentials)
+
+        captured = {}
+
+        class _FakeStream:
+            status_code = 200
+
+            def iter_bytes(self):
+                return [b"file-bytes"]
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class _FakeHttpxClient:
+            def __init__(self, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def stream(self, method, url, headers=None):
+                captured["headers"] = headers
+                return _FakeStream()
+
+        monkeypatch.setattr("httpx.Client", _FakeHttpxClient)
+
+        out_path = tmp_path / "downloaded.bin"
+        downloader._raw_download_google_drive_file("https://drive/file", out_path)
+
+        assert captured["headers"]["Authorization"] == "Bearer ya29.raw-access-token"
 
 
 class TestGoogleDriveNativeExports:

--- a/test/unit/connectors/test_google_drive.py
+++ b/test/unit/connectors/test_google_drive.py
@@ -256,6 +256,9 @@ class TestGoogleDriveAuthorizedUserCredentials:
 
     def test_get_client_authorized_user_builds_refreshable_credential(self, monkeypatch):
         """get_client builds a refreshable OAuth credential for an authorized_user key."""
+        # get_client imports googleapiclient (the google-drive extra), which the bare unit-test
+        # environment does not install; the other cases here only need google-auth.
+        pytest.importorskip("googleapiclient")
         from google.oauth2.credentials import Credentials as OAuthCredentials
 
         connection_config = GoogleDriveConnectionConfig(

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.15"  # pragma: no cover
+__version__ = "1.6.16"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -35,6 +35,8 @@ CONNECTOR_TYPE = "google_drive"
 GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 GOOGLE_DRIVE_NATIVE_MIME_PREFIX = "application/vnd.google-apps."
 
+DRIVE_READONLY_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
+
 # Native Google MIME types that have no downloadable or exportable content.
 # Shortcuts are aliases to other files, forms/maps/sites are web-only apps.
 # These are silently skipped during indexing and downloading.
@@ -121,6 +123,30 @@ def _build_extension_query_filter(extensions: list[str]) -> str:
     return " or ".join(clauses)
 
 
+def _authorized_user_credentials(key_data: dict):
+    """Build a self-refreshing OAuth credential from an ``authorized_user`` key dict.
+
+    The platform translates widget OAuth into an ``authorized_user`` credential carrying
+    refresh_token, client_id, client_secret, and token_uri, and packs it into
+    ``service_account_key``; google-auth then refreshes the access token automatically on
+    expiry. A malformed dict (missing required OAuth fields) surfaces as a UserAuthError,
+    matching how the service-account path reports invalid credentials.
+    """
+    # builtins.ValueError, not the module-level unstructured_ingest.error.ValueError that
+    # shadows it here: from_authorized_user_info raises the builtin on missing fields.
+    import builtins
+
+    from google.oauth2.credentials import Credentials as OAuthCredentials
+
+    try:
+        return OAuthCredentials.from_authorized_user_info(key_data, scopes=[DRIVE_READONLY_SCOPE])
+    except builtins.ValueError as exc:
+        raise UserAuthError(
+            "Invalid authorized_user credentials: missing required OAuth fields "
+            "(refresh_token, client_id, client_secret)."
+        ) from exc
+
+
 class GoogleDriveAccessConfig(AccessConfig):
     service_account_key: Optional[Annotated[dict, BeforeValidator(conform_string_to_dict)]] = Field(
         default=None, description="Credentials values to use for authentication"
@@ -200,7 +226,10 @@ class GoogleDriveConnectionConfig(ConnectionConfig):
                 creds = OAuthCredentials(token=access_config.oauth_token)
             else:
                 key_data = access_config.get_service_account_key()
-                creds = service_account.Credentials.from_service_account_info(key_data)
+                if isinstance(key_data, dict) and key_data.get("type") == "authorized_user":
+                    creds = _authorized_user_credentials(key_data)
+                else:
+                    creds = service_account.Credentials.from_service_account_info(key_data)
 
             service = build("drive", "v3", credentials=creds)
             with service.files() as client:
@@ -897,9 +926,14 @@ class GoogleDriveDownloader(Downloader):
             return OAuthCredentials(token=access_config.oauth_token)
 
         key_data = access_config.get_service_account_key()
+        if isinstance(key_data, dict) and key_data.get("type") == "authorized_user":
+            # The streaming downloader relies on this credential being refreshable: its
+            # creds.refresh(Request()) call mints a fresh access token for an authorized_user
+            # credential exactly as it does for a service account.
+            return _authorized_user_credentials(key_data)
         return service_account.Credentials.from_service_account_info(
             key_data,
-            scopes=["https://www.googleapis.com/auth/drive.readonly"],
+            scopes=[DRIVE_READONLY_SCOPE],
         )
 
     def _download_file(self, file_data: FileData) -> Optional[Path]:


### PR DESCRIPTION
## Why It Matters

Google Drive ingestion authenticated with a raw OAuth access token that `google-auth` cannot refresh. Access tokens expire after ~1 hour; on the next request after expiry `google-auth` looks for refresh material (`refresh_token`, `token_uri`, `client_id`, `client_secret`), finds none, and raises:

```
[RefreshError] The credentials do not contain the necessary fields need to refresh the access token.
You must specify refresh_token, token_uri, client_id, and client_secret.
```

The indexer then lists zero files and the job "completes" with nothing processed. In practice a Drive source works right after it is connected and silently stops ingesting about an hour later. Google Cloud Storage already avoids this by accepting a self-refreshing `authorized_user` credential; Google Drive shares the same OAuth flow but never gained the consumption path.

## Summary

The Google Drive connector now consumes an `authorized_user` credential. When `service_account_key` holds a credential whose `type` is `authorized_user` (carrying `refresh_token`, `client_id`, `client_secret`, and `token_uri`), the connector builds it with `Credentials.from_authorized_user_info(...)` instead of treating the key as a service account. `google-auth` then mints a fresh access token automatically whenever the current one expires, so long-running and repeated jobs no longer fail with `RefreshError`.

The two existing authentication paths are unchanged: a raw `oauth_token` is still used directly as a bare access token, and a service-account key still goes through `from_service_account_info`. The connector decides purely on the `type` field of the parsed key, so callers that already work keep working.

This is the connector half of the fix. For the path to engage in the hosted platform, the control plane must supply the `authorized_user` credential JSON (the same translation already performed for Google Cloud Storage); that producer-side change ships separately.

## Changes

- `unstructured_ingest/processes/connectors/google_drive.py`:
  - `get_client()` and `_get_credentials()` build a self-refreshing `Credentials.from_authorized_user_info(key, scopes=[DRIVE_READONLY_SCOPE])` when the parsed `service_account_key` has `type == "authorized_user"`; otherwise the service-account path is taken as before.
  - The streaming downloader needs no new branch: an `authorized_user` key leaves `oauth_token` unset, so the existing `else` branch already calls `_get_credentials()` and `creds.refresh(Request())`, which now refreshes the authorized-user credential and uses the freshly minted token.
  - Added a `DRIVE_READONLY_SCOPE` module constant for the Drive read-only scope.
- `test/unit/connectors/test_google_drive.py`: added `TestGoogleDriveAuthorizedUserCredentials` covering that `_get_credentials()` and `get_client()` produce a refreshable credential from an `authorized_user` key (dict and JSON-string forms), that the streaming downloader refreshes and uses a freshly minted token, that the raw `oauth_token` path stays non-refreshable and never builds/refreshes a credential, and that a service-account key still dispatches to `from_service_account_info`.
- Version bump to `1.6.16` with the matching `CHANGELOG.md` entry.
</content>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## E2E Validation

Validated live on a personal SND against real Google OAuth and a real connected Google Drive corpus. The `authorized_user` credential this change produces refreshes against live Google (fresh access token, `expires_in 3599`, `drive.readonly` scope) and lists the real corpus (10 files); the pre-fix raw-token credential returns HTTP 401 once expired with no way to refresh — the production failure, reproduced live. Full before/after evidence: https://gist.github.com/ryannikolaidis/b8fbe9cb309140561776b29eb6efc607
