### PR TITLE
fix(FS-2105): populate Confluence creation/modification dates and version at index time (fixes FS-2107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.24]
+
+### Fixes
+
+- **fix(FS-2105): populate Confluence creation/modification dates and version at index time.** The Confluence indexer now sets `date_created`, `date_modified`, and `version` from the v2 pages list response so Foundation can store page timestamps and detect page edits on subsequent runs (fixes FS-2107).
+
 ## [1.6.23]
 
 ### Fixes

--- a/test/unit/connectors/test_confluence.py
+++ b/test/unit/connectors/test_confluence.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from dateutil import parser
 
 from unstructured_ingest.data_types.file_data import (
     FileData,
@@ -164,8 +165,12 @@ def test_indexer_oauth_file_data_uses_cloud_identity():
     assert file_data.identifier == "456"
     assert file_data.source_identifiers.fullpath == "cloud-123/ENG/456.html"
     assert file_data.metadata.url == "https://example.atlassian.net/wiki/pages/456"
-    assert file_data.metadata.date_created == "2026-05-28T10:00:00Z"
-    assert file_data.metadata.date_modified == "2026-05-28T11:00:00Z"
+    assert file_data.metadata.date_created == str(
+        parser.parse("2026-05-28T10:00:00Z").timestamp()
+    )
+    assert file_data.metadata.date_modified == str(
+        parser.parse("2026-05-28T11:00:00Z").timestamp()
+    )
     assert file_data.metadata.version == "7"
     assert file_data.metadata.record_locator["cloud_id"] == "cloud-123"
     assert file_data.additional_metadata["site_url"] == "https://example.atlassian.net/wiki"
@@ -339,8 +344,12 @@ def test_downloader_uses_v2_page_api(tmp_path, connection_config):
         params={"body-format": "view", "include-version": "true"},
     )
     assert response["path"] == tmp_path / "SPACE/123.html"
-    assert response["file_data"].metadata.date_created == "2026-05-28T10:00:00Z"
-    assert response["file_data"].metadata.date_modified == "2026-05-28T11:00:00Z"
+    assert response["file_data"].metadata.date_created == str(
+        parser.parse("2026-05-28T10:00:00Z").timestamp()
+    )
+    assert response["file_data"].metadata.date_modified == str(
+        parser.parse("2026-05-28T11:00:00Z").timestamp()
+    )
     assert response["file_data"].metadata.version == "7"
     assert response["file_data"].display_name == "Test Page"
     assert (tmp_path / "SPACE/123.html").read_text(encoding="utf8")

--- a/test/unit/connectors/test_confluence.py
+++ b/test/unit/connectors/test_confluence.py
@@ -145,7 +145,15 @@ def test_indexer_oauth_file_data_uses_cloud_identity():
     mock_client = mock.MagicMock()
     mock_client.get.side_effect = [
         {"results": [{"id": 987, "key": "ENG"}]},
-        {"results": [{"id": "456"}]},
+        {
+            "results": [
+                {
+                    "id": "456",
+                    "createdAt": "2026-05-28T10:00:00Z",
+                    "version": {"createdAt": "2026-05-28T11:00:00Z", "number": 7},
+                }
+            ]
+        },
     ]
 
     with mock.patch.object(type(config), "get_client", mock.MagicMock()):
@@ -156,6 +164,9 @@ def test_indexer_oauth_file_data_uses_cloud_identity():
     assert file_data.identifier == "456"
     assert file_data.source_identifiers.fullpath == "cloud-123/ENG/456.html"
     assert file_data.metadata.url == "https://example.atlassian.net/wiki/pages/456"
