### PR TITLE
feat: weaviate auto schema option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.24]
+
+### Enhancements
+
+- **feat(weaviate): add `auto_schema` option to the destination connector.** New uploader option that defaults to `false`. When `false`, the connector behaves exactly as before: the collection must already exist (or, in non-flatten mode, is seeded from the default config), and in `flatten_metadata` mode each object is conformed to the existing schema (unknown properties dropped, missing ones set to null). When `true`, the connector skips the schema fetch/conform step and lets Weaviate create the collection and its columns from the uploaded objects on first insert, so a collection does not need to exist up front (requires `AUTOSCHEMA_ENABLED=true` in Weaviate). Combined with `flatten_metadata=true`, this allows dynamic, up-front-unknown metadata to land as top-level columns without a predefined schema.
+
 ## [1.6.23]
 
 ### Fixes

--- a/test/integration/connectors/weaviate/test_local.py
+++ b/test/integration/connectors/weaviate/test_local.py
@@ -12,12 +12,14 @@ from weaviate.collections.classes.config import PropertyConfig
 from test.integration.connectors.utils.constants import DESTINATION_TAG, VECTOR_DB_TAG
 from test.integration.connectors.utils.docker import container_context
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
+from unstructured_ingest.error import WriteError
 from unstructured_ingest.processes.connectors.weaviate.local import (
     CONNECTOR_TYPE,
     LocalWeaviateConnectionConfig,
     LocalWeaviateUploader,
     LocalWeaviateUploaderConfig,
     LocalWeaviateUploadStager,
+    LocalWeaviateUploadStagerConfig,
 )
 
 COLLECTION_NAME = "elements"
@@ -40,6 +42,17 @@ def weaviate_instance():
     with container_context(
         image="semitechnologies/weaviate:1.27.3",
         ports={8080: 8080, 50051: 50051},
+    ) as ctx:
+        wait_for_container()
+        yield ctx
+
+
+@pytest.fixture
+def weaviate_instance_no_autoschema():
+    with container_context(
+        image="semitechnologies/weaviate:1.27.3",
+        ports={8080: 8080, 50051: 50051},
+        environment={"AUTOSCHEMA_ENABLED": "false"},
     ) as ctx:
         wait_for_container()
         yield ctx
@@ -157,6 +170,160 @@ def test_weaviate_local_destination(upload_file: Path, collection: str, tmp_path
         file_data=file_data,
         expected_count=expected_count,
     )
