### PR TITLE
feat(slack): user token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.21]
+
+### Enhancements
+
+- **feat(slack): user token specific behavior** - differentiate between user and bot token in slack indexer, bot still attempts to join channels (required for ingestion) while user reads channel without joining. Add token specific error messages.
+
+
 ## [1.6.20]
 
 ### Fixes

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -15,6 +15,7 @@ from unstructured_ingest.processes.connectors.slack import (
     SlackDownloader,
     SlackIndexer,
     SlackIndexerConfig,
+    _channel_history_error_msg,
     _channel_join_error_msg,
     _NoRedirectHandler,
     _token_kind,
@@ -461,3 +462,57 @@ def test_precheck_uses_channel_validation():
 
     with pytest.raises(SourceConnectionError, match="archived"):
         indexer.precheck()
+
+
+# ---------------------------------------------------------------------------
+# _channel_history_error_msg (user-token path)
+# ---------------------------------------------------------------------------
+
+
+def test_channel_history_error_msg_not_in_channel():
+    msg = _channel_history_error_msg("not_in_channel", ["C1"], granted_scopes=set())
+    assert "private" in msg.lower()
+    assert "invite" in msg.lower()
+
+
+def test_channel_history_error_msg_channel_not_found():
+    msg = _channel_history_error_msg("channel_not_found", ["C1"], granted_scopes=set())
+    assert "not found" in msg.lower() or "accessible" in msg.lower()
+
+
+def test_channel_history_error_msg_archived():
+    msg = _channel_history_error_msg("is_archived", ["C1"], granted_scopes=set())
+    assert "archived" in msg.lower()
+
+
+def test_channel_history_error_msg_archived_multiple_channels():
+    msg = _channel_history_error_msg("is_archived", ["C1", "C2"], granted_scopes=set())
+    assert "C1, C2" in msg
+    assert "are" in msg
+
+
+def test_channel_history_error_msg_missing_scope():
+    msg = _channel_history_error_msg("missing_scope", ["C1"], granted_scopes=set())
+    assert "channels:history" in msg
+
+
+def test_channel_history_error_msg_missing_scope_includes_granted():
+    msg = _channel_history_error_msg(
+        "missing_scope", ["C1"], granted_scopes={"channels:read"}
+    )
+    assert "channels:read" in msg
+
+
+def test_channel_history_error_msg_invalid_auth():
+    msg = _channel_history_error_msg("invalid_auth", ["C1"], granted_scopes=set())
+    assert "token" in msg.lower() or "auth" in msg.lower()
+
+
+def test_channel_history_error_msg_token_revoked():
+    msg = _channel_history_error_msg("token_revoked", ["C1"], granted_scopes=set())
+    assert "revoked" in msg.lower() or "token" in msg.lower()
+
+
+def test_channel_history_error_msg_unknown_error():
+    msg = _channel_history_error_msg("some_weird_error", ["C1"], granted_scopes=set())
+    assert "some_weird_error" in msg

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -17,7 +17,24 @@ from unstructured_ingest.processes.connectors.slack import (
     SlackIndexerConfig,
     _channel_join_error_msg,
     _NoRedirectHandler,
+    _token_kind,
 )
+
+
+def test_token_kind_user_prefix():
+    assert _token_kind("xoxp-12345") == "user"
+
+
+def test_token_kind_bot_prefix():
+    assert _token_kind("xoxb-12345") == "bot"
+
+
+def test_token_kind_unknown_prefix_is_bot():
+    assert _token_kind("xoxa-12345") == "bot"
+
+
+def test_token_kind_non_string_is_bot():
+    assert _token_kind(Mock()) == "bot"
 
 
 def test_slack_access_config_accepts_refresh_token():

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -500,6 +500,7 @@ def test_run_joins_channels_before_yielding():
     client.conversations_join.side_effect = _make_slack_api_error("channel_not_found")
     connection_config = Mock()
     connection_config.get_client.return_value = client
+    connection_config.access_config.get_secret_value.return_value.token = "xoxb-bot"
     indexer = SlackIndexer(
         index_config=SlackIndexerConfig(channels=["C1"]),
         connection_config=connection_config,
@@ -511,11 +512,28 @@ def test_run_joins_channels_before_yielding():
     client.conversations_join.assert_called_once_with(channel="C1")
 
 
+def test_run_does_not_join_channels_with_user_token():
+    client = Mock()
+    client.conversations_history.return_value = []
+    connection_config = Mock()
+    connection_config.get_client.return_value = client
+    connection_config.access_config.get_secret_value.return_value.token = "xoxp-user"
+    indexer = SlackIndexer(
+        index_config=SlackIndexerConfig(channels=["C1"]),
+        connection_config=connection_config,
+    )
+
+    list(indexer.run())
+
+    client.conversations_join.assert_not_called()
+
+
 def test_precheck_uses_channel_validation():
     client = Mock()
     client.conversations_join.side_effect = _make_slack_api_error("is_archived")
     connection_config = Mock()
     connection_config.get_client.return_value = client
+    connection_config.access_config.get_secret_value.return_value.token = "xoxb-bot"
     indexer = SlackIndexer(
         index_config=SlackIndexerConfig(channels=["C1"]),
         connection_config=connection_config,
@@ -523,6 +541,22 @@ def test_precheck_uses_channel_validation():
 
     with pytest.raises(SourceConnectionError, match="archived"):
         indexer.precheck()
+
+
+def test_precheck_user_token_does_not_join():
+    client = Mock()
+    client.conversations_history.return_value = [{"messages": []}]
+    connection_config = Mock()
+    connection_config.get_client.return_value = client
+    connection_config.access_config.get_secret_value.return_value.token = "xoxp-user"
+    indexer = SlackIndexer(
+        index_config=SlackIndexerConfig(channels=["C1"]),
+        connection_config=connection_config,
+    )
+
+    indexer.precheck()
+
+    client.conversations_join.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -302,31 +302,31 @@ def _make_slack_api_error(error_code: str):
     return SlackApiError(message=error_code, response=response)
 
 
-def test_validate_and_join_channels_succeeds_when_all_joins_succeed():
+def test_validate_channels_bot_succeeds_when_all_joins_succeed():
     client = Mock()
     indexer = _make_indexer(channels=["C1", "C2"])
 
-    indexer._validate_and_join_channels(client, granted_scopes=set())
+    indexer._validate_channels_bot(client, granted_scopes=set())
 
     assert client.conversations_join.call_count == 2
 
 
-def test_validate_and_join_channels_raises_for_failed_channel():
+def test_validate_channels_bot_raises_for_failed_channel():
     client = Mock()
     client.conversations_join.side_effect = _make_slack_api_error("channel_not_found")
     indexer = _make_indexer(channels=["C1"])
 
     with pytest.raises(SourceConnectionError, match="C1"):
-        indexer._validate_and_join_channels(client, granted_scopes=set())
+        indexer._validate_channels_bot(client, granted_scopes=set())
 
 
-def test_validate_and_join_channels_groups_same_error_across_channels():
+def test_validate_channels_bot_groups_same_error_across_channels():
     client = Mock()
     client.conversations_join.side_effect = _make_slack_api_error("is_archived")
     indexer = _make_indexer(channels=["C1", "C2"])
 
     with pytest.raises(SourceConnectionError) as exc_info:
-        indexer._validate_and_join_channels(client, granted_scopes=set())
+        indexer._validate_channels_bot(client, granted_scopes=set())
 
     msg = str(exc_info.value)
     assert "C1, C2" in msg
@@ -334,7 +334,7 @@ def test_validate_and_join_channels_groups_same_error_across_channels():
     assert msg.count("  - ") == 1
 
 
-def test_validate_and_join_channels_reports_all_failures_together():
+def test_validate_channels_bot_reports_all_failures_together():
     def join_side_effect(channel, **_):
         if channel == "C1":
             raise _make_slack_api_error("channel_not_found")
@@ -346,7 +346,7 @@ def test_validate_and_join_channels_reports_all_failures_together():
     indexer = _make_indexer(channels=["C1", "C2"])
 
     with pytest.raises(SourceConnectionError) as exc_info:
-        indexer._validate_and_join_channels(client, granted_scopes=set())
+        indexer._validate_channels_bot(client, granted_scopes=set())
 
     msg = str(exc_info.value)
     assert "C1" in msg
@@ -354,17 +354,17 @@ def test_validate_and_join_channels_reports_all_failures_together():
     assert "2 channel" in msg
 
 
-def test_validate_and_join_channels_missing_scope_succeeds_if_already_member():
+def test_validate_channels_bot_missing_scope_succeeds_if_already_member():
     client = Mock()
     client.conversations_join.side_effect = _make_slack_api_error("missing_scope")
     indexer = _make_indexer(channels=["C1"])
 
-    indexer._validate_and_join_channels(client, granted_scopes=set())
+    indexer._validate_channels_bot(client, granted_scopes=set())
 
     client.conversations_history.assert_called_once_with(channel="C1", limit=1)
 
 
-def test_validate_and_join_channels_missing_scope_fails_if_not_member():
+def test_validate_channels_bot_missing_scope_fails_if_not_member():
 
     def history_side_effect(**_):
         raise _make_slack_api_error("not_in_channel")
@@ -375,33 +375,33 @@ def test_validate_and_join_channels_missing_scope_fails_if_not_member():
     indexer = _make_indexer(channels=["C1"])
 
     with pytest.raises(SourceConnectionError, match="channels:join"):
-        indexer._validate_and_join_channels(client, granted_scopes={"channels:history"})
+        indexer._validate_channels_bot(client, granted_scopes={"channels:history"})
 
 
-def test_validate_and_join_channels_archived_always_fails():
+def test_validate_channels_bot_archived_always_fails():
     client = Mock()
     client.conversations_join.side_effect = _make_slack_api_error("is_archived")
     indexer = _make_indexer(channels=["C1"])
 
     with pytest.raises(SourceConnectionError, match="archived"):
-        indexer._validate_and_join_channels(client, granted_scopes=set())
+        indexer._validate_channels_bot(client, granted_scopes=set())
 
     client.conversations_history.assert_not_called()
 
 
-def test_validate_and_join_channels_private_succeeds_if_already_invited():
+def test_validate_channels_bot_private_succeeds_if_already_invited():
     client = Mock()
     client.conversations_join.side_effect = _make_slack_api_error(
         "method_not_supported_for_channel_type"
     )
     indexer = _make_indexer(channels=["C1"])
 
-    indexer._validate_and_join_channels(client, granted_scopes=set())
+    indexer._validate_channels_bot(client, granted_scopes=set())
 
     client.conversations_history.assert_called_once_with(channel="C1", limit=1)
 
 
-def test_validate_and_join_channels_private_fails_if_not_invited():
+def test_validate_channels_bot_private_fails_if_not_invited():
     client = Mock()
     client.conversations_join.side_effect = _make_slack_api_error(
         "method_not_supported_for_channel_type"
@@ -410,7 +410,68 @@ def test_validate_and_join_channels_private_fails_if_not_invited():
     indexer = _make_indexer(channels=["C1"])
 
     with pytest.raises(SourceConnectionError, match="private"):
-        indexer._validate_and_join_channels(client, granted_scopes=set())
+        indexer._validate_channels_bot(client, granted_scopes=set())
+
+
+def test_validate_channels_user_does_not_call_join():
+    client = Mock()
+    indexer = _make_indexer(channels=["C1", "C2"])
+
+    indexer._validate_channels_user(client, granted_scopes=set())
+
+    client.conversations_join.assert_not_called()
+    assert client.conversations_history.call_count == 2
+
+
+def test_validate_channels_user_raises_when_history_fails():
+    client = Mock()
+    client.conversations_history.side_effect = _make_slack_api_error("not_in_channel")
+    indexer = _make_indexer(channels=["C1"])
+
+    with pytest.raises(SourceConnectionError, match="user token"):
+        indexer._validate_channels_user(client, granted_scopes=set())
+
+
+def test_validate_channels_user_succeeds_when_history_accessible():
+    client = Mock()
+    client.conversations_history.return_value = [{"messages": []}]
+    indexer = _make_indexer(channels=["C1"])
+
+    indexer._validate_channels_user(client, granted_scopes=set())
+
+    client.conversations_history.assert_called_once_with(channel="C1", limit=1)
+
+
+def test_validate_channels_user_groups_errors():
+    client = Mock()
+    client.conversations_history.side_effect = _make_slack_api_error("is_archived")
+    indexer = _make_indexer(channels=["C1", "C2"])
+
+    with pytest.raises(SourceConnectionError) as exc_info:
+        indexer._validate_channels_user(client, granted_scopes=set())
+
+    msg = str(exc_info.value)
+    assert "C1, C2" in msg
+    assert msg.count("  - ") == 1
+
+
+def test_validate_channels_dispatches_bot_for_bot_token():
+    client = Mock()
+    indexer = _make_indexer(channels=["C1"])
+
+    indexer._validate_channels(client, token_kind="bot", granted_scopes=set())
+
+    client.conversations_join.assert_called_once_with(channel="C1")
+
+
+def test_validate_channels_dispatches_user_for_user_token():
+    client = Mock()
+    indexer = _make_indexer(channels=["C1"])
+
+    indexer._validate_channels(client, token_kind="user", granted_scopes=set())
+
+    client.conversations_join.assert_not_called()
+    client.conversations_history.assert_called_once_with(channel="C1", limit=1)
 
 
 def test_channel_join_error_msg_private_channel_hint_when_join_scope_present():

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -34,10 +34,6 @@ def test_token_kind_unknown_prefix_is_bot():
     assert _token_kind("xoxa-12345") == "bot"
 
 
-def test_token_kind_non_string_is_bot():
-    assert _token_kind(Mock()) == "bot"
-
-
 def test_slack_access_config_accepts_refresh_token():
     config = SlackAccessConfig(token="xoxb-slack-token", refresh_token="xoxe-slack-refresh-token")
 
@@ -592,9 +588,7 @@ def test_channel_history_error_msg_missing_scope():
 
 
 def test_channel_history_error_msg_missing_scope_includes_granted():
-    msg = _channel_history_error_msg(
-        "missing_scope", ["C1"], granted_scopes={"channels:read"}
-    )
+    msg = _channel_history_error_msg("missing_scope", ["C1"], granted_scopes={"channels:read"})
     assert "channels:read" in msg
 
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.20"  # pragma: no cover
+__version__ = "1.6.21"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -220,7 +220,8 @@ class SlackIndexer(Indexer):
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
         client = self.connection_config.get_client()
         granted_scopes = self._get_granted_scopes(client)
-        self._validate_and_join_channels(client, granted_scopes)
+        token = self.connection_config.access_config.get_secret_value().token
+        self._validate_channels(client, _token_kind(token), granted_scopes)
         for channel in self.index_config.channels:
             messages = []
             oldest = (
@@ -408,7 +409,8 @@ class SlackIndexer(Indexer):
     def precheck(self) -> None:
         client = self.connection_config.get_client()
         granted_scopes = self._get_granted_scopes(client)
-        self._validate_and_join_channels(client, granted_scopes)
+        token = self.connection_config.access_config.get_secret_value().token
+        self._validate_channels(client, _token_kind(token), granted_scopes)
 
 
 class SlackDownloaderConfig(DownloaderConfig):

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -47,6 +47,11 @@ SLACK_PRIVATE_FILE_HOST = "files.slack.com"
 CONNECTOR_TYPE = "slack"
 
 
+def _token_kind(token: object) -> str:
+    """Returns 'user' for xoxp- tokens, 'bot' for all others."""
+    return "user" if isinstance(token, str) and token.startswith("xoxp-") else "bot"
+
+
 def _safe_slack_filename(filename: str) -> str:
     sanitized = re.sub(r"[/\\]+", "_", filename).strip()
     return sanitized or "slack-file"
@@ -130,8 +135,10 @@ def _channel_join_error_msg(error_code: str, channels: list, granted_scopes: set
 
 class SlackAccessConfig(AccessConfig):
     token: str = Field(
-        description="Bot token used to access Slack API, must have channels:history scope for the"
-        " bot user."
+        description="Bot token (xoxb-…) or user token (xoxp-…) for the Slack API. "
+        "Both require channels:history scope. "
+        "With a bot token the connector auto-joins public channels; "
+        "with a user token it does not — user tokens can view public channels without joining."
     )
     refresh_token: Optional[str] = Field(default=None, description="Slack OAuth refresh token.")
 

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -156,7 +156,7 @@ def _channel_history_error_msg(error_code: str, channels: list, granted_scopes: 
         scope_note = f" (granted: {', '.join(sorted(granted_scopes))})" if granted_scopes else ""
         return (
             f"User token is missing a required scope {scope_note}. "
-            f"Re-authorize the token with channels:history for public channels and groups:history"
+            f"Re-authorize the token with channels:history for public channels and groups:history "
             f"for private channels to read {channel_list}."
         )
     if error_code in ("not_authed", "invalid_auth", "token_revoked"):

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -138,7 +138,7 @@ def _channel_history_error_msg(error_code: str, channels: list, granted_scopes: 
     are = "are" if len(channels) > 1 else "is"
     if error_code == "not_in_channel":
         return (
-            f"{channel_list}: user is not a member of this private channel. "
+            f"{channel_list}: user is not a member of this private channel(s). "
             "Ask a channel admin to invite the user."
         )
     if error_code == "channel_not_found":
@@ -155,8 +155,9 @@ def _channel_history_error_msg(error_code: str, channels: list, granted_scopes: 
     if error_code == "missing_scope":
         scope_note = f" (granted: {', '.join(sorted(granted_scopes))})" if granted_scopes else ""
         return (
-            f"User token is missing the 'channels:history' scope{scope_note}. "
-            f"Re-authorize the token with channels:history to read {channel_list}."
+            f"User token is missing a required scope {scope_note}. "
+            f"Re-authorize the token with channels:history for public channels and groups:history"
+            f"for private channels to read {channel_list}."
         )
     if error_code in ("not_authed", "invalid_auth", "token_revoked"):
         return (

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -47,9 +47,9 @@ SLACK_PRIVATE_FILE_HOST = "files.slack.com"
 CONNECTOR_TYPE = "slack"
 
 
-def _token_kind(token: object) -> Literal["user", "bot"]:
+def _token_kind(token: str) -> Literal["user", "bot"]:
     """Returns 'user' for xoxp- tokens, 'bot' for all others."""
-    return "user" if isinstance(token, str) and token.startswith("xoxp-") else "bot"
+    return "user" if token.startswith("xoxp-") else "bot"
 
 
 def _safe_slack_filename(filename: str) -> str:
@@ -170,7 +170,7 @@ class SlackAccessConfig(AccessConfig):
     token: str = Field(
         description="Bot token (xoxb-…) or user token (xoxp-…) for the Slack API. "
         "Both require channels:history scope. "
-        "With a bot token the connector auto-joins public channels; "
+        "With a bot token the connector attempts to auto-join public channels; "
         "with a user token it does not — user tokens can view public channels without joining."
     )
     refresh_token: Optional[str] = Field(default=None, description="Slack OAuth refresh token.")

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -133,6 +133,39 @@ def _channel_join_error_msg(error_code: str, channels: list, granted_scopes: set
     return f"Failed to join {channel_list}: {error_code}."
 
 
+def _channel_history_error_msg(error_code: str, channels: list, granted_scopes: set) -> str:
+    channel_list = ", ".join(channels)
+    are = "are" if len(channels) > 1 else "is"
+    if error_code == "not_in_channel":
+        return (
+            f"{channel_list}: user is not a member of this private channel. "
+            "Ask a channel admin to invite the user."
+        )
+    if error_code == "channel_not_found":
+        return (
+            f"{channel_list}: channel not found or not accessible with this user token. "
+            "Verify the channel ID is correct."
+        )
+    if error_code == "is_archived":
+        return (
+            f"{channel_list} {are} archived. "
+            "Archived channels are readable by former members — "
+            "if the user was not a member before archival, access will be denied."
+        )
+    if error_code == "missing_scope":
+        scope_note = f" (granted: {', '.join(sorted(granted_scopes))})" if granted_scopes else ""
+        return (
+            f"User token is missing the 'channels:history' scope{scope_note}. "
+            f"Re-authorize the token with channels:history to read {channel_list}."
+        )
+    if error_code in ("not_authed", "invalid_auth", "token_revoked"):
+        return (
+            f"Authentication failed for {channel_list}: {error_code}. "
+            "Check that the user token is valid and has not expired or been revoked."
+        )
+    return f"Cannot read history for {channel_list}: {error_code}."
+
+
 class SlackAccessConfig(AccessConfig):
     token: str = Field(
         description="Bot token (xoxb-…) or user token (xoxp-…) for the Slack API. "

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Optional
+from typing import TYPE_CHECKING, Any, Generator, Literal, Optional
 
 from pydantic import Field, Secret
 
@@ -47,7 +47,7 @@ SLACK_PRIVATE_FILE_HOST = "files.slack.com"
 CONNECTOR_TYPE = "slack"
 
 
-def _token_kind(token: object) -> str:
+def _token_kind(token: object) -> Literal["user", "bot"]:
     """Returns 'user' for xoxp- tokens, 'bot' for all others."""
     return "user" if isinstance(token, str) and token.startswith("xoxp-") else "bot"
 
@@ -341,7 +341,7 @@ class SlackIndexer(Indexer):
         except Exception:
             return set()
 
-    def _validate_and_join_channels(self, client: "WebClient", granted_scopes: set) -> None:
+    def _validate_channels_bot(self, client: "WebClient", granted_scopes: set) -> None:
         from slack_sdk.errors import SlackApiError
 
         issues: list[_ChannelIssue] = []
@@ -371,6 +371,38 @@ class SlackIndexer(Indexer):
                 f"Cannot access {len(issues)} channel(s):\n"
                 + "\n".join(f"  - {line}" for line in lines)
             )
+
+    def _validate_channels_user(self, client: "WebClient", granted_scopes: set) -> None:
+        from slack_sdk.errors import SlackApiError
+
+        issues: list[_ChannelIssue] = []
+        for channel in self.index_config.channels:
+            try:
+                client.conversations_history(channel=channel, limit=1)
+            except SlackApiError as e:
+                error_code = e.response.get("error", "unknown")
+                issues.append(_ChannelIssue(channel=channel, error_code=error_code))
+
+        if issues:
+            groups: dict[str, list] = defaultdict(list)
+            for issue in issues:
+                groups[issue.error_code].append(issue.channel)
+            lines = [
+                _channel_history_error_msg(error_code, channels, granted_scopes)
+                for error_code, channels in groups.items()
+            ]
+            raise SourceConnectionError(
+                f"Cannot access {len(issues)} channel(s) with user token:\n"
+                + "\n".join(f"  - {line}" for line in lines)
+            )
+
+    def _validate_channels(
+        self, client: "WebClient", token_kind: Literal["user", "bot"], granted_scopes: set
+    ) -> None:
+        if token_kind == "user":
+            self._validate_channels_user(client, granted_scopes)
+        else:
+            self._validate_channels_bot(client, granted_scopes)
 
     @SourceConnectionError.wrap
     def precheck(self) -> None:


### PR DESCRIPTION
Updates to slack indexer:
- Differentiates between user and bot token.
- Does not attempt to join channels when using user tokens (user token can view public channels without being a member)
- Raises error messages aligned with the token used

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