+    assert file_data.metadata.date_created == "2026-05-28T10:00:00Z"
+    assert file_data.metadata.date_modified == "2026-05-28T11:00:00Z"
+    assert file_data.metadata.version == "7"
     assert file_data.metadata.record_locator["cloud_id"] == "cloud-123"
     assert file_data.additional_metadata["site_url"] == "https://example.atlassian.net/wiki"
     mock_client.get.assert_has_calls(
@@ -235,7 +246,22 @@ def test_get_docs_ids_within_one_space_uses_v2_pages(connection_config):
 
         doc_ids = indexer._get_docs_ids_within_one_space(987)
 
-    assert doc_ids == [{"space_id": 987, "doc_id": "1"}, {"space_id": 987, "doc_id": "2"}]
+    assert doc_ids == [
+        {
+            "space_id": 987,
+            "doc_id": "1",
+            "date_created": None,
+            "date_modified": None,
+            "version_number": None,
+        },
+        {
+            "space_id": 987,
+            "doc_id": "2",
+            "date_created": None,
+            "date_modified": None,
+            "version_number": None,
+        },
+    ]
     mock_client.get.assert_called_once_with(
         "api/v2/pages",
         params={"space-id": 987, "limit": 2},
@@ -262,7 +288,13 @@ def test_get_docs_ids_within_one_space_paginates_until_configured_limit(connecti
         doc_ids = indexer._get_docs_ids_within_one_space(987)
 
     assert len(doc_ids) == 251
-    assert doc_ids[-1] == {"space_id": 987, "doc_id": "250"}
+    assert doc_ids[-1] == {
+        "space_id": 987,
+        "doc_id": "250",
+        "date_created": None,
+        "date_modified": None,
+        "version_number": None,
+    }
     mock_client.get.assert_has_calls(
         [
             mock.call("api/v2/pages", params={"space-id": 987, "limit": 250}),

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.23"  # pragma: no cover
+__version__ = "1.6.24"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Generator, List, Optional, Tuple
 from urllib.parse import urlparse
 
+from dateutil import parser
 from pydantic import Field, Secret
 
 from unstructured_ingest.data_types.file_data import (
@@ -44,6 +45,13 @@ if TYPE_CHECKING:
 CONNECTOR_TYPE = "confluence"
 CONFLUENCE_SPACE_PAGE_SIZE = 250
 CONFLUENCE_PAGE_PAGE_SIZE = 250
+
+
+def _iso8601_to_epoch_str(iso_date: Optional[str]) -> Optional[str]:
+    """Convert an ISO8601 datetime string to a Unix epoch string for FileData metadata."""
+    if iso_date is None:
+        return None
+    return str(parser.parse(iso_date).timestamp())
 
 
 class ConfluenceAccessConfig(AccessConfig):
@@ -319,8 +327,8 @@ class ConfluenceIndexer(Indexer):
                 {
                     "space_id": space_id,
                     "doc_id": page["id"],
-                    "date_created": page.get("createdAt"),
-                    "date_modified": version.get("createdAt"),
+                    "date_created": _iso8601_to_epoch_str(page.get("createdAt")),
+                    "date_modified": _iso8601_to_epoch_str(version.get("createdAt")),
                     "version_number": version.get("number"),
                 }
             )
@@ -638,8 +646,8 @@ class ConfluenceDownloader(Downloader):
                 file_data.metadata.permissions_data = combined_doc_permissions
 
         # Update file_data with metadata
-        file_data.metadata.date_created = page["createdAt"]
-        file_data.metadata.date_modified = page["version"]["createdAt"]
+        file_data.metadata.date_created = _iso8601_to_epoch_str(page["createdAt"])
+        file_data.metadata.date_modified = _iso8601_to_epoch_str(page["version"]["createdAt"])
         file_data.metadata.version = str(page["version"]["number"])
         file_data.display_name = title
 

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -308,7 +308,22 @@ class ConfluenceIndexer(Indexer):
                 },
                 limit=self.index_config.max_num_of_docs_from_each_space,
             )
-        doc_ids = [{"space_id": space_id, "doc_id": page["id"]} for page in pages]
+        # The v2 /pages list returns each page's creation date and version metadata
+        # (createdAt + version{createdAt, number}) by default. We carry them here so the
+        # indexer can populate FileData.metadata at index time, which is what the platform
+        # uses to detect new/modified records (FS-2105 creation date, FS-2107 change detection).
+        doc_ids = []
+        for page in pages:
+            version = page.get("version") or {}
+            doc_ids.append(
+                {
+                    "space_id": space_id,
+                    "doc_id": page["id"],
+                    "date_created": page.get("createdAt"),
+                    "date_modified": version.get("createdAt"),
+                    "version_number": version.get("number"),
+                }
+            )
         return doc_ids
 
     def run(self) -> Generator[FileData, None, None]:
@@ -319,8 +334,14 @@ class ConfluenceIndexer(Indexer):
             doc_ids = self._get_docs_ids_within_one_space(space_id)
             for doc in doc_ids:
                 doc_id = doc["doc_id"]
-                # Build metadata
+                version_number = doc.get("version_number")
+                # Build metadata. date_created/date_modified/version come from the v2 /pages
+                # list so the indexer reports them at index time; the platform relies on the
+                # indexer's metadata to detect new/modified records (FS-2105 + FS-2107).
                 metadata = FileDataSourceMetadata(
+                    date_created=doc.get("date_created"),
+                    date_modified=doc.get("date_modified"),
+                    version=str(version_number) if version_number is not None else None,
                     date_processed=str(time()),
                     url=self.connection_config.page_url(doc_id),
                     record_locator={


### PR DESCRIPTION
## Summary
Confluence indexer now sets `date_created`, `date_modified`, and `version` from the v2 pages list at index time so Foundation stores page timestamps and detects page edits on subsequent runs.

Fixes FS-2105
Fixes FS-2107

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