+
+
+def _aggregate_count(client: WeaviateClient, collection_name: str) -> int:
+    resp = client.collections.get(collection_name).aggregate.over_all(total_count=True)
+    return resp.total_count
+
+
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+def test_weaviate_local_auto_schema_flatten(weaviate_instance, tmp_path: Path):
+    """auto_schema + flatten_metadata: no collection is pre-created — Weaviate builds it
+    from the uploaded objects — and the stager normalizes values that have no native
+    Weaviate type before flattening. Regression guard for coordinates.points (a list of
+    [x, y] pairs) which otherwise reaches Weaviate as an unsupported array-of-arrays and
+    fails every insert."""
+    collection_name = "AutoSchemaFlatten"
+    elements = [
+        {
+            "type": "NarrativeText",
+            "element_id": "el-1",
+            "text": "hello world",
+            "metadata": {
+                "filename": "sample.pdf",
+                "page_number": 1,
+                "languages": ["eng"],
+                "coordinates": {
+                    "system": "PixelSpace",
+                    "layout_width": 612,
+                    "layout_height": 792,
+                    "points": [[72.0, 72.69], [72.0, 83.69], [135.8, 83.69], [135.8, 72.69]],
+                },
+                "links": [{"text": "click", "url": "https://example.com", "start_index": 0}],
+                "data_source": {
+                    "version": 12345,
+                    "date_modified": "2025-01-08T22:45:32",
+                    "permissions_data": [{"mode": 33204}],
+                },
+            },
+        },
+        {
+            "type": "NarrativeText",
+            "element_id": "el-2",
+            "text": "second element",
+            "metadata": {"filename": "sample.pdf", "page_number": 2, "languages": ["eng"]},
+        },
+    ]
+    file_data = FileData(
+        source_identifiers=SourceIdentifiers(fullpath="sample.pdf", filename="sample.pdf"),
+        connector_type=CONNECTOR_TYPE,
+        identifier="rec-auto-schema",
+    )
+    elements_path = tmp_path / "elements.json"
+    with elements_path.open("w") as f:
+        json.dump(elements, f)
+
+    stager = LocalWeaviateUploadStager(
+        upload_stager_config=LocalWeaviateUploadStagerConfig(
+            flatten_metadata=True, auto_schema=True
+        )
+    )
+    staged_filepath = stager.run(
+        elements_filepath=elements_path,
+        file_data=file_data,
+        output_dir=tmp_path,
+        output_filename=elements_path.name,
+    )
+
+    uploader = LocalWeaviateUploader(
+        upload_config=LocalWeaviateUploaderConfig(
+            collection=collection_name, flatten_metadata=True, auto_schema=True
+        ),
+        connection_config=LocalWeaviateConnectionConfig(),
+    )
+    # Collection does not exist yet: precheck must pass and the upload must not raise
+    # (a raw 2-D coordinates array would fail every insert -> WriteError).
+    uploader.precheck()
+    uploader.run(path=staged_filepath, file_data=file_data)
+
+    with weaviate.connect_to_local() as client:
+        # Weaviate auto-created the collection from the uploaded objects.
+        assert client.collections.exists(name=collection_name)
+
+        expected_count = len(elements)
+        retries = 0
+        while _aggregate_count(client, collection_name) != expected_count and retries < 10:
+            retries += 1
+            time.sleep(1)
+        assert _aggregate_count(client, collection_name) == expected_count
+
+        collection = client.collections.get(collection_name)
+        props = {p.name: p for p in collection.config.get().properties}
+        # Flattened top-level columns exist; the problematic nested/2-D fields are
+        # stringified so Weaviate can type them.
+        assert props["coordinates_points"].data_type == DataType.TEXT
+        assert props["data_source_permissions_data"].data_type == DataType.TEXT
+        assert props["data_source_version"].data_type == DataType.TEXT
+
+        obj = next(
+            o
+            for o in collection.iterator()
+            if o.properties.get("element_id") == "el-1"
+        )
+        # points arrived as a JSON string, not a 2-D array
+        assert isinstance(obj.properties["coordinates_points"], str)
+        assert obj.properties["coordinates_points"].startswith("[[")
+        assert obj.properties["data_source_version"] == "12345"
+
+
+@pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)
+def test_weaviate_local_auto_schema_upload_fails_without_autoschema(
+    weaviate_instance_no_autoschema, tmp_path: Path
+):
+    """auto_schema=true against a cluster with AUTOSCHEMA_ENABLED=false: precheck passes
+    (we don't probe the cluster), but the upload fails with a clear error because
+    Weaviate refuses to auto-create the collection."""
+    collection_name = "AutoSchemaDisabled"
+    elements = [
+        {
+            "type": "NarrativeText",
+            "element_id": "el-1",
+            "text": "hello world",
+            "metadata": {"filename": "sample.pdf", "page_number": 1},
+        }
+    ]
+    file_data = FileData(
+        source_identifiers=SourceIdentifiers(fullpath="sample.pdf", filename="sample.pdf"),
+        connector_type=CONNECTOR_TYPE,
+        identifier="rec-no-autoschema",
+    )
+    elements_path = tmp_path / "elements.json"
+    with elements_path.open("w") as f:
+        json.dump(elements, f)
+
+    stager = LocalWeaviateUploadStager(
+        upload_stager_config=LocalWeaviateUploadStagerConfig(
+            flatten_metadata=True, auto_schema=True
+        )
+    )
+    staged_filepath = stager.run(
+        elements_filepath=elements_path,
+        file_data=file_data,
+        output_dir=tmp_path,
+        output_filename=elements_path.name,
+    )
+    uploader = LocalWeaviateUploader(
+        upload_config=LocalWeaviateUploaderConfig(
+            collection=collection_name, flatten_metadata=True, auto_schema=True
+        ),
+        connection_config=LocalWeaviateConnectionConfig(),
+    )
+    # precheck does not probe AUTOSCHEMA_ENABLED, so it passes.
+    uploader.precheck()
+    # The upload fails because the cluster refuses to auto-create the collection.
+    with pytest.raises(WriteError):
+        uploader.run(path=staged_filepath, file_data=file_data)
 
 
 @pytest.mark.tags(CONNECTOR_TYPE, DESTINATION_TAG, VECTOR_DB_TAG)

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -420,6 +420,30 @@ def test_get_schema_property_names_caches_across_calls(
     assert mock_client.collections.get.call_count == 1
 
 
+def test_collection_present_caches_positive_result(uploader: WeaviateUploader):
+    """Once the collection is known to exist, the result is cached and the
+    existence round-trip is not repeated on subsequent uploads."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", auto_schema=True)
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+
+    assert uploader._collection_present(mock_client) is True
+    assert uploader._collection_present(mock_client) is True
+    mock_client.collections.exists.assert_called_once()
+
+
+def test_collection_present_rechecks_until_it_exists(uploader: WeaviateUploader):
+    """A negative result is not cached — in auto_schema mode Weaviate creates the
+    collection on first insert, so it can flip from absent to present mid-run."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", auto_schema=True)
+    mock_client = MagicMock()
+    mock_client.collections.exists.side_effect = [False, True]
+
+    assert uploader._collection_present(mock_client) is False
+    assert uploader._collection_present(mock_client) is True
+    assert mock_client.collections.exists.call_count == 2
+
+
 # ---------------------------------------------------------------------------
 # Stager — nested (default) mode: deeper coverage of every transform branch
 # ---------------------------------------------------------------------------

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -796,6 +796,22 @@ def test_check_for_errors_with_failures_raises_write_error(
     assert "uuid-2" in caplog.text
 
 
+def test_check_for_errors_surfaces_reason_and_auto_schema_hint(uploader: WeaviateUploader):
+    """The raised error includes the Weaviate failure reason, and when auto_schema is on
+    it points at AUTOSCHEMA_ENABLED as the likely cause (the cluster refusing to
+    auto-create the collection)."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", auto_schema=True)
+    mock_client = MagicMock()
+    mock_client.batch.failed_objects = [
+        MagicMock(original_uuid="uuid-1", message='class "MyColl" not found in schema'),
+    ]
+
+    with pytest.raises(WriteError) as excinfo:
+        uploader.check_for_errors(client=mock_client)
+    assert "not found in schema" in str(excinfo.value)
+    assert "AUTOSCHEMA_ENABLED" in str(excinfo.value)
+
+
 # ---------------------------------------------------------------------------
 # Uploader — run_data integration
 # ---------------------------------------------------------------------------

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -221,6 +221,39 @@ def test_conform_dict_flatten_drops_none_metadata_values(file_data: FileData):
     assert "sent_from" not in out
 
 
+def test_conform_dict_flatten_auto_schema_normalizes_then_flattens(file_data: FileData):
+    """With auto_schema, flatten mode applies the same value normalization as the
+    non-flatten path (stringify 2-D arrays / dicts / list[dict], format dates, cast
+    version/page_number) BEFORE flattening, so every value is Weaviate-typeable —
+    unlike pure flatten which leaves e.g. coordinates.points as a 2-D array that
+    Weaviate cannot type."""
+    stager = WeaviateUploadStager(
+        upload_stager_config=WeaviateUploadStagerConfig(flatten_metadata=True, auto_schema=True)
+    )
+    out = stager.conform_dict(_sample_element(), file_data=file_data)
+
+    assert "metadata" not in out  # still flattened to top level
+
+    # 2-D array / dict / list[dict] fields become strings, not raw structures
+    assert out["coordinates_points"] == "[[0, 0], [612, 0], [612, 792], [0, 792]]"
+    assert isinstance(out["data_source_permissions_data"], str)
+    assert isinstance(out["links"], str)
+    assert isinstance(out["regex_metadata"], str)
+
+    # record_locator collapses to a single string column, not proliferated sub-keys
+    assert isinstance(out["data_source_record_locator"], str)
+    assert "data_source_record_locator_protocol" not in out
+
+    # scalars cast to strings; dates formatted RFC3339
+    assert out["data_source_version"] == "12345"
+    assert out["page_number"] == "1"
+    assert out["last_modified"].endswith("Z") and "T" in out["last_modified"]
+
+    # plain 1-D arrays remain arrays (Weaviate text[])
+    assert out["languages"] == ["eng"]
+    assert out["record_id"] == "rec-123"
+
+
 def test_conform_to_schema_drops_unknown_and_fills_missing():
     schema_props = {"record_id", "text", "filename", "languages", "page_number"}
     row = {

--- a/test/unit/connectors/weaviate/test_weaviate.py
+++ b/test/unit/connectors/weaviate/test_weaviate.py
@@ -330,6 +330,50 @@ def test_create_destination_noop_in_flatten_mode(
     mock_client.collections.create_from_dict.assert_not_called()
 
 
+def test_create_destination_default_mode_creates_when_absent(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    """Default mode (auto_schema disabled, non-flatten) seeds the collection from
+    the default asset config when it does not exist yet (pre-declaring
+    metadata.data_source.version as text) and formats the name."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="my-coll", auto_schema=False)
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = False
+    connection_config.set_mock_client(mock_client)
+
+    created = uploader.create_destination()
+    assert created is True
+    assert uploader.upload_config.collection == "My_coll"
+    mock_client.collections.create_from_dict.assert_called_once()
+
+
+def test_create_destination_default_mode_skips_when_present(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    """Default mode does not recreate an existing collection."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", auto_schema=False)
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    connection_config.set_mock_client(mock_client)
+
+    created = uploader.create_destination()
+    assert created is False
+    mock_client.collections.create_from_dict.assert_not_called()
+
+
+def test_create_destination_resolves_fallback_name(
+    uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
+):
+    """With no collection set, create_destination falls back to the default name."""
+    uploader.upload_config = WeaviateUploaderConfig(collection=None, auto_schema=False)
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    connection_config.set_mock_client(mock_client)
+
+    uploader.create_destination()
+    assert uploader.upload_config.collection == "Unstructuredautocreated"
+
+
 def test_get_schema_property_names_caches_across_calls(
     uploader: WeaviateUploader,
 ):
@@ -396,9 +440,7 @@ def test_conform_dict_default_json_dumps_complex_metadata(
     "ds_key",
     ["date_created", "date_modified", "date_processed"],
 )
-def test_conform_dict_default_reformats_unix_timestamp_dates(
-    file_data: FileData, ds_key: str
-):
+def test_conform_dict_default_reformats_unix_timestamp_dates(file_data: FileData, ds_key: str):
     """Default mode parses unix-timestamp-strings ("1778727504.0") and
     reformats them to Weaviate's RFC3339-Z form (YYYY-MM-DDTHH:MM:SS.fffZ)."""
     stager = WeaviateUploadStager(upload_stager_config=WeaviateUploadStagerConfig())
@@ -508,9 +550,7 @@ def test_conform_dict_flatten_recursive_flatten_of_dynamic_keys(file_data: FileD
     )
     out = stager.conform_dict(_sample_element(), file_data=file_data)
     assert "regex_metadata" not in out
-    assert out["regex_metadata_phone"] == [
-        {"text": "555-1234", "start": 0, "end": 8}
-    ]
+    assert out["regex_metadata_phone"] == [{"text": "555-1234", "start": 0, "end": 8}]
 
 
 def test_conform_dict_flatten_does_not_mutate_input(file_data: FileData):
@@ -533,9 +573,7 @@ def test_conform_dict_flatten_passthrough_lists_unmodified(file_data: FileData):
     )
     out = stager.conform_dict(_sample_element(), file_data=file_data)
     assert out["languages"] == ["eng"]
-    assert out["links"] == [
-        {"text": "click", "url": "https://example.com", "start_index": 0}
-    ]
+    assert out["links"] == [{"text": "click", "url": "https://example.com", "start_index": 0}]
     assert out["data_source_permissions_data"] == [{"role": "viewer"}]
     assert out["coordinates_points"] == [[0, 0], [612, 0], [612, 792], [0, 792]]
 
@@ -547,17 +585,13 @@ def test_conform_dict_flatten_passthrough_lists_unmodified(file_data: FileData):
 
 def test_conform_to_schema_empty_schema_returns_empty_dict():
     """If the schema has no properties, every incoming key is dropped."""
-    out = WeaviateUploader.conform_to_schema(
-        {"a": 1, "b": 2}, schema_props=set()
-    )
+    out = WeaviateUploader.conform_to_schema({"a": 1, "b": 2}, schema_props=set())
     assert out == {}
 
 
 def test_conform_to_schema_empty_properties_fills_all_with_none():
     """If incoming properties is empty, every schema field is filled with None."""
-    out = WeaviateUploader.conform_to_schema(
-        {}, schema_props={"a", "b", "c"}
-    )
+    out = WeaviateUploader.conform_to_schema({}, schema_props={"a", "b", "c"})
     assert out == {"a": None, "b": None, "c": None}
 
 
@@ -587,9 +621,7 @@ def test_conform_to_schema_preserves_explicit_none():
 def test_precheck_default_mode_collection_missing_raises(
     uploader: WeaviateUploader, connection_config: WeaviateConnectionConfigTest
 ):
-    uploader.upload_config = WeaviateUploaderConfig(
-        collection="MyColl", flatten_metadata=False
-    )
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=False)
     mock_client = MagicMock()
     mock_client.collections.exists.return_value = False
     connection_config.set_mock_client(mock_client)
