### PR TITLE
test(PLU-370): integration test for sharepoint per-file collapsed perms

### DIFF
--- a/test/integration/connectors/test_sharepoint.py
+++ b/test/integration/connectors/test_sharepoint.py
@@ -326,23 +326,13 @@ async def test_sharepoint_library_with_path(temp_dir):
 async def test_sharepoint_permissions_not_collapsed():
     """Regression test for PLU-370.
 
-    Bug: office365-rest-python-client shared one mutable Identity object as a class-level
-    default across every Permission deserialization. Each file's permissions overwrote the
-    same singleton in place, so by the time all files were indexed every file reported the
-    same user/group — whichever identity happened to be deserialized last.
+    Bug: office365-rest-python-client shared a mutable Identity singleton across all
+    Permission deserializations, so every file collapsed to the same last-deserialized
+    user/group. Fix (1.6.15) parses raw Graph /$batch JSON directly.
 
-    Fix (1.6.15): bypass the SDK's typed accessors entirely and parse raw Graph /$batch
-    JSON directly, so each file gets its own identity objects.
-
-    We assert structural correctness rather than exact values because permissions_data is a
-    live ACL snapshot: a tenant admin changing sharing on the test site would break a golden
-    fixture without any code change. See SHAREPOINT_SOURCE_EXCLUDE_FIELDS for the same
-    reasoning applied to the other source tests.
-
-    What "distinct identities" proves: if the singleton bug were still present, every file
-    would return the same collapsed identity (the last one deserialized). Seeing at least two
-    different permissions_data values across files means each file is getting its own snapshot
-    from the raw JSON — the bug is gone.
+    We check structural correctness (non-null + distinct) rather than exact values because
+    permissions_data is a live ACL snapshot that drifts with tenant admin changes — same
+    reasoning as SHAREPOINT_SOURCE_EXCLUDE_FIELDS in the other source tests.
     """
     import json
 

--- a/test/integration/connectors/test_sharepoint.py
+++ b/test/integration/connectors/test_sharepoint.py
@@ -320,6 +320,48 @@ async def test_sharepoint_library_with_path(temp_dir):
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.tags(CONNECTOR_TYPE, SOURCE_TAG, BLOB_STORAGE_TAG)
+@requires_env("SHAREPOINT_CLIENT_ID", "SHAREPOINT_CRED", "MS_TENANT_ID", "MS_USER_PNAME")
+async def test_sharepoint_permissions_not_collapsed():
+    """Regression test for PLU-370.
+
+    The office365-rest-python-client SDK shared a mutable-default Identity singleton across
+    every Permission deserialization, causing all files to report the same collapsed identity
+    in permissions_data. The fix parses raw Graph /$batch JSON directly.
+
+    Asserts:
+    - At least one file has non-null permissions_data (permissions are fetched at all).
+    - Not all files share identical permissions_data (no singleton identity collapse).
+    """
+    import json
+
+    site = "https://unstructuredio.sharepoint.com/sites/utic-platform-test-source"
+    config = sharepoint_config()
+
+    indexer = SharepointIndexer(
+        connection_config=SharepointConnectionConfig(
+            client_id=config.client_id,
+            site=site,
+            tenant=config.tenant,
+            access_config=SharepointAccessConfig(client_cred=config.client_cred),
+        ),
+        index_config=SharepointIndexerConfig(recursive=True),
+    )
+
+    file_datas = [fd async for fd in indexer.run_async()]
+    assert len(file_datas) > 1, "Need multiple files to test for identity collapse"
+
+    perms = [fd.metadata.permissions_data for fd in file_datas]
+    assert any(p for p in perms), "permissions_data is null for all files — permissions not fetched"
+
+    unique_perms = {json.dumps(p, sort_keys=True) for p in perms}
+    assert len(unique_perms) > 1, (
+        "All files returned identical permissions_data — "
+        "SDK singleton identity collapse (PLU-370) may still be present"
+    )
+
+
 @pytest.fixture
 def base_sharepoint_config():
     """Base SharePoint config for testing."""

--- a/test/integration/connectors/test_sharepoint.py
+++ b/test/integration/connectors/test_sharepoint.py
@@ -326,13 +326,23 @@ async def test_sharepoint_library_with_path(temp_dir):
 async def test_sharepoint_permissions_not_collapsed():
     """Regression test for PLU-370.
 
-    The office365-rest-python-client SDK shared a mutable-default Identity singleton across
-    every Permission deserialization, causing all files to report the same collapsed identity
-    in permissions_data. The fix parses raw Graph /$batch JSON directly.
+    Bug: office365-rest-python-client shared one mutable Identity object as a class-level
+    default across every Permission deserialization. Each file's permissions overwrote the
+    same singleton in place, so by the time all files were indexed every file reported the
+    same user/group — whichever identity happened to be deserialized last.
 
-    Asserts:
-    - At least one file has non-null permissions_data (permissions are fetched at all).
-    - Not all files share identical permissions_data (no singleton identity collapse).
+    Fix (1.6.15): bypass the SDK's typed accessors entirely and parse raw Graph /$batch
+    JSON directly, so each file gets its own identity objects.
+
+    We assert structural correctness rather than exact values because permissions_data is a
+    live ACL snapshot: a tenant admin changing sharing on the test site would break a golden
+    fixture without any code change. See SHAREPOINT_SOURCE_EXCLUDE_FIELDS for the same
+    reasoning applied to the other source tests.
+
+    What "distinct identities" proves: if the singleton bug were still present, every file
+    would return the same collapsed identity (the last one deserialized). Seeing at least two
+    different permissions_data values across files means each file is getting its own snapshot
+    from the raw JSON — the bug is gone.
     """
     import json
 
@@ -353,8 +363,11 @@ async def test_sharepoint_permissions_not_collapsed():
     assert len(file_datas) > 1, "Need multiple files to test for identity collapse"
 
     perms = [fd.metadata.permissions_data for fd in file_datas]
+    # Permissions must be populated — a null across the board means the fetch didn't run.
     assert any(p for p in perms), "permissions_data is null for all files — permissions not fetched"
 
+    # PLU-370: the singleton bug made every file return the same identity. If this fails,
+    # all files collapsed to one identity again — check onedrive.py for SDK typed accessor use.
     unique_perms = {json.dumps(p, sort_keys=True) for p in perms}
     assert len(unique_perms) > 1, (
         "All files returned identical permissions_data — "


### PR DESCRIPTION
Adds a functional integration test that hits the live SharePoint site and asserts each file returns distinct permissions_data - catching the SDK singleton identity collapse fixed in 1.6.15.

mostly for my own sanity. 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

