### PR TITLE
fix(teradata): auto-create destination table at upload time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.23]
+
+### Fixes
+
+- **fix(teradata): auto-create the destination table during upload, not only during pipeline init.** Table auto-creation ran only via `TeradataUploader.init()`, whose sole caller is the local `Pipeline`. Orchestrators that drive only the upload phase (e.g. the Unstructured Platform) never created the table, so a not-pre-created destination failed with Teradata error 3807 (`Object '<table>' does not exist`). `upload_dataframe` now ensures the table exists itself — once per run, via the idempotent `create_destination()` whose `DBC.TablesV` check skips `CREATE` for existing tables, so a user's table is never recreated.
+
 ## [1.6.22]
 
 ### Enhancements

--- a/test/unit/connectors/sql/test_teradata.py
+++ b/test/unit/connectors/sql/test_teradata.py
@@ -1522,3 +1522,131 @@ def test_teradata_uploader_create_destination_no_privilege_raises_user_error(
         match=r"3523.*does not have the required privilege.*brand_new_table",
     ):
         uploader.create_destination(destination_name="brand_new_table")
+
+
+# --- Run-path auto-create (lazy create_destination in upload_dataframe) -------
+# init() is the only auto-create trigger and only the local Pipeline calls it, so
+# upload_dataframe must ensure the table exists itself — idempotently — or
+# orchestrators that skip init() fail with Teradata 3807 ("object does not exist").
+
+_OPINIONATED_COLUMNS = [
+    ("id",), ("record_id",), ("element_id",), ("text",), ("type",), ("metadata",),
+]
+
+
+def _opinionated_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "id": ["1"],
+            "record_id": ["r1"],
+            "element_id": ["e1"],
+            "text": ["hello"],
+            "type": ["NarrativeText"],
+            "metadata": ["{}"],
+        }
+    )
+
+
+def _upload_file_data() -> FileData:
+    return FileData(
+        identifier="r1",
+        connector_type="teradata",
+        source_identifiers=SourceIdentifiers(filename="test.txt", fullpath="test.txt"),
+    )
+
+
+def test_teradata_uploader_upload_dataframe_auto_creates_named_table_when_missing(
+    mock_cursor: MagicMock,
+    mock_get_cursor: MagicMock,
+    teradata_connection_config: TeradataConnectionConfig,
+):
+    """Reproduces the production failure (Pylon #2098): a destination connector with
+    a table name given (e.g. 'uns_382') but the table not pre-created. The platform
+    drives the upload run without calling init(), so upload_dataframe must auto-create
+    the opinionated table instead of failing with Teradata 3807 'object does not exist'.
+    """
+    uploader = TeradataUploader(
+        connection_config=teradata_connection_config,
+        upload_config=TeradataUploaderConfig(table_name="uns_382", record_id_key="record_id"),
+    )
+    # create_destination: SELECT DATABASE -> current_db, DBC.TablesV -> None (missing) -> CREATE
+    mock_cursor.fetchone.side_effect = [("test_db",), None]
+    mock_cursor.description = _OPINIONATED_COLUMNS
+    mock_cursor.rowcount = 0
+
+    uploader.upload_dataframe(df=_opinionated_df(), file_data=_upload_file_data())
+
+    assert uploader.upload_config.table_name == "uns_382"
+    create_calls = [
+        c[0][0] for c in mock_cursor.execute.call_args_list if "CREATE MULTISET TABLE" in c[0][0]
+    ]
+    assert len(create_calls) == 1
+    assert '"uns_382"' in create_calls[0]
+    insert_calls = [c[0][0] for c in mock_cursor.executemany.call_args_list]
+    assert any('INSERT INTO "uns_382"' in c for c in insert_calls)
+
+
+def test_teradata_uploader_upload_dataframe_auto_creates_default_table_when_name_is_none(
+    mock_cursor: MagicMock,
+    teradata_uploader_auto_create: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """When no table name is configured, upload_dataframe auto-creates the default
+    opinionated table rather than issuing SQL against a null table name."""
+    assert teradata_uploader_auto_create.upload_config.table_name is None
+    mock_cursor.fetchone.side_effect = [("test_db",), None]
+    mock_cursor.description = _OPINIONATED_COLUMNS
+    mock_cursor.rowcount = 0
+
+    teradata_uploader_auto_create.upload_dataframe(
+        df=_opinionated_df(), file_data=_upload_file_data()
+    )
+
+    assert teradata_uploader_auto_create.upload_config.table_name == DEFAULT_TABLE_NAME
+    assert any(
+        "CREATE MULTISET TABLE" in c[0][0] for c in mock_cursor.execute.call_args_list
+    )
+    assert any("INSERT INTO" in c[0][0] for c in mock_cursor.executemany.call_args_list)
+
+
+def test_teradata_uploader_upload_dataframe_skips_create_when_table_exists(
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """upload_dataframe's auto-create is idempotent: when the destination table
+    already exists, no CREATE is issued, so a user's pre-existing table is never
+    clobbered. (create_destination's DBC.TablesV existence check guards this.)"""
+    # create_destination: SELECT DATABASE -> current_db, DBC.TablesV -> (1,) exists -> no CREATE
+    mock_cursor.fetchone.side_effect = [("test_db",), (1,)]
+    mock_cursor.description = _OPINIONATED_COLUMNS
+    mock_cursor.rowcount = 0
+
+    teradata_uploader.upload_dataframe(df=_opinionated_df(), file_data=_upload_file_data())
+
+    assert not any("CREATE" in c[0][0] for c in mock_cursor.execute.call_args_list)
+    insert_calls = [c[0][0] for c in mock_cursor.executemany.call_args_list]
+    assert any('INSERT INTO "test_table"' in c for c in insert_calls)
+
+
+def test_teradata_uploader_init_marks_destination_ensured_so_upload_skips_reprobe(
+    mocker: MockerFixture,
+    mock_cursor: MagicMock,
+    teradata_uploader_auto_create: TeradataUploader,
+    mock_get_cursor: MagicMock,
+):
+    """When init() already ran create_destination (the local Pipeline path),
+    upload_dataframe must not re-probe: create_destination is invoked exactly once."""
+    mock_cursor.fetchone.side_effect = [("test_db",), None, ("test_db",), (1,)]
+    mock_cursor.description = _OPINIONATED_COLUMNS
+    mock_cursor.rowcount = 0
+    spy = mocker.spy(teradata_uploader_auto_create, "create_destination")
+
+    teradata_uploader_auto_create.init()
+    assert teradata_uploader_auto_create._destination_ensured is True
+
+    teradata_uploader_auto_create.upload_dataframe(
+        df=_opinionated_df(), file_data=_upload_file_data()
+    )
+
+    assert spy.call_count == 1

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.22"  # pragma: no cover
+__version__ = "1.6.23"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/sql/teradata.py
+++ b/unstructured_ingest/processes/connectors/sql/teradata.py
@@ -469,6 +469,7 @@ class TeradataUploader(SQLUploader):
     connection_config: TeradataConnectionConfig
     connector_type: str = CONNECTOR_TYPE
     values_delimiter: str = "?"
+    _destination_ensured: bool = field(init=False, default=False)
 
     def format_destination_name(self, destination_name: str) -> str:
         return _sanitize_table_name(destination_name)
@@ -476,7 +477,9 @@ class TeradataUploader(SQLUploader):
     def init(self, **kwargs: Any) -> None:
         # Auto-creation builds the 6-column JSON blob table, so the stager must have
         # metadata_as_json=True to match. The UI/caller is responsible for setting both.
+        # Mark ensured so upload_dataframe doesn't redundantly re-probe on the Pipeline path.
         self.create_destination(**kwargs)
+        self._destination_ensured = True
 
     def create_destination(self, destination_name: str = DEFAULT_TABLE_NAME, **kwargs: Any) -> bool:
         """Create an opinionated table (id, record_id, element_id, text, type, embeddings, metadata)
@@ -589,6 +592,13 @@ class TeradataUploader(SQLUploader):
 
     def upload_dataframe(self, df: "DataFrame", file_data: FileData) -> None:
         import numpy as np
+
+        # init() is the only auto-create trigger, and only the local Pipeline calls it.
+        # Ensure the table exists here too, so orchestrators that skip init() don't fail
+        # with Teradata 3807. create_destination() is idempotent; probe once per run.
+        if not self._destination_ensured:
+            self.create_destination()
+            self._destination_ensured = True
 
         if self.can_delete():
             self.delete_by_record_id(file_data=file_data)


### PR DESCRIPTION
## Summary

A Teradata **destination** connector with the database name left empty and a table name given (table not pre-created), with **"metadata as JSON" = Yes**, fails the workflow at upload with:

> `422: Error in uploader - Teradata error 3807 (object does not exist or user has no privilege on it) for 'uns_382'. ... [Error 3807] [SQLState 42S02] Object 'uns_382' does not exist.`

The table is supposed to be auto-created, but it never is.

## Root cause

The opinionated-table auto-create (`TeradataUploader.create_destination`, added in #654 for the "metadata as JSON" write mode) is reachable **only** through `TeradataUploader.init()`, and the **sole** caller of `init()` in the library is the local `Pipeline._run_initialization`. #655 then removed precheck's table-existence guard in favour of "auto-create instead of failing".

So when an external orchestrator (the Unstructured Platform) drives only the upload phase, `init()` never runs, the destination table is never created, and the first DB touch in `upload_dataframe` (`can_delete` → `get_table_columns` → `SELECT TOP 1 *`) hits Teradata **3807**, surfaced as the 422 `UserError` above. (The 422 wording itself is the #722 error-classification working correctly — the real defect is the missing table.)

## Fix

`upload_dataframe` now ensures the destination exists before its first table access by calling the already-idempotent `create_destination()` **once per uploader instance** (memoized via `_destination_ensured`). This brings the upload run-path to parity with the `init()` path and is independent of how the orchestrator drives the connector.

- **No clobbering:** `create_destination()`'s `DBC.TablesV` existence check returns early without issuing `CREATE` when the table already exists, so a user's pre-existing table is never recreated.
- **Cheap:** the existence probe runs at most once per run.
- **Covers** both a user-supplied table name that isn't pre-created (the reported case) and the no-table-name default-table case.

Mirrors the existing in-run-path creation pattern already used by the Neo4j connector.

## Behavior note

Auto-create is intentionally **not** gated on `metadata_as_json` — the uploader has no reference to the stager's config, and adding a required flag would re-break the orchestrator-driven path this fixes. This matches what `init()` already does today (it also unconditionally creates the opinionated table when missing), so a flattened-mode user pointing at a missing table now gets the opinionated table auto-created rather than a 3807 error — consistent with the #654/#655 "auto-create instead of failing" direction.

## Testing

- TDD: added 3 unit tests (named-but-missing table → auto-create; no-name → default table; existing table → no `CREATE`, idempotent). Confirmed red before the fix, green after.
- `test/unit/connectors/sql/test_teradata.py`: 98 passed. All SQL connectors: 161 passed. `ruff check`: clean.
- Patch version bump `1.6.22` → `1.6.23` + CHANGELOG entry.

Resolves Pylon #2098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

