### PR TITLE
fix(PLU-437): Azure OpenAI precheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.21]
+
+### Fixes
+
+- **fix(embed): validate Azure OpenAI deployments by reaching them, not via `models.list()`.** The Azure precheck inherited from OpenAI validated the model against `client.models.list()`, which on Azure returns the base-model catalog (`text-embedding-3-small`, …), never deployment names — so any deployment whose name differs from the base model (the normal Azure pattern) failed the precheck. `AzureOpenAIEmbeddingConfig.run_precheck` now validates via a minimal live `embeddings.create(input="precheck", model=<deployment>)` instead. `DeploymentNotFound` surfaces as a `UserError`; all other API errors route through `wrap_error`, closing a path where non-404 errors were silently swallowed.
+
 ## [1.6.20]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **fix(embed): validate Azure OpenAI deployments by reaching them, not via `models.list()`.** The Azure precheck inherited from OpenAI validated the model against `client.models.list()`, which on Azure returns the base-model catalog (`text-embedding-3-small`, …), never deployment names — so any deployment whose name differs from the base model (the normal Azure pattern) failed the precheck. `AzureOpenAIEmbeddingConfig.run_precheck` now validates via a minimal live `embeddings.create(input="precheck", model=<deployment>)` instead. `DeploymentNotFound` surfaces as a `UserError`; all other API errors route through `wrap_error`, closing a path where non-404 errors were silently swallowed.
+- **fix(embed): fix Azure OpenAI embedding precheck failing on valid deployments.** The precheck rejected Azure deployments whose name differed from the base model (the normal Azure setup), because it checked against the base-model catalog rather than the deployment. It now validates the deployment with a real test embedding call, so correctly configured deployments pass and a missing deployment reports a clear error.
 
 ## [1.6.20]
 

--- a/test/unit/embed/test_azure_openai.py
+++ b/test/unit/embed/test_azure_openai.py
@@ -1,0 +1,104 @@
+import importlib.util
+
+import httpx
+import pytest
+
+from unstructured_ingest.embed.azure_openai import AzureOpenAIEmbeddingConfig
+from unstructured_ingest.error import UserAuthError, UserError
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("openai") is None,
+    reason="openai extra not installed",
+)
+
+
+def _config() -> AzureOpenAIEmbeddingConfig:
+    # `model_name` is the deployment name on Azure (deliberately not a base-model id).
+    return AzureOpenAIEmbeddingConfig(
+        api_key="key",
+        azure_endpoint="https://example-resource.openai.azure.com/",
+        model_name="myprefix-ada-3-small",
+    )
+
+
+def _api_error(exc_cls, status_code: int, code: str, message: str):
+    """Build a realistic openai APIStatusError subclass with a JSON error body."""
+    response = httpx.Response(
+        status_code,
+        request=httpx.Request("POST", "https://example-resource.openai.azure.com/"),
+        json={"error": {"code": code, "message": message}},
+    )
+    return exc_cls(message, response=response, body={"code": code, "message": message})
+
+
+def test_run_precheck_validates_deployment_via_embeddings_call(mocker):
+    """Happy path: the precheck issues a minimal embeddings request against the
+    deployment name and passes when the call succeeds."""
+    mock_client = mocker.MagicMock()
+    mocker.patch.object(AzureOpenAIEmbeddingConfig, "get_client", return_value=mock_client)
+
+    _config().run_precheck()
+
+    mock_client.embeddings.create.assert_called_once_with(
+        input="precheck", model="myprefix-ada-3-small"
+    )
+
+
+def test_run_precheck_does_not_call_models_list(mocker):
+    """Core of the fix: precheck must NOT validate against client.models.list(), whose
+    Azure catalog never contains custom deployment names."""
+    mock_client = mocker.MagicMock()
+    mocker.patch.object(AzureOpenAIEmbeddingConfig, "get_client", return_value=mock_client)
+
+    _config().run_precheck()
+
+    mock_client.models.list.assert_not_called()
+
+
+def test_run_precheck_deployment_not_found_raises_user_error(mocker):
+    """A genuinely missing deployment surfaces as a UserError naming the deployment."""
+    from openai import NotFoundError
+
+    mock_client = mocker.MagicMock()
+    mock_client.embeddings.create.side_effect = _api_error(
+        NotFoundError,
+        status_code=404,
+        code="DeploymentNotFound",
+        message="The API deployment for this resource does not exist.",
+    )
+    mocker.patch.object(AzureOpenAIEmbeddingConfig, "get_client", return_value=mock_client)
+
+    with pytest.raises(UserError) as exc_info:
+        _config().run_precheck()
+
+    assert "myprefix-ada-3-small" in str(exc_info.value)
+
+
+def test_run_precheck_auth_error_is_not_swallowed(mocker):
+    """Regression: a non-404 APIStatusError (e.g. bad key) must be wrapped and raised,
+    not silently treated as a passing precheck."""
+    from openai import AuthenticationError
+
+    mock_client = mocker.MagicMock()
+    mock_client.embeddings.create.side_effect = _api_error(
+        AuthenticationError,
+        status_code=401,
+        code="401",
+        message="Access denied due to invalid subscription key.",
+    )
+    mocker.patch.object(AzureOpenAIEmbeddingConfig, "get_client", return_value=mock_client)
+
+    with pytest.raises(UserAuthError):
+        _config().run_precheck()
+
+
+def test_run_precheck_unexpected_error_is_wrapped(mocker):
+    """A non-API exception (e.g. connection failure) is routed through wrap_error."""
+    mock_client = mocker.MagicMock()
+    mock_client.embeddings.create.side_effect = ValueError("boom")
+    mocker.patch.object(AzureOpenAIEmbeddingConfig, "get_client", return_value=mock_client)
+
+    # wrap_error re-raises non-APIStatusError exceptions as-is rather than letting the
+    # precheck pass silently.
+    with pytest.raises(ValueError, match="boom"):
+        _config().run_precheck()

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.20"  # pragma: no cover
+__version__ = "1.6.21"  # pragma: no cover