@@ -603,9 +635,7 @@ def test_precheck_default_mode_collection_exists_passes(
 ):
     """Default mode is permissive: existence is enough — no schema-shape or
     record_id checks are run because the connector may auto-create later."""
-    uploader.upload_config = WeaviateUploaderConfig(
-        collection="MyColl", flatten_metadata=False
-    )
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=False)
     mock_client = MagicMock()
     mock_client.collections.exists.return_value = True
     connection_config.set_mock_client(mock_client)
@@ -622,9 +652,7 @@ def test_precheck_default_mode_collection_none_skips_validation(
     """In default mode, if no collection name is set precheck silently passes —
     the missing name is resolved later in create_destination (fallback to
     'Unstructuredautocreated')."""
-    uploader.upload_config = WeaviateUploaderConfig(
-        collection=None, flatten_metadata=False
-    )
+    uploader.upload_config = WeaviateUploaderConfig(collection=None, flatten_metadata=False)
     mock_client = MagicMock()
     connection_config.set_mock_client(mock_client)
 
@@ -639,9 +667,7 @@ def test_precheck_flatten_mode_collection_none_raises(
     """Flatten mode requires an explicit collection name because there is no
     auto-create fallback — fail early with a clear message, before even
     opening a client connection."""
-    uploader.upload_config = WeaviateUploaderConfig(
-        collection=None, flatten_metadata=True
-    )
+    uploader.upload_config = WeaviateUploaderConfig(collection=None, flatten_metadata=True)
     mock_client = MagicMock()
     connection_config.set_mock_client(mock_client)
 
@@ -761,9 +787,7 @@ def _batch_client_from(mock_client: MagicMock) -> MagicMock:
     return mock_client.batch.dynamic.return_value.__enter__.return_value
 
 
-def test_run_data_raises_when_no_collection_set(
-    uploader: WeaviateUploader, file_data: FileData
-):
+def test_run_data_raises_when_no_collection_set(uploader: WeaviateUploader, file_data: FileData):
     uploader.upload_config = WeaviateUploaderConfig(collection=None)
     with pytest.raises(ValueError, match="No collection specified"):
         uploader.run_data(data=[{"text": "x"}], file_data=file_data)
@@ -777,9 +801,7 @@ def test_run_data_default_mode_passes_unmodified_properties(
 ):
     """In default mode, properties go to add_object exactly as the stager
     produced them; only embeddings are popped into the vector arg."""
-    uploader.upload_config = WeaviateUploaderConfig(
-        collection="MyColl", flatten_metadata=False
-    )
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=False)
     mock_client = _make_run_data_client()
     connection_config.set_mock_client(mock_client)
     monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
@@ -811,16 +833,12 @@ def test_run_data_default_mode_does_not_fetch_schema(
 ):
     """Default mode never reads the destination schema — no introspection
     is performed because conform_to_schema isn't applied."""
-    uploader.upload_config = WeaviateUploaderConfig(
-        collection="MyColl", flatten_metadata=False
-    )
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=False)
     mock_client = _make_run_data_client()
     connection_config.set_mock_client(mock_client)
     monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
 
