### PR TITLE
fix(FS-2106): populate Jira creation and modification dates at index time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.24]
+
+### Fixes
+
+- **fix(FS-2106): populate Jira creation and modification dates at index time.** `JiraIndexer._create_file_data_from_issue` only set `version` (from the issue's `updated` timestamp) and never populated `date_created`/`date_modified`, and the indexer field lists omitted `created`. Because the platform detects new and modified records from the indexer's `FileData.metadata`, Jira records carried no creation/modification dates. The indexer now requests the `created` field in `_get_issues_within_projects`, `_get_issues_within_single_board`, and `_get_issues_by_keys`, and sets `metadata.date_created` (from `created`) and `metadata.date_modified` (from `updated`) alongside the existing `version`.
+
 ## [1.6.23]
 
 ### Fixes

--- a/test/unit/connectors/test_jira.py
+++ b/test/unit/connectors/test_jira.py
@@ -80,6 +80,7 @@ def test_indexer_oauth_file_data_uses_cloud_identity_and_updated_version():
         id="10001",
         key="ENG-7",
         fields={
+            "created": "2026-05-21T10:00:00.000+0000",
             "updated": "2026-05-22T10:00:00.000+0000",
             "attachment": [],
         },
@@ -91,7 +92,50 @@ def test_indexer_oauth_file_data_uses_cloud_identity_and_updated_version():
     assert file_data.source_identifiers.fullpath == "cloud-123/ENG/ENG-7.txt"
     assert file_data.metadata.url == "https://example.atlassian.net/browse/ENG-7"
     assert file_data.metadata.version == "2026-05-22T10:00:00.000+0000"
+    assert file_data.metadata.date_created == "2026-05-21T10:00:00.000+0000"
+    assert file_data.metadata.date_modified == "2026-05-22T10:00:00.000+0000"
     assert file_data.metadata.record_locator["cloud_id"] == "cloud-123"
+
+
+def test_indexer_file_data_populates_creation_and_modification_dates():
+    indexer = JiraIndexer(
+        connection_config=JiraConnectionConfig(
+            access_config=JiraAccessConfig(token="pat"),
+            url="https://jira.example.com",
+        ),
+        index_config=JiraIndexerConfig(issues=["ENG-7"]),
+    )
+    issue = JiraIssueMetadata(
+        id="10001",
+        key="ENG-7",
+        fields={
+            "created": "2026-05-21T10:00:00.000+0000",
+            "updated": "2026-05-22T10:00:00.000+0000",
+        },
+    )
+
+    file_data = indexer._create_file_data_from_issue(issue)
+
+    assert file_data.metadata.date_created == "2026-05-21T10:00:00.000+0000"
+    assert file_data.metadata.date_modified == "2026-05-22T10:00:00.000+0000"
+    assert file_data.metadata.version == "2026-05-22T10:00:00.000+0000"
+
+
+def test_indexer_file_data_handles_missing_fields():
+    indexer = JiraIndexer(
+        connection_config=JiraConnectionConfig(
+            access_config=JiraAccessConfig(token="pat"),
+            url="https://jira.example.com",
+        ),
+        index_config=JiraIndexerConfig(issues=["ENG-7"]),
+    )
+    issue = JiraIssueMetadata(id="10001", key="ENG-7", fields=None)
+
+    file_data = indexer._create_file_data_from_issue(issue)
+
+    assert file_data.metadata.date_created is None
+    assert file_data.metadata.date_modified is None
+    assert file_data.metadata.version is None
 
 
 def test_downloader_sets_issue_key_summary_display_and_version():

--- a/test/unit/connectors/test_jira.py
+++ b/test/unit/connectors/test_jira.py
@@ -1,4 +1,5 @@
 import pytest
+from dateutil import parser
 
 from unstructured_ingest.error import ValueError
 from unstructured_ingest.processes.connectors.jira import (
@@ -92,8 +93,12 @@ def test_indexer_oauth_file_data_uses_cloud_identity_and_updated_version():
     assert file_data.source_identifiers.fullpath == "cloud-123/ENG/ENG-7.txt"
     assert file_data.metadata.url == "https://example.atlassian.net/browse/ENG-7"
     assert file_data.metadata.version == "2026-05-22T10:00:00.000+0000"
-    assert file_data.metadata.date_created == "2026-05-21T10:00:00.000+0000"
-    assert file_data.metadata.date_modified == "2026-05-22T10:00:00.000+0000"
+    assert file_data.metadata.date_created == str(
+        parser.parse("2026-05-21T10:00:00.000+0000").timestamp()
+    )
+    assert file_data.metadata.date_modified == str(
+        parser.parse("2026-05-22T10:00:00.000+0000").timestamp()
+    )
     assert file_data.metadata.record_locator["cloud_id"] == "cloud-123"
 
 
@@ -116,8 +121,12 @@ def test_indexer_file_data_populates_creation_and_modification_dates():
 
     file_data = indexer._create_file_data_from_issue(issue)
 
-    assert file_data.metadata.date_created == "2026-05-21T10:00:00.000+0000"
-    assert file_data.metadata.date_modified == "2026-05-22T10:00:00.000+0000"
+    assert file_data.metadata.date_created == str(
+        parser.parse("2026-05-21T10:00:00.000+0000").timestamp()
+    )
+    assert file_data.metadata.date_modified == str(
+        parser.parse("2026-05-22T10:00:00.000+0000").timestamp()
+    )
     assert file_data.metadata.version == "2026-05-22T10:00:00.000+0000"
 
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.23"  # pragma: no cover
+__version__ = "1.6.24"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/jira.py
+++ b/unstructured_ingest/processes/connectors/jira.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Generator, List, Optional, Union
 
+from dateutil import parser
 from pydantic import BaseModel, Field, Secret
 
 from unstructured_ingest.data_types.file_data import (
@@ -33,6 +34,14 @@ if TYPE_CHECKING:
     from atlassian import Jira
 
 CONNECTOR_TYPE = "jira"
+
+
+def _iso8601_to_epoch_str(iso_date: Optional[str]) -> Optional[str]:
+    """Convert an ISO8601 datetime string to a Unix epoch string for FileData metadata."""
+    if iso_date is None:
+        return None
+    return str(parser.parse(iso_date).timestamp())
+
 
 DEFAULT_C_SEP = " " * 5
 DEFAULT_R_SEP = "\n"
@@ -310,8 +319,8 @@ class JiraIndexer(Indexer):
         fields = issue.fields or {}
         metadata = FileDataSourceMetadata(
             date_processed=str(time()),
-            date_created=fields.get("created"),
-            date_modified=fields.get("updated"),
+            date_created=_iso8601_to_epoch_str(fields.get("created")),
+            date_modified=_iso8601_to_epoch_str(fields.get("updated")),
             url=self.connection_config.issue_url(issue.key),
             version=fields.get("updated"),
             record_locator=record_locator,
@@ -451,8 +460,8 @@ class JiraDownloader(Downloader):
         )
 
     def update_file_data(self, file_data: FileData, issue: dict) -> None:
-        file_data.metadata.date_created = issue["fields"]["created"]
-        file_data.metadata.date_modified = issue["fields"]["updated"]
+        file_data.metadata.date_created = _iso8601_to_epoch_str(issue["fields"]["created"])
+        file_data.metadata.date_modified = _iso8601_to_epoch_str(issue["fields"]["updated"])
         file_data.metadata.version = issue["fields"]["updated"]
         file_data.display_name = f"{issue['key']}: {issue['fields']['summary']}"
 
@@ -486,7 +495,7 @@ class JiraDownloader(Downloader):
         new_filedata.identifier = "{}a".format(attachment_dict["id"])
         filename = f"{attachment_dict['filename']}.{attachment_dict['id']}"
         new_filedata.metadata.filesize_bytes = attachment_dict.get("size")
-        new_filedata.metadata.date_created = attachment_dict.get("created")
+        new_filedata.metadata.date_created = _iso8601_to_epoch_str(attachment_dict.get("created"))
         new_filedata.metadata.url = attachment_dict.get("self")
         new_filedata.metadata.record_locator = attachment_record_locator
         full_path = (

--- a/unstructured_ingest/processes/connectors/jira.py
+++ b/unstructured_ingest/processes/connectors/jira.py
@@ -234,7 +234,7 @@ class JiraIndexer(Indexer):
                     yield JiraIssueMetadata.model_validate(issue)
 
     def _get_issues_within_projects(self) -> Generator[JiraIssueMetadata, None, None]:
-        fields = ["key", "id", "status", "attachment", "updated"]  # Add attachment field
+        fields = ["key", "id", "status", "attachment", "created", "updated"]  # Add attachment field
         jql = "project in ({})".format(", ".join(self.index_config.projects))
         jql = self._update_jql(jql)
         logger.debug(f"running jql: {jql}")
@@ -245,6 +245,7 @@ class JiraIndexer(Indexer):
     ) -> Generator[JiraIssueMetadata, None, None]:
         with self.connection_config.get_client() as client:
             fields = ["key", "id", "attachment"]  # Add attachment field
+            fields.append("created")
             fields.append("updated")
             if self.index_config.status_filters:
                 jql = "status in ({}) ORDER BY id".format(
@@ -274,7 +275,7 @@ class JiraIndexer(Indexer):
         return jql
 
     def _get_issues_by_keys(self) -> Generator[JiraIssueMetadata, None, None]:
-        fields = ["key", "id", "attachment", "updated"]  # Add attachment field
+        fields = ["key", "id", "attachment", "created", "updated"]  # Add attachment field
         jql = "key in ({})".format(", ".join(self.index_config.issues))
         jql = self._update_jql(jql)
         logger.debug(f"running jql: {jql}")
@@ -306,10 +307,13 @@ class JiraIndexer(Indexer):
                 for att in attachments
             ]
 
+        fields = issue.fields or {}
         metadata = FileDataSourceMetadata(
             date_processed=str(time()),
+            date_created=fields.get("created"),
+            date_modified=fields.get("updated"),
             url=self.connection_config.issue_url(issue.key),
-            version=issue.fields.get("updated") if issue.fields else None,
+            version=fields.get("updated"),
             record_locator=record_locator,
         )
 


### PR DESCRIPTION
## Summary
Jira indexer now requests the `created` field and sets `date_created` and `date_modified` on indexed issue metadata at index time so Foundation stores issue timestamps correctly.

Fixes FS-2106

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