--- a/unstructured_ingest/embed/azure_openai.py
+++ b/unstructured_ingest/embed/azure_openai.py
@@ -42,6 +42,7 @@ class AzureOpenAIEmbeddingConfig(OpenAIEmbeddingConfig):
         except APIStatusError as e:
             if e.status_code == 404 and e.code == "DeploymentNotFound":
                 raise UserError(f"model '{self.embedder_model_name}' not found: {e.message}")
+            raise self.wrap_error(e=e)
         except Exception as e:
             raise self.wrap_error(e=e)
 

--- a/unstructured_ingest/embed/azure_openai.py
+++ b/unstructured_ingest/embed/azure_openai.py
@@ -8,6 +8,7 @@ from unstructured_ingest.embed.openai import (
     OpenAIEmbeddingConfig,
     OpenAIEmbeddingEncoder,
 )
+from unstructured_ingest.error import UserError
 from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.utils.tls import ssl_context_with_optional_ca_override
 
@@ -21,6 +22,28 @@ class AzureOpenAIEmbeddingConfig(OpenAIEmbeddingConfig):
     embedder_model_name: str = Field(
         default="text-embedding-ada-002", alias="model_name", description="Azure OpenAI model name"
     )
+
+    @requires_dependencies(["openai"], extras="openai")
+    def run_precheck(self) -> None:
+        """
+        Check if embedding model can be reached.
+
+        In Azure OpenAI fetched models list is a list of all available models
+        throughout the whole Azure AI Foundry, and not the deployed models
+        in our Azure AI Foundry instance.
+        Validating model against the list might not yield correct results, so
+        we need to validate that the given model deployment can be reached.
+        """
+        from openai import APIStatusError
+
+        try:
+            client = self.get_client()
+            client.embeddings.create(input="precheck", model=self.embedder_model_name)
+        except APIStatusError as e:
+            if e.status_code == 404 and e.code == "DeploymentNotFound":
+                raise UserError(f"model '{self.embedder_model_name}' not found: {e.message}")
+        except Exception as e:
+            raise self.wrap_error(e=e)
 
     @requires_dependencies(["openai"], extras="openai")
     def get_client(self) -> "AzureOpenAI":

--- a/unstructured_ingest/embed/azure_openai.py
+++ b/unstructured_ingest/embed/azure_openai.py
@@ -28,11 +28,12 @@ class AzureOpenAIEmbeddingConfig(OpenAIEmbeddingConfig):
         """
         Check if embedding model can be reached.
 
-        In Azure OpenAI fetched models list is a list of all available models
-        throughout the whole Azure AI Foundry, and not the deployed models
-        in our Azure AI Foundry instance.
-        Validating model against the list might not yield correct results, so
-        we need to validate that the given model deployment can be reached.
+        In Azure OpenAI the fetched models list (``client.models.list()``) is the
+        base-model catalog available to the resource, NOT the deployments created in
+        the Azure AI Foundry instance — and a deployment name is the only valid value
+        for the ``model`` parameter. Validating a deployment name against that catalog
+        rejects every custom-named deployment, so instead we validate that the given
+        deployment can actually be reached by issuing a minimal embeddings request.
         """
         from openai import APIStatusError
 
@@ -41,7 +42,7 @@ class AzureOpenAIEmbeddingConfig(OpenAIEmbeddingConfig):
             client.embeddings.create(input="precheck", model=self.embedder_model_name)
         except APIStatusError as e:
             if e.status_code == 404 and e.code == "DeploymentNotFound":
-                raise UserError(f"model '{self.embedder_model_name}' not found: {e.message}")
+                raise UserError(f"model '{self.embedder_model_name}' not found: {e.message}") from e
             raise self.wrap_error(e=e)
         except Exception as e:
             raise self.wrap_error(e=e)


### PR DESCRIPTION
## Fix Azure OpenAI embed precheck for custom-named deployments

### What
`AzureOpenAIEmbeddingConfig` inherited OpenAI's precheck, which validates the model against `client.models.list()`. On Azure that returns the base-model catalog (`text-embedding-3-small`, …), never deployment names — yet a deployment name is the only valid `model` value. Any deployment whose name differs from the base-model name (the normal Azure pattern) failed the precheck, making the embed step unusable. Reported by a customer running Azure OpenAI on AKS.

### Change
Override `run_precheck` on `AzureOpenAIEmbeddingConfig` to validate via a minimal live `embeddings.create(input="precheck", model=<deployment>)` instead of catalog membership. This checks auth, endpoint, and deployment existence using the only identifier Azure accepts, and works with any deployment name. The model is already validated against the model registry upstream, so the catalog check was also redundant.

- `DeploymentNotFound` (404) → `UserError` naming the deployment.
- All other API errors route through `wrap_error` (fixes a silent-failure path where non-404 API errors were swallowed and the precheck falsely passed).

### Tests
- New `test/unit/embed/test_azure_openai.py`: happy path, asserts `models.list()` is not called, `DeploymentNotFound`→`UserError`, auth-error-not-swallowed regression, unexpected-error wrapped.
- Existing `test/integration/embedders/test_azure_openai.py` still passes.

### Notes
Precheck now makes one small billable embeddings call per embedder init (previously a free `models.list()`). Flows into `platform-plugins-embed` via a dependency bump — no plugin code change needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