-    uploader.run_data(
-        data=[{"text": "x", "embeddings": [0.1]}], file_data=file_data
-    )
+    uploader.run_data(data=[{"text": "x", "embeddings": [0.1]}], file_data=file_data)
 
     mock_client.collections.get.return_value.config.get.assert_not_called()
 
@@ -833,9 +851,7 @@ def test_run_data_flatten_mode_applies_schema_conform(
 ):
     """Flatten mode runs each element through conform_to_schema:
     unknown keys are dropped, missing schema keys are filled with None."""
-    uploader.upload_config = WeaviateUploaderConfig(
-        collection="MyColl", flatten_metadata=True
-    )
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", flatten_metadata=True)
     mock_client = _make_run_data_client()
     config_mock = MagicMock()
     config_mock.properties = [
@@ -932,16 +948,12 @@ def test_run_data_propagates_check_for_errors_failure(
     after the batch context manager closes."""
     uploader.upload_config = WeaviateUploaderConfig(collection="MyColl")
     mock_client = _make_run_data_client()
-    mock_client.batch.failed_objects = [
-        MagicMock(original_uuid="uuid-1", message="rejected")
-    ]
+    mock_client.batch.failed_objects = [MagicMock(original_uuid="uuid-1", message="rejected")]
     connection_config.set_mock_client(mock_client)
     monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
 
     with pytest.raises(WriteError, match="Failed to upload to weaviate"):
-        uploader.run_data(
-            data=[{"text": "x"}], file_data=file_data
-        )
+        uploader.run_data(data=[{"text": "x"}], file_data=file_data)
 
 
 # ---------------------------------------------------------------------------
@@ -977,3 +989,117 @@ def test_uploader_config_dynamic_default_alone_is_valid():
     assert cfg.dynamic_batch is True
     assert cfg.batch_size is None
     assert cfg.requests_per_minute is None
+
+
+# ---------------------------------------------------------------------------
+# Uploader — auto_schema behavior
+# ---------------------------------------------------------------------------
+
+
+def test_run_data_auto_schema_passes_unknown_keys_without_dropping(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """auto_schema mode uploads every property as-is even when they are not in
+    any existing schema — nothing is dropped and the schema is never fetched."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", auto_schema=True)
+    mock_client = _make_run_data_client()
+    mock_client.collections.exists.return_value = True
+    connection_config.set_mock_client(mock_client)
+    monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
+
+    uploader.run_data(
+        data=[{"text": "x", "brand_new_field": "keep me", "embeddings": [0.1]}],
+        file_data=file_data,
+    )
+
+    batch_client = _batch_client_from(mock_client)
+    batch_client.add_object.assert_called_once_with(
+        collection="MyColl",
+        properties={"text": "x", "brand_new_field": "keep me"},
+        vector=[0.1],
+    )
+    # Schema is never read in auto_schema mode.
+    mock_client.collections.get.return_value.config.get.assert_not_called()
+
+
+def test_run_data_auto_schema_skips_delete_when_collection_absent(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """On the first run in auto_schema mode the collection may not exist yet
+    (Weaviate creates it on insert), so delete_by_record_id is skipped rather
+    than erroring on a missing collection — but the object is still uploaded."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", auto_schema=True)
+    mock_client = _make_run_data_client()
+    mock_client.collections.exists.return_value = False
+    connection_config.set_mock_client(mock_client)
+    delete_spy = MagicMock()
+    monkeypatch.setattr(uploader, "delete_by_record_id", delete_spy)
+
+    uploader.run_data(data=[{"text": "x"}], file_data=file_data)
+
+    delete_spy.assert_not_called()
+    _batch_client_from(mock_client).add_object.assert_called_once()
+
+
+def test_run_data_auto_schema_deletes_when_collection_present(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When the collection already exists, auto_schema mode still purges prior
+    records for this record_id before writing the new batch."""
+    uploader.upload_config = WeaviateUploaderConfig(collection="MyColl", auto_schema=True)
+    mock_client = _make_run_data_client()
+    mock_client.collections.exists.return_value = True
+    connection_config.set_mock_client(mock_client)
+    delete_spy = MagicMock()
+    monkeypatch.setattr(uploader, "delete_by_record_id", delete_spy)
+
+    uploader.run_data(data=[{"text": "x"}], file_data=file_data)
+
+    delete_spy.assert_called_once()
+
+
+def test_uploader_config_auto_schema_defaults_false():
+    """auto_schema defaults to False so the connector keeps its pre-existing
+    behavior (conform-to-schema in flatten mode, no conform in non-flatten);
+    dynamic auto-schema is opt-in."""
+    assert WeaviateUploaderConfig(collection="MyColl").auto_schema is False
+
+
+def test_run_data_default_mode_does_not_conform(
+    uploader: WeaviateUploader,
+    connection_config: WeaviateConnectionConfigTest,
+    file_data: FileData,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Non-flatten + auto_schema disabled (the default) uploads properties as-is —
+    conform_to_schema is only applied in flatten mode, matching the connector's
+    pre-auto_schema behavior (type/element_id are never dropped)."""
+    uploader.upload_config = WeaviateUploaderConfig(
+        collection="MyColl", auto_schema=False, flatten_metadata=False
+    )
+    mock_client = _make_run_data_client()
+    connection_config.set_mock_client(mock_client)
+    monkeypatch.setattr(uploader, "delete_by_record_id", MagicMock())
+
+    uploader.run_data(
+        data=[{"type": "Title", "element_id": "e1", "text": "x", "embeddings": [0.1]}],
+        file_data=file_data,
+    )
+
+    batch_client = _batch_client_from(mock_client)
+    batch_client.add_object.assert_called_once_with(
+        collection="MyColl",
+        properties={"type": "Title", "element_id": "e1", "text": "x"},
+        vector=[0.1],
+    )
+    # No schema is fetched in non-flatten mode, regardless of auto_schema.
+    mock_client.collections.get.return_value.config.get.assert_not_called()

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.23"  # pragma: no cover
+__version__ = "1.6.24"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -281,6 +281,22 @@ class WeaviateUploader(VectorDBUploader, ABC):
     upload_config: WeaviateUploaderConfig
     connection_config: WeaviateConnectionConfig
     _schema_property_names: Optional[set[str]] = field(init=False, repr=False, default=None)
+    _collection_exists: Optional[bool] = field(init=False, repr=False, default=None)
+
+    def _collection_present(self, client: "WeaviateClient") -> bool:
+        """Whether the destination collection exists, memoized across a run.
+
+        The collection name is fixed for an uploader and, once the collection exists,
+        it will not disappear mid-run, so a positive result is cached to avoid
+        repeating the existence round-trip on every upload. A negative result is not
+        cached: in auto_schema mode Weaviate creates the collection on the first
+        insert, so it can flip from absent to present within the same run.
+        """
+        if not self._collection_exists:
+            self._collection_exists = client.collections.exists(
+                name=self.upload_config.collection
+            )
+        return self._collection_exists
 
     def get_schema_property_names(self, client: "WeaviateClient") -> set[str]:
         if self._schema_property_names is None:
@@ -314,7 +330,7 @@ class WeaviateUploader(VectorDBUploader, ABC):
                 if not self.upload_config.collection:
                     return
 
-                if not weaviate_client.collections.exists(name=self.upload_config.collection):
+                if not self._collection_present(weaviate_client):
                     raise DestinationConnectionError(
                         f"Collection '{self.upload_config.collection}' does not exist "
                         "(must be pre-created when auto_schema is disabled)"
@@ -384,7 +400,7 @@ class WeaviateUploader(VectorDBUploader, ABC):
             return False
 
         with self.connection_config.get_client() as weaviate_client:
-            if weaviate_client.collections.exists(name=collection_name):
+            if self._collection_present(weaviate_client):
                 logger.debug(
                     f"Collection with name '{collection_name}' already exists, skipping creation"
                 )
@@ -396,6 +412,8 @@ class WeaviateUploader(VectorDBUploader, ABC):
             collection_config["class"] = collection_name
             logger.info(f"Creating weaviate collection '{collection_name}' with default configs")
             weaviate_client.collections.create_from_dict(config=collection_config)
+            # Keep the memoized existence flag correct now that we've created it.
+            self._collection_exists = True
             return True
 
     def check_for_errors(self, client: "WeaviateClient") -> None:
@@ -449,8 +467,7 @@ class WeaviateUploader(VectorDBUploader, ABC):
             raise ValueError("No collection specified")
 
         with self.connection_config.get_client() as weaviate_client:
-            # Only purge prior records when the collection is already present.
-            if weaviate_client.collections.exists(self.upload_config.collection):
+            if self._collection_present(weaviate_client):
                 self.delete_by_record_id(client=weaviate_client, file_data=file_data)
             schema_props: Optional[set[str]] = None
             if self.upload_config.flatten_metadata and not self.upload_config.auto_schema:

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -66,6 +66,17 @@ class WeaviateUploadStagerConfig(UploadStagerConfig):
             "Requires pre-existing collection if auto_schema is disabled."
         ),
     )
+    auto_schema: bool = Field(
+        default=False,
+        description=(
+            "Rely on Weaviate's auto-schema to build the collection and its "
+            "properties from the uploaded objects. When true, the collection "
+            "and its properties are created automatically. "
+            "When false, the collection must already exist and each "
+            "object is conformed to it (unknown properties are dropped, missing "
+            "ones set to null). Requires AUTOSCHEMA_ENABLED=true in Weaviate."
+        ),
+    )
 
 
 @dataclass
@@ -91,9 +102,13 @@ class WeaviateUploadStager(UploadStager):
         working_data = data.copy()
 
         if self.upload_stager_config.flatten_metadata:
-            # Pure flatten: no opinionated transforms. User owns the schema and
-            # declares types matching raw values (e.g. OBJECT_ARRAY for list[dict]
-            # fields like links, permissions_data, regex_metadata_<pattern>).
+            if self.upload_stager_config.auto_schema:
+                # auto_schema: Weaviate infers each column's type from the values.
+                # Apply normalization as the non-flatten path.
+                self._conform_metadata_values(working_data)
+            # else: pure flatten — the user owns the schema and declares types
+            # matching the raw values (e.g. OBJECT_ARRAY for list[dict] fields
+            # like links, permissions_data, regex_metadata_<pattern>).
             metadata = working_data.pop("metadata", {})
             working_data.update(
                 flatten_dict(
@@ -106,6 +121,14 @@ class WeaviateUploadStager(UploadStager):
             working_data[RECORD_ID_LABEL] = file_data.identifier
             return working_data
 
+        self._conform_metadata_values(working_data)
+        working_data[RECORD_ID_LABEL] = file_data.identifier
+        return working_data
+
+    def _conform_metadata_values(self, working_data: dict) -> None:
+        """Normalize nested metadata values into Weaviate-typeable forms in place:
+        stringify dicts / 2-D arrays / list[dict] fields that have no native scalar
+        type, format dates as RFC3339, and cast version/page_number to strings."""
         # Dict as string formatting
         if (
             record_locator := working_data.get("metadata", {})
@@ -181,9 +204,6 @@ class WeaviateUploadStager(UploadStager):
 
         if regex_metadata := working_data.get("metadata", {}).get("regex_metadata"):
             working_data["metadata"]["regex_metadata"] = str(json.dumps(regex_metadata))
-
-        working_data[RECORD_ID_LABEL] = file_data.identifier
-        return working_data
 
 
 class WeaviateUploaderConfig(UploaderConfig):

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -62,7 +62,8 @@ class WeaviateUploadStagerConfig(UploadStagerConfig):
         default=False,
         description=(
             "Flatten nested metadata into top-level properties "
-            "(e.g. metadata.data_source.version -> data_source_version)."
+            "(e.g. metadata.data_source.version -> data_source_version). "
+            "Requires pre-existing collection if auto_schema is disabled."
         ),
     )
 

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -400,12 +400,22 @@ class WeaviateUploader(VectorDBUploader, ABC):
 
     def check_for_errors(self, client: "WeaviateClient") -> None:
         failed_uploads = client.batch.failed_objects
-        if failed_uploads:
-            for failure in failed_uploads:
-                logger.error(
-                    f"Failed to upload object with id {failure.original_uuid}: {failure.message}"
-                )
-            raise WriteError("Failed to upload to weaviate")
+        if not failed_uploads:
+            return
+        for failure in failed_uploads:
+            logger.error(
+                f"Failed to upload object with id {failure.original_uuid}: {failure.message}"
+            )
+        reasons = "; ".join(sorted({str(failure.message) for failure in failed_uploads}))
+        message = f"Failed to upload to weaviate: {reasons}"
+        if self.upload_config.auto_schema:
+            # The most common cause with auto_schema is the cluster refusing to
+            # auto-create the collection/columns because AUTOSCHEMA_ENABLED is off.
+            message += (
+                " (auto_schema=true requires AUTOSCHEMA_ENABLED=true in Weaviate; if it is "
+                "disabled, pre-create the collection and set auto_schema=false)"
+            )
+        raise WriteError(message)
 
     @requires_dependencies(["weaviate"], extras="weaviate")
     def delete_by_record_id(self, client: "WeaviateClient", file_data: FileData) -> None:

--- a/unstructured_ingest/processes/connectors/weaviate/weaviate.py
+++ b/unstructured_ingest/processes/connectors/weaviate/weaviate.py
@@ -61,9 +61,8 @@ class WeaviateUploadStagerConfig(UploadStagerConfig):
     flatten_metadata: bool = Field(
         default=False,
         description=(
-            "Flatten metadata into top-level properties. Destination collection "
-            "must already exist (no auto-create); unknown incoming fields are "
-            "dropped and missing schema fields are filled with null."
+            "Flatten nested metadata into top-level properties "
+            "(e.g. metadata.data_source.version -> data_source_version)."
         ),
     )
 
@@ -188,7 +187,11 @@ class WeaviateUploadStager(UploadStager):
 
 class WeaviateUploaderConfig(UploaderConfig):
     collection: Optional[str] = Field(
-        description="The name of the collection this object belongs to", default=None
+        description=(
+            "The name of the collection this object belongs to. "
+            "If not provided, a default collection name will be used."
+        ),
+        default=None,
     )
     batch_size: Optional[int] = Field(default=None, description="Number of records per batch")
     requests_per_minute: Optional[int] = Field(default=None, description="Rate limit for upload")
@@ -200,9 +203,20 @@ class WeaviateUploaderConfig(UploaderConfig):
     flatten_metadata: bool = Field(
         default=False,
         description=(
-            "Flatten metadata into top-level properties. Destination collection "
-            "must already exist (no auto-create); unknown incoming fields are "
-            "dropped and missing schema fields are filled with null."
+            "Flatten nested metadata into top-level properties "
+            "(e.g. metadata.data_source.version -> data_source_version). "
+            "Requires pre-existing collection if auto_schema is disabled."
+        ),
+    )
+    auto_schema: bool = Field(
+        default=False,
+        description=(
+            "Rely on Weaviate's auto-schema to build the collection and its "
+            "properties from the uploaded objects. When true, the collection "
+            "and its properties are created automatically. "
+            "When false, the collection must already exist and each "
+            "object is conformed to it (unknown properties are dropped, missing "
+            "ones set to null). Requires AUTOSCHEMA_ENABLED=true in Weaviate."
         ),
     )
 
@@ -247,11 +261,6 @@ class WeaviateUploader(VectorDBUploader, ABC):
     connection_config: WeaviateConnectionConfig
     _schema_property_names: Optional[set[str]] = field(init=False, repr=False, default=None)
 
-    def _collection_exists(self, collection_name: Optional[str] = None):
-        collection_name = collection_name or self.upload_config.collection
-        with self.connection_config.get_client() as weaviate_client:
-            return weaviate_client.collections.exists(name=collection_name)
-
     def get_schema_property_names(self, client: "WeaviateClient") -> set[str]:
         if self._schema_property_names is None:
             collection = client.collections.get(self.upload_config.collection)
@@ -265,21 +274,30 @@ class WeaviateUploader(VectorDBUploader, ABC):
         return {k: properties.get(k) for k in schema_props}
 
     def precheck(self) -> None:
-        if self.upload_config.flatten_metadata and not self.upload_config.collection:
-            raise DestinationConnectionError(
-                "flatten_metadata=true requires an explicit collection name."
-            )
-
         try:
             with self.connection_config.get_client() as weaviate_client:
+                if not weaviate_client.is_connected():
+                    raise DestinationConnectionError("failed to connect to Weaviate")
+
+                if self.upload_config.auto_schema:
+                    # Weaviate creates the collection and its properties on the
+                    # first insert (requires AUTOSCHEMA_ENABLED=true)
+                    return
+
+                if self.upload_config.flatten_metadata and not self.upload_config.collection:
+                    raise DestinationConnectionError(
+                        "flatten_metadata=true requires an explicit collection name "
+                        "when auto_schema is disabled."
+                    )
+
                 if not self.upload_config.collection:
                     return
 
                 if not weaviate_client.collections.exists(name=self.upload_config.collection):
-                    msg = f"collection '{self.upload_config.collection}' does not exist"
-                    if self.upload_config.flatten_metadata:
-                        msg += " (must be pre-created when flatten_metadata=true)"
-                    raise DestinationConnectionError(msg)
+                    raise DestinationConnectionError(
+                        f"Collection '{self.upload_config.collection}' does not exist "
+                        "(must be pre-created when auto_schema is disabled)"
+                    )
 
                 if self.upload_config.flatten_metadata:
                     # Schema shape (OBJECT_ARRAY for nested fields, etc.) is the
@@ -332,26 +350,32 @@ class WeaviateUploader(VectorDBUploader, ABC):
         vector_length: Optional[int] = None,
         **kwargs: Any,
     ) -> bool:
-        if self.upload_config.flatten_metadata:
-            # User manages the collection under flatten mode; precheck validates existence.
-            return False
         collection_name = self.upload_config.collection or destination_name
         collection_name = self.format_destination_name(collection_name)
         self.upload_config.collection = collection_name
 
-        if not self._collection_exists():
+        if self.upload_config.auto_schema:
+            # Weaviate creates the collection and its properties on the
+            # first insert (requires AUTOSCHEMA_ENABLED=true)
+            return False
+        if self.upload_config.flatten_metadata:
+            # User manages the collection under flatten mode; precheck validates existence.
+            return False
+
+        with self.connection_config.get_client() as weaviate_client:
+            if weaviate_client.collections.exists(name=collection_name):
+                logger.debug(
+                    f"Collection with name '{collection_name}' already exists, skipping creation"
+                )
+                return False
             connectors_dir = Path(__file__).parents[1]
             collection_config_file = connectors_dir / "assets" / "weaviate_collection_config.json"
             with collection_config_file.open() as f:
                 collection_config = json.load(f)
             collection_config["class"] = collection_name
-
             logger.info(f"Creating weaviate collection '{collection_name}' with default configs")
-            with self.connection_config.get_client() as weaviate_client:
-                weaviate_client.collections.create_from_dict(config=collection_config)
-                return True
-        logger.debug(f"Collection with name '{collection_name}' already exists, skipping creation")
-        return False
+            weaviate_client.collections.create_from_dict(config=collection_config)
+            return True
 
     def check_for_errors(self, client: "WeaviateClient") -> None:
         failed_uploads = client.batch.failed_objects
@@ -394,9 +418,11 @@ class WeaviateUploader(VectorDBUploader, ABC):
             raise ValueError("No collection specified")
 
         with self.connection_config.get_client() as weaviate_client:
-            self.delete_by_record_id(client=weaviate_client, file_data=file_data)
+            # Only purge prior records when the collection is already present.
+            if weaviate_client.collections.exists(self.upload_config.collection):
+                self.delete_by_record_id(client=weaviate_client, file_data=file_data)
             schema_props: Optional[set[str]] = None
-            if self.upload_config.flatten_metadata:
+            if self.upload_config.flatten_metadata and not self.upload_config.auto_schema:
                 schema_props = self.get_schema_property_names(weaviate_client)
             with self.upload_config.get_batch_client(client=weaviate_client) as batch_client:
                 for e in data:


### PR DESCRIPTION
## Summary

Adds an opt-in `auto_schema` option to the Weaviate destination connector that lets Weaviate build the collection and its columns from the uploaded objects, so a destination collection no longer has to be created (with a full, correct schema) up front.

`auto_schema` defaults to `false`, so **existing behavior is unchanged unless the flag is set**.

## Why

With `flatten_metadata=true` the connector previously required the collection schema to be declared up front and dropped any property not already in it. `auto_schema=true` hands schema creation to Weaviate's native auto-schema so those fields land as columns automatically.

## Behavior

| Mode | `auto_schema=false` (default) | `auto_schema=true` |
|---|---|---|
| non-flatten | as before: nested `metadata`, nothing dropped, collection seeded from default config on `init` | Weaviate auto-creates the collection/columns on insert; nothing dropped |
| `flatten_metadata=true` | as before: conform to existing schema (unknown dropped, missing null-filled), collection must pre-exist | flattened metadata lands as **dynamic top-level columns**, nothing dropped, no predefined schema needed |

Requires `AUTOSCHEMA_ENABLED=true` on the Weaviate side (its default).

## Changes

- New `auto_schema` field on `WeaviateUploaderConfig` (and mirrored on `WeaviateUploadStagerConfig`).
- `precheck`: in `auto_schema` mode, don't require the collection to exist and don't read/enforce the schema; validate connectivity only.
- `run_data`: schema fetch + `conform_to_schema` now gated on `flatten_metadata and not auto_schema`; delete-by-record_id is skipped on the first run when the collection doesn't exist yet (Weaviate creates it on insert).
- Stager: extracted the value-normalization into a shared helper and apply it in **flatten + `auto_schema`** mode before flattening. Without this, `coordinates.points` reaches Weaviate as an unsupported array-of-arrays and every insert fails. Pure flatten (`auto_schema=false`) still passes raw values through for a user-declared schema.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

