### PR TITLE
fix(sharepoint): surface real upstream HTTP status in downloader instead of masking as "Site not found"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **fix(sharepoint): surface the real upstream HTTP status in the downloader instead of masking every error as "Site not found".** `SharepointDownloader._fetch_file` caught every `ClientRequestException` and re-raised it as `SourceConnectionError("Site not found")`, discarding the underlying HTTP status and body — so `401`/`403`/`404`/`429`/`5xx` all surfaced identically as a `400`, and the retry classifier (matching the rewritten message) never retried genuine `429` throttles. The status→typed-error mapping is now shared between the indexer and downloader (`401`/`403` → `UserAuthError`, `404` → `NotFoundError`, `429` → `RateLimitError`), preserves the status/body and Microsoft correlation headers for diagnosis before labeling, and `429`s and `503`s are now retried (matching the OneDrive downloader) and surfaced with their real status.
+- **fix(sharepoint): surface the real upstream HTTP status instead of masking every error as "Site not found".** SharePoint upstream errors now map to typed exceptions carrying the real status code and response body (instead of a generic `400`), and genuine throttles are retried.
 
 ## [1.6.28]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **fix(sharepoint): surface the real upstream HTTP status instead of masking every error as "Site not found".** SharePoint upstream errors now map to typed exceptions carrying the real status code and response body (instead of a generic `400`), and genuine throttles are retried.
+- **fix(sharepoint): surface the real upstream HTTP status instead of masking every error as "Site not found".** SharePoint upstream errors now map to typed exceptions carrying the real status code and response body (instead of a generic `400`), and genuine throttles are retried, honoring the server's `Retry-After` backoff.
 
 ## [1.6.28]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.29]
+
+### Fixes
+
+- **fix(sharepoint): surface the real upstream HTTP status in the downloader instead of masking every error as "Site not found".** `SharepointDownloader._fetch_file` caught every `ClientRequestException` and re-raised it as `SourceConnectionError("Site not found")`, discarding the underlying HTTP status and body — so `401`/`403`/`404`/`429`/`5xx` all surfaced identically as a `400`, and the retry classifier (matching the rewritten message) never retried genuine `429` throttles. The status→typed-error mapping is now shared between the indexer and downloader (`401`/`403` → `UserAuthError`, `404` → `NotFoundError`, `429` → `RateLimitError`), preserves the status/body and Microsoft correlation headers for diagnosis before labeling, and `429`s and `503`s are now retried (matching the OneDrive downloader) and surfaced with their real status.
+
 ## [1.6.28]
 
 ### Fixes

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -299,6 +299,43 @@ def test_fetch_file_truncates_long_response_body(mock_client, sharepoint_downloa
     assert "…" in message
 
 
+def test_fetch_file_404_on_file_attributes_to_file_not_site(
+    mock_client, mock_drive_item, mock_site, sharepoint_downloader, file_data
+):
+    # A 404 on the file fetch must be attributed to the file, not the site: the site
+    # resolved fine, the requested file is what's missing.
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.return_value = (
+        mock_site
+    )
+    mock_drive_item.get_by_path.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(404)
+    )
+    with pytest.raises(NotFoundError) as exc_info:
+        sharepoint_downloader._fetch_file(file_data)
+    message = str(exc_info.value)
+    assert "SharePoint file" in message
+    assert "SharePoint site" not in message
+
+
+def test_fetch_file_truncates_response_body_in_logs(
+    mock_client, sharepoint_downloader, file_data, caplog
+):
+    # The logged body is capped too (not just the raised message) so a large upstream
+    # payload isn't written unbounded — and on every retry attempt.
+    import logging
+
+    from unstructured_ingest.processes.connectors.sharepoint import _MAX_BODY_CHARS
+
+    long_body = "x" * (_MAX_BODY_CHARS + 100)
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(403, text=long_body)
+    )
+    with caplog.at_level(logging.ERROR), pytest.raises(UserAuthError):
+        sharepoint_downloader._fetch_file(file_data)
+    assert "…" in caplog.text
+    assert "x" * (_MAX_BODY_CHARS + 1) not in caplog.text
+
+
 def test_fetch_file_retries_then_raises_rate_limit_on_429(
     mock_client, sharepoint_downloader, file_data
 ):

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -336,6 +336,71 @@ def test_fetch_file_truncates_response_body_in_logs(
     assert "x" * (_MAX_BODY_CHARS + 1) not in caplog.text
 
 
+# A throttle's Retry-After is stamped on the typed error so the downloader's retry can
+# honor the server's requested backoff (the retry sees the typed error, not the raw
+# ClientRequestException). Tested on the mapper directly to avoid a real wait loop.
+def test_handle_exception_stamps_retry_after_from_header():
+    from unstructured_ingest.processes.connectors.sharepoint import (
+        _handle_client_request_exception,
+    )
+
+    exc = _client_request_exception(429, headers={"Retry-After": "30"})
+    with pytest.raises(RateLimitError) as exc_info:
+        _handle_client_request_exception(exc, "SharePoint site x")
+    assert exc_info.value.retry_after == 30.0
+
+
+def test_handle_exception_no_retry_after_when_header_absent():
+    from unstructured_ingest.processes.connectors.sharepoint import (
+        _handle_client_request_exception,
+    )
+
+    exc = _client_request_exception(429)  # no Retry-After header
+    with pytest.raises(RateLimitError) as exc_info:
+        _handle_client_request_exception(exc, "SharePoint site x")
+    assert getattr(exc_info.value, "retry_after", None) is None
+
+
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [
+        ("30", 30.0),  # delta-seconds form (what Graph sends)
+        ("0", 0.0),
+        ("not-a-number", None),  # unparseable -> ignored
+        (None, None),  # absent
+    ],
+)
+def test_parse_retry_after(header, expected):
+    from unstructured_ingest.processes.connectors.sharepoint import _parse_retry_after
+
+    headers = {"Retry-After": header} if header is not None else {}
+    assert _parse_retry_after(headers) == expected
+
+
+def test_honor_retry_after_prefers_larger_server_backoff_capped():
+    from unstructured_ingest.processes.connectors.sharepoint import (
+        _MAX_RETRY_AFTER_WAIT,
+        _honor_retry_after,
+    )
+
+    class _Exc(Exception):
+        pass
+
+    exc = _Exc()
+
+    # Server backoff longer than exponential wins.
+    exc.retry_after = 30.0
+    assert _honor_retry_after(4.0, exc) == 30.0
+    # Exponential wins when it's already longer than Retry-After.
+    exc.retry_after = 1.0
+    assert _honor_retry_after(4.0, exc) == 4.0
+    # Pathologically large Retry-After is capped.
+    exc.retry_after = 99999.0
+    assert _honor_retry_after(4.0, exc) == _MAX_RETRY_AFTER_WAIT
+    # No Retry-After stamped -> fall back to exponential.
+    assert _honor_retry_after(4.0, _Exc()) == 4.0
+
+
 def test_fetch_file_retries_then_raises_rate_limit_on_429(
     mock_client, sharepoint_downloader, file_data
 ):

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -10,6 +10,7 @@ from unstructured_ingest.error import (
     SourceConnectionError,
     SourceConnectionNetworkError,
     UserAuthError,
+    UserError,
     ValueError,
 )
 from unstructured_ingest.processes.connectors.onedrive import OnedriveIndexer
@@ -231,26 +232,71 @@ def test_fetch_file_surfaces_auth_error_on_401(mock_client, sharepoint_downloade
     mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
         _client_request_exception(401)
     )
-    with pytest.raises(UserAuthError):
+    with pytest.raises(UserAuthError) as exc_info:
         sharepoint_downloader._fetch_file(file_data)
+    assert exc_info.value.status_code == 401
     # 401 is not retriable — one attempt only, no retry storm under auth misconfig.
     assert mock_client.sites.get_by_url.return_value.get.return_value.execute_query.call_count == 1
 
 
 def test_fetch_file_surfaces_auth_error_on_403(mock_client, sharepoint_downloader, file_data):
+    # 403 keeps the UserAuthError type (auth-class handling) but must pass through the real
+    # HTTP 403 rather than collapsing to UserAuthError's class default of 401.
     mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
         _client_request_exception(403)
     )
-    with pytest.raises(UserAuthError):
+    with pytest.raises(UserAuthError) as exc_info:
         sharepoint_downloader._fetch_file(file_data)
+    assert exc_info.value.status_code == 403
+    assert "[HTTP 403]" in str(exc_info.value)
 
 
 def test_fetch_file_surfaces_not_found_on_404(mock_client, sharepoint_downloader, file_data):
     mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
         _client_request_exception(404)
     )
-    with pytest.raises(NotFoundError):
+    with pytest.raises(NotFoundError) as exc_info:
         sharepoint_downloader._fetch_file(file_data)
+    assert exc_info.value.status_code == 404
+
+
+def test_fetch_file_surfaces_real_status_on_other_4xx(
+    mock_client, sharepoint_downloader, file_data
+):
+    # An unmapped 4xx (e.g. 409 Conflict) falls to UserError, but must still report its real
+    # status instead of UserError's class default (422) — "pass the status through at least".
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(409)
+    )
+    with pytest.raises(UserError) as exc_info:
+        sharepoint_downloader._fetch_file(file_data)
+    assert exc_info.value.status_code == 409
+    assert "[HTTP 409]" in str(exc_info.value)
+
+
+def test_fetch_file_includes_response_body_in_error(mock_client, sharepoint_downloader, file_data):
+    # The upstream response body is passed through on the raised error, not just logged.
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(403, text="AccessDenied: app lacks Sites.Read.All")
+    )
+    with pytest.raises(UserAuthError) as exc_info:
+        sharepoint_downloader._fetch_file(file_data)
+    assert "AccessDenied: app lacks Sites.Read.All" in str(exc_info.value)
+
+
+def test_fetch_file_truncates_long_response_body(mock_client, sharepoint_downloader, file_data):
+    # A pathologically long body is truncated so the error message stays bounded.
+    from unstructured_ingest.processes.connectors.sharepoint import _MAX_BODY_CHARS
+
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(404, text="x" * (_MAX_BODY_CHARS + 100))
+    )
+    with pytest.raises(NotFoundError) as exc_info:
+        sharepoint_downloader._fetch_file(file_data)
+    message = str(exc_info.value)
+    assert "x" * _MAX_BODY_CHARS in message
+    assert "x" * (_MAX_BODY_CHARS + 1) not in message
+    assert "…" in message
 
 
 def test_fetch_file_retries_then_raises_rate_limit_on_429(
@@ -261,8 +307,9 @@ def test_fetch_file_retries_then_raises_rate_limit_on_429(
     mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
         _client_request_exception(429)
     )
-    with pytest.raises(RateLimitError):
+    with pytest.raises(RateLimitError) as exc_info:
         sharepoint_downloader._fetch_file(file_data)
+    assert exc_info.value.status_code == 429
     assert (
         mock_client.sites.get_by_url.return_value.get.return_value.execute_query.call_count
         == sharepoint_downloader.download_config.max_retries
@@ -323,8 +370,10 @@ def test_fetch_file_maps_5xx_to_connection_error_not_user_error(
     mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
         _client_request_exception(503)
     )
-    with pytest.raises(SourceConnectionNetworkError):
+    with pytest.raises(SourceConnectionNetworkError) as exc_info:
         sharepoint_downloader._fetch_file(file_data)
+    # Real 5xx passes through instead of collapsing to the class default (400).
+    assert exc_info.value.status_code == 503
 
 
 def test_fetch_file_retries_5xx_then_raises_connection_error(
@@ -341,6 +390,23 @@ def test_fetch_file_retries_5xx_then_raises_connection_error(
         mock_client.sites.get_by_url.return_value.get.return_value.execute_query.call_count
         == sharepoint_downloader.download_config.max_retries
     )
+
+
+def test_fetch_file_retriable_then_nonretriable_stops_on_nonretriable(
+    mock_client, sharepoint_downloader, file_data
+):
+    # Mixed sequence: a retriable 503 followed by a non-retriable 403 must stop on the 403
+    # (no further retries) and surface it with its real status — pins that the classifier
+    # keys off each error's actual status, not a blanket "keep retrying".
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = [
+        _client_request_exception(503),
+        _client_request_exception(403),
+    ]
+    with pytest.raises(UserAuthError) as exc_info:
+        sharepoint_downloader._fetch_file(file_data)
+    assert exc_info.value.status_code == 403
+    # Exactly two attempts: 503 retried once, 403 halted retrying.
+    assert mock_client.sites.get_by_url.return_value.get.return_value.execute_query.call_count == 2
 
 
 def test_fetch_file_wraps_unknown_exception_as_connection_error(

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -4,7 +4,14 @@ import pytest
 from pydantic import Secret
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
-from unstructured_ingest.error import SourceConnectionError, ValueError
+from unstructured_ingest.error import (
+    NotFoundError,
+    RateLimitError,
+    SourceConnectionError,
+    SourceConnectionNetworkError,
+    UserAuthError,
+    ValueError,
+)
 from unstructured_ingest.processes.connectors.onedrive import OnedriveIndexer
 from unstructured_ingest.processes.connectors.sharepoint import (
     SharepointAccessConfig,
@@ -197,6 +204,206 @@ def test_fetch_file_handles_site_not_found_immediately(
     assert mock_client.sites.get_by_url.return_value.get.return_value.execute_query.call_count == 1
 
 
+def _client_request_exception(status_code, text="upstream error", headers=None):
+    """Build a ClientRequestException carrying a real HTTP status, as office365 raises.
+
+    ClientRequestException subclasses requests.RequestException, whose __init__ reads
+    ``response.headers``/``response.content`` — so we pass a response object, not a message.
+    """
+    from office365.runtime.client_request_exception import ClientRequestException
+
+    response = Mock()
+    response.headers = headers or {}
+    response.content = b""
+    response.status_code = status_code
+    response.text = text
+    return ClientRequestException(response=response)
+
+
+# Regression: the downloader used to catch every ClientRequestException and re-raise
+# it as SourceConnectionError("Site not found"), discarding the real HTTP status —
+# so 401/403/404/429 all surfaced identically as "400: ... Site not found", and the
+# retry classifier (matching the rewritten string) never fired for genuine throttles.
+# These pin that the real status is now surfaced (and 429s retry).
+
+
+def test_fetch_file_surfaces_auth_error_on_401(mock_client, sharepoint_downloader, file_data):
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(401)
+    )
+    with pytest.raises(UserAuthError):
+        sharepoint_downloader._fetch_file(file_data)
+    # 401 is not retriable — one attempt only, no retry storm under auth misconfig.
+    assert mock_client.sites.get_by_url.return_value.get.return_value.execute_query.call_count == 1
+
+
+def test_fetch_file_surfaces_auth_error_on_403(mock_client, sharepoint_downloader, file_data):
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(403)
+    )
+    with pytest.raises(UserAuthError):
+        sharepoint_downloader._fetch_file(file_data)
+
+
+def test_fetch_file_surfaces_not_found_on_404(mock_client, sharepoint_downloader, file_data):
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(404)
+    )
+    with pytest.raises(NotFoundError):
+        sharepoint_downloader._fetch_file(file_data)
+
+
+def test_fetch_file_retries_then_raises_rate_limit_on_429(
+    mock_client, sharepoint_downloader, file_data
+):
+    # A genuine 429 must both trigger retries and surface as RateLimitError — previously
+    # it was rewritten to "Site not found" before the retry classifier could see the 429.
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(429)
+    )
+    with pytest.raises(RateLimitError):
+        sharepoint_downloader._fetch_file(file_data)
+    assert (
+        mock_client.sites.get_by_url.return_value.get.return_value.execute_query.call_count
+        == sharepoint_downloader.download_config.max_retries
+    )
+
+
+def test_fetch_file_preserves_http_status_and_headers_in_logs(
+    mock_client, sharepoint_downloader, file_data, caplog
+):
+    # Core AC: the real status/text + MS correlation headers must be captured before any
+    # label, so the next occurrence attributes to a real HTTP condition.
+    import logging
+
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(
+            403,
+            text="Access forbidden for app",
+            headers={"x-ms-ags-diagnostic": "diag-xyz", "request-id": "req-123"},
+        )
+    )
+    with caplog.at_level(logging.ERROR), pytest.raises(UserAuthError):
+        sharepoint_downloader._fetch_file(file_data)
+    assert "403" in caplog.text
+    assert "diag-xyz" in caplog.text
+
+
+def _indexer_with_site_error(exc) -> SharepointIndexer:
+    conn = Mock(spec=SharepointConnectionConfig)
+    conn.site = "https://test.sharepoint.com/sites/test"
+    conn.get_token.return_value = {"access_token": "tok"}
+    conn.get_client.return_value.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (  # noqa: E501
+        exc
+    )
+    idx_config = Mock(spec=SharepointIndexerConfig)
+    idx_config.path = ""
+    return SharepointIndexer(connection_config=conn, index_config=idx_config)
+
+
+def _drain_run_async(indexer: SharepointIndexer) -> list:
+    import asyncio
+
+    async def _drain() -> list:
+        return [fd async for fd in indexer.run_async()]
+
+    return asyncio.run(_drain())
+
+
+# The indexer's async run path resolves the same site as the downloader, so it must map
+# upstream HTTP status the same way (shared helper) rather than masking as a generic
+# connection error — otherwise index-time auth/throttle failures are misclassified.
+
+
+def test_fetch_file_maps_5xx_to_connection_error_not_user_error(
+    mock_client, sharepoint_downloader, file_data
+):
+    # A transient upstream 5xx must stay a connection-class error (retriable semantics),
+    # not be reclassified as a non-retriable UserError.
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(503)
+    )
+    with pytest.raises(SourceConnectionNetworkError):
+        sharepoint_downloader._fetch_file(file_data)
+
+
+def test_fetch_file_retries_5xx_then_raises_connection_error(
+    mock_client, sharepoint_downloader, file_data
+):
+    # A transient upstream 5xx (503) is retriable (parity with OneDrive's 429/503 set):
+    # it must both retry up to max_retries and finally surface as SourceConnectionNetworkError.
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(503)
+    )
+    with pytest.raises(SourceConnectionNetworkError):
+        sharepoint_downloader._fetch_file(file_data)
+    assert (
+        mock_client.sites.get_by_url.return_value.get.return_value.execute_query.call_count
+        == sharepoint_downloader.download_config.max_retries
+    )
+
+
+def test_fetch_file_wraps_unknown_exception_as_connection_error(
+    mock_client, sharepoint_downloader, file_data
+):
+    # A non-HTTP / unrecognized failure still surfaces as a connection error — this pins the
+    # inline catch-all that replaced the removed @SourceConnectionNetworkError.wrap decorator.
+    mock_client.sites.get_by_url.return_value.get.return_value.execute_query.side_effect = (
+        RuntimeError("boom")
+    )
+    with pytest.raises(SourceConnectionNetworkError):
+        sharepoint_downloader._fetch_file(file_data)
+
+
+def test_indexer_run_async_surfaces_auth_error_on_401():
+    indexer = _indexer_with_site_error(_client_request_exception(401))
+    with pytest.raises(UserAuthError):
+        _drain_run_async(indexer)
+
+
+def test_indexer_run_async_surfaces_rate_limit_on_429():
+    indexer = _indexer_with_site_error(_client_request_exception(429))
+    with pytest.raises(RateLimitError):
+        _drain_run_async(indexer)
+
+
+def test_indexer_run_async_maps_path_resolution_error():
+    # Site resolves, but the configured (non-root) path 404s during resolution.
+    conn = Mock(spec=SharepointConnectionConfig)
+    conn.site = "https://test.sharepoint.com/sites/test"
+    conn.get_token.return_value = {"access_token": "tok"}
+    site_drive_item = Mock()
+    conn._get_drive_item.return_value = site_drive_item
+    conn.get_client.return_value.sites.get_by_url.return_value.get.return_value.execute_query.return_value = Mock()  # noqa: E501
+    site_drive_item.get_by_path.return_value.get.return_value.execute_query.side_effect = (
+        _client_request_exception(404)
+    )
+    idx_config = Mock(spec=SharepointIndexerConfig)
+    idx_config.path = "Shared Documents/Subfolder"
+    indexer = SharepointIndexer(connection_config=conn, index_config=idx_config)
+    with pytest.raises(NotFoundError):
+        _drain_run_async(indexer)
+
+
+def test_indexer_run_async_maps_file_listing_error():
+    # Site + path resolve, but listing files throttles.
+    conn = Mock(spec=SharepointConnectionConfig)
+    conn.site = "https://test.sharepoint.com/sites/test"
+    conn.get_token.return_value = {"access_token": "tok"}
+    site_drive_item = Mock()
+    conn._get_drive_item.return_value = site_drive_item
+    conn.get_client.return_value.sites.get_by_url.return_value.get.return_value.execute_query.return_value = Mock()  # noqa: E501
+    site_drive_item.get_files.return_value.execute_query.side_effect = _client_request_exception(
+        429
+    )
+    idx_config = Mock(spec=SharepointIndexerConfig)
+    idx_config.path = ""  # root -> target drive item is the site drive item
+    idx_config.recursive = False
+    indexer = SharepointIndexer(connection_config=conn, index_config=idx_config)
+    with pytest.raises(RateLimitError):
+        _drain_run_async(indexer)
+
+
 # Full coverage for the permission machinery lives in test_onedrive.py since
 # the implementation is on OnedriveIndexer; the tests below pin the inheritance
 # contract so any future SharePoint-side override has to come with real
@@ -231,22 +438,13 @@ class TestSharepointInheritsPermissionMachinery:
         # same function object on both classes -> SharePoint runs identical code;
         # if anyone overrides on SharepointIndexer this fails and forces them to
         # add SharePoint-specific coverage
-        assert (
-            SharepointIndexer.extract_permissions
-            is OnedriveIndexer.extract_permissions
-        )
-        assert (
-            SharepointIndexer._fetch_permissions_raw
-            is OnedriveIndexer._fetch_permissions_raw
-        )
+        assert SharepointIndexer.extract_permissions is OnedriveIndexer.extract_permissions
+        assert SharepointIndexer._fetch_permissions_raw is OnedriveIndexer._fetch_permissions_raw
         assert (
             SharepointIndexer._extract_identity_ids_from_raw
             is OnedriveIndexer._extract_identity_ids_from_raw
         )
-        assert (
-            SharepointIndexer._parse_batch_response
-            is OnedriveIndexer._parse_batch_response
-        )
+        assert SharepointIndexer._parse_batch_response is OnedriveIndexer._parse_batch_response
 
     def test_extract_permissions_owner_role_smoke(self):
         indexer = _make_sharepoint_indexer()
@@ -271,9 +469,7 @@ class TestSharepointInheritsPermissionMachinery:
         drive_item = _make_sharepoint_drive_item()
         file_data = indexer.drive_item_to_file_data_sync(
             drive_item,
-            raw_permissions=[
-                {"roles": ["read"], "grantedToV2": {"user": {"id": "u-1"}}}
-            ],
+            raw_permissions=[{"roles": ["read"], "grantedToV2": {"user": {"id": "u-1"}}}],
         )
         assert file_data.metadata.permissions_data is not None
         assert file_data.metadata.permissions_data[0]["read"]["users"] == ["u-1"]
@@ -290,9 +486,7 @@ class TestSharepointInheritsPermissionMachinery:
                     "id": "0",
                     "status": 200,
                     "body": {
-                        "value": [
-                            {"roles": ["read"], "grantedToV2": {"user": {"id": "u-1"}}}
-                        ]
+                        "value": [{"roles": ["read"], "grantedToV2": {"user": {"id": "u-1"}}}]
                     },
                 }
             ]

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.28"  # pragma: no cover
+__version__ = "1.6.29"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -110,6 +110,14 @@ _MS_CORRELATION_HEADERS = (
 _MAX_BODY_CHARS = 500
 
 
+def _truncate_body(body: Optional[str]) -> Optional[str]:
+    """Cap an upstream response body to ``_MAX_BODY_CHARS`` for both logs and error
+    messages, so a large payload isn't written unbounded (and repeatedly on retries)."""
+    if not body:
+        return body
+    return body if len(body) <= _MAX_BODY_CHARS else f"{body[:_MAX_BODY_CHARS]}…"
+
+
 def _handle_client_request_exception(e: ClientRequestException, context: str) -> NoReturn:
     """Map a SharePoint ``ClientRequestException`` to a typed error from its real HTTP
     status, preserving the status/body/Microsoft correlation headers for diagnosis first.
@@ -138,7 +146,7 @@ def _handle_client_request_exception(e: ClientRequestException, context: str) ->
             "SharePoint upstream error for %s: status_code=%s body=%r correlation=%s",
             context,
             status_code,
-            body,
+            _truncate_body(body),
             correlation,
         )
     else:
@@ -146,11 +154,7 @@ def _handle_client_request_exception(e: ClientRequestException, context: str) ->
 
     def _raise(error_cls: type[UnstructuredIngestError], summary: str) -> NoReturn:
         prefix = f"[HTTP {status_code}] " if status_code is not None else ""
-        if body:
-            snippet = body if len(body) <= _MAX_BODY_CHARS else f"{body[:_MAX_BODY_CHARS]}…"
-            message = f"{prefix}{summary}: {snippet}"
-        else:
-            message = f"{prefix}{summary}"
+        message = f"{prefix}{summary}: {_truncate_body(body)}" if body else f"{prefix}{summary}"
         err = error_cls(message)
         # Shadow the class-level default with the real upstream status so it flows through to
         # whatever surfaces the error (e.g. 403 stays a UserAuthError but reports HTTP 403).
@@ -355,20 +359,24 @@ class SharepointDownloader(OnedriveDownloader):
             reraise=True,
         )
         def _get_item_by_path() -> DriveItem:
+            # Split so the failure is attributed to what actually failed: a 404 on the
+            # file fetch means the file is missing, not the site. Both paths preserve the
+            # real status/body/correlation headers and map to a typed error (401/403 ->
+            # auth, 404 -> not found, 429 -> rate limit, which the retry classifier above
+            # then retries) instead of masking every upstream failure as "Site not found".
             try:
                 client_site = (
                     client.sites.get_by_url(self.connection_config.site).get().execute_query()
                 )
                 site_drive_item = self.connection_config._get_drive_item(client_site)
-                return site_drive_item.get_by_path(server_relative_path).get().execute_query()
             except ClientRequestException as e:
-                # Preserve the real status/body/correlation headers and map to a typed error
-                # (401/403 -> auth, 404 -> not found, 429 -> rate limit — which the retry
-                # classifier above then retries) instead of masking every upstream failure
-                # as "Site not found" and discarding the status.
                 _handle_client_request_exception(
                     e, f"SharePoint site {self.connection_config.site}"
                 )
+            try:
+                return site_drive_item.get_by_path(server_relative_path).get().execute_query()
+            except ClientRequestException as e:
+                _handle_client_request_exception(e, f"SharePoint file '{server_relative_path}'")
 
         # Intentionally NOT decorated with @SourceConnectionNetworkError.wrap: that coerces
         # sibling typed errors (UserAuthError/RateLimitError/NotFoundError) back to a 400,

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncIterator, Optional
+from typing import TYPE_CHECKING, Any, AsyncIterator, NoReturn, Optional
 
 from pydantic import Field
 
@@ -12,8 +12,10 @@ from unstructured_ingest.data_types.file_data import (
 )
 from unstructured_ingest.error import (
     NotFoundError,
+    RateLimitError,
     SourceConnectionError,
     SourceConnectionNetworkError,
+    UnstructuredIngestError,
     UserAuthError,
     UserError,
     ValueError,
@@ -93,29 +95,70 @@ class SharepointIndexerConfig(OnedriveIndexerConfig):
     path: str = Field(default="")
 
 
+# Microsoft/SharePoint correlation headers worth preserving for support/diagnosis.
+_MS_CORRELATION_HEADERS = (
+    "request-id",
+    "client-request-id",
+    "x-ms-ags-diagnostic",
+    "SPRequestGuid",
+    "Retry-After",
+    "WWW-Authenticate",
+)
+
+
+def _handle_client_request_exception(e: ClientRequestException, context: str) -> NoReturn:
+    """Map a SharePoint ``ClientRequestException`` to a typed error from its real HTTP
+    status, preserving the status/body/Microsoft correlation headers for diagnosis first.
+
+    Shared by the indexer and downloader so both surface the true condition
+    (auth vs not-found vs throttle vs other) instead of one opaque label. Preserving the
+    real signal *before* labeling is the fix for the downloader that previously re-raised
+    every upstream failure as ``SourceConnectionError("Site not found")``.
+    """
+    response = getattr(e, "response", None)
+    status_code = getattr(response, "status_code", None)
+
+    # Preserve the real HTTP signal BEFORE applying any label.
+    if response is not None:
+        headers = getattr(response, "headers", None) or {}
+        correlation = {k: headers.get(k) for k in _MS_CORRELATION_HEADERS if headers.get(k)}
+        logger.error(
+            "SharePoint upstream error for %s: status_code=%s body=%r correlation=%s",
+            context,
+            status_code,
+            getattr(response, "text", None),
+            correlation,
+        )
+    else:
+        logger.error("SharePoint upstream error for %s: %s", context, e)
+
+    if status_code == 401:
+        raise UserAuthError(
+            f"Unauthorized access to {context}. Check client credentials and permissions"
+        )
+    if status_code == 403:
+        raise UserAuthError(
+            f"Access forbidden to {context}. Check app permissions (Sites.Read.All required)"
+        )
+    if status_code == 404:
+        raise NotFoundError(f"Not found: {context}")
+    if status_code == 429:
+        raise RateLimitError(f"Rate limited by SharePoint for {context}")
+    if status_code is not None and status_code >= 500:
+        # Upstream/provider outage (5xx) is transient — keep it a connection-class error
+        # (as the downloader did before) rather than a non-retriable user fault.
+        raise SourceConnectionNetworkError(
+            f"Upstream SharePoint error {status_code} for {context}: {e}"
+        )
+
+    raise UserError(f"Failed to access {context}: {e}")
+
+
 @dataclass
 class SharepointIndexer(OnedriveIndexer):
     connection_config: SharepointConnectionConfig
     index_config: SharepointIndexerConfig
     connector_type: str = CONNECTOR_TYPE
-
-    def _handle_client_request_exception(self, e: ClientRequestException, context: str) -> None:
-        """Convert ClientRequestException to appropriate user-facing error based on HTTP status."""
-        if hasattr(e, "response") and e.response is not None and hasattr(e.response, "status_code"):
-            status_code = e.response.status_code
-            if status_code == 401:
-                raise UserAuthError(
-                    f"Unauthorized access to {context}. Check client credentials and permissions"
-                )
-            elif status_code == 403:
-                raise UserAuthError(
-                    f"Access forbidden to {context}. "
-                    f"Check app permissions (Sites.Read.All required)"
-                )
-            elif status_code == 404:
-                raise UserError(f"Not found: {context}")
-
-        raise UserError(f"Failed to access {context}: {str(e)}")
 
     def _is_root_path(self, path: str) -> bool:
         """Check if the path represents root access (empty string or legacy default)."""
@@ -123,10 +166,16 @@ class SharepointIndexer(OnedriveIndexer):
 
     def _get_target_drive_item(self, site_drive_item: DriveItem, path: str) -> DriveItem:
         """Get the drive item to search in based on the path."""
+        from office365.runtime.client_request_exception import ClientRequestException
+
         if self._is_root_path(path):
             return site_drive_item
-        else:
+        try:
             return site_drive_item.get_by_path(path).get().execute_query()
+        except ClientRequestException as e:
+            # Path resolution hits the same upstream — classify it (404/403/429/...) rather
+            # than letting a raw ClientRequestException escape unclassified.
+            _handle_client_request_exception(e, f"SharePoint path '{path}'")
 
     def _validate_folder_path(self, site_drive_item: DriveItem, path: str) -> None:
         """Validate that a specific folder path exists and is accessible."""
@@ -142,7 +191,7 @@ class SharepointIndexer(OnedriveIndexer):
             logger.info(f"SharePoint folder path '{path}' validated successfully")
         except ClientRequestException as e:
             logger.error(f"Failed to access SharePoint path '{path}': {e}")
-            self._handle_client_request_exception(e, f"SharePoint path '{path}'")
+            _handle_client_request_exception(e, f"SharePoint path '{path}'")
         except Exception as e:
             logger.error(f"Unexpected error accessing SharePoint path '{path}': {e}")
             raise UserError(f"Failed to validate SharePoint path '{path}': {str(e)}")
@@ -173,9 +222,7 @@ class SharepointIndexer(OnedriveIndexer):
 
         except ClientRequestException as e:
             logger.error(f"SharePoint precheck failed for site: {self.connection_config.site}")
-            self._handle_client_request_exception(
-                e, f"SharePoint site {self.connection_config.site}"
-            )
+            _handle_client_request_exception(e, f"SharePoint site {self.connection_config.site}")
         except Exception as e:
             logger.error(f"Unexpected error during SharePoint precheck: {e}", exc_info=True)
             raise UserError(f"Failed to validate SharePoint connection: {str(e)}")
@@ -198,9 +245,7 @@ class SharepointIndexer(OnedriveIndexer):
             site_drive_item = self.connection_config._get_drive_item(client_site)
         except ClientRequestException as e:
             logger.error(f"Failed to access SharePoint site: {self.connection_config.site}")
-            raise SourceConnectionError(
-                f"Unable to access SharePoint site at {self.connection_config.site}: {str(e)}"
-            )
+            _handle_client_request_exception(e, f"SharePoint site {self.connection_config.site}")
 
         path = self.index_config.path
         target_drive_item = await asyncio.to_thread(
@@ -208,19 +253,23 @@ class SharepointIndexer(OnedriveIndexer):
         )
 
         async def _flush(chunk: list[DriveItem]) -> AsyncIterator[FileData]:
-            perms_by_id = await asyncio.to_thread(
-                self._fetch_permissions_raw, chunk, access_token
-            )
+            perms_by_id = await asyncio.to_thread(self._fetch_permissions_raw, chunk, access_token)
             for di in chunk:
                 yield await self.drive_item_to_file_data(
                     drive_item=di,
                     raw_permissions=perms_by_id.get(di.id, []),
                 )
 
+        try:
+            drive_items = target_drive_item.get_files(
+                recursive=self.index_config.recursive
+            ).execute_query()
+        except ClientRequestException as e:
+            logger.error(f"Failed to list SharePoint files for site: {self.connection_config.site}")
+            _handle_client_request_exception(e, f"SharePoint site {self.connection_config.site}")
+
         chunk: list[DriveItem] = []
-        for drive_item in target_drive_item.get_files(
-            recursive=self.index_config.recursive
-        ).execute_query():
+        for drive_item in drive_items:
             chunk.append(drive_item)
             if len(chunk) >= PERMISSIONS_BATCH_SIZE:
                 async for fd in _flush(chunk):
@@ -243,10 +292,20 @@ class SharepointDownloader(OnedriveDownloader):
 
     @staticmethod
     def retry_on_status_code(exc):
+        # Retry genuine throttles (429) and transient upstream outages (5xx, esp. 503),
+        # matching OneDrive's throttle-retry set. Inspect the typed error first — the
+        # previous string-only match never fired once the status was masked upstream.
+        # Both RateLimitError and SourceConnectionNetworkError are raised only by the
+        # shared mapper inside the retry-wrapped `_get_item_by_path`, so within this
+        # scope a RateLimitError uniquely means a 429 and a SourceConnectionNetworkError
+        # uniquely means a 5xx; retrying on them is therefore precise. (The outer
+        # catch-all's SourceConnectionNetworkError is outside the retry scope and never
+        # reaches this classifier.)
+        if isinstance(exc, (RateLimitError, SourceConnectionNetworkError)):
+            return True
         error_msg = str(exc).lower()
         return "429" in error_msg or "activitylimitreached" in error_msg or "throttled" in error_msg
 
-    @SourceConnectionNetworkError.wrap
     @requires_dependencies(["office365"], extras="sharepoint")
     def _fetch_file(self, file_data: FileData) -> DriveItem:
         from office365.runtime.client_request_exception import ClientRequestException
@@ -280,14 +339,29 @@ class SharepointDownloader(OnedriveDownloader):
                     client.sites.get_by_url(self.connection_config.site).get().execute_query()
                 )
                 site_drive_item = self.connection_config._get_drive_item(client_site)
-            except ClientRequestException:
-                logger.info(f"Site not found: {self.connection_config.site}")
-                raise SourceConnectionError(f"Site not found: {self.connection_config.site}")
-            file = site_drive_item.get_by_path(server_relative_path).get().execute_query()
-            return file
+                return site_drive_item.get_by_path(server_relative_path).get().execute_query()
+            except ClientRequestException as e:
+                # Preserve the real status/body/correlation headers and map to a typed error
+                # (401/403 -> auth, 404 -> not found, 429 -> rate limit — which the retry
+                # classifier above then retries) instead of masking every upstream failure
+                # as "Site not found" and discarding the status.
+                _handle_client_request_exception(
+                    e, f"SharePoint site {self.connection_config.site}"
+                )
 
-        # Call the retry-wrapped function
-        file = _get_item_by_path()
+        # Intentionally NOT decorated with @SourceConnectionNetworkError.wrap: that coerces
+        # sibling typed errors (UserAuthError/RateLimitError/NotFoundError) back to a 400,
+        # re-masking the real status. We replicate its catch-all here so genuinely
+        # unrecognized failures still surface as a connection error, while typed errors pass
+        # through with their true status.
+        try:
+            file = _get_item_by_path()
+        except UnstructuredIngestError:
+            raise
+        except Exception as e:
+            raise SourceConnectionNetworkError(
+                f"Error in connecting to upstream data source: {e}"
+            ) from e
 
         if not file:
             raise NotFoundError(f"file not found: {server_relative_path}")

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -105,6 +105,10 @@ _MS_CORRELATION_HEADERS = (
     "WWW-Authenticate",
 )
 
+# Cap the amount of upstream response body carried on the raised error message. Enough to
+# diagnose (SharePoint/Graph error bodies are small JSON) without dumping an unbounded payload.
+_MAX_BODY_CHARS = 500
+
 
 def _handle_client_request_exception(e: ClientRequestException, context: str) -> NoReturn:
     """Map a SharePoint ``ClientRequestException`` to a typed error from its real HTTP
@@ -114,9 +118,17 @@ def _handle_client_request_exception(e: ClientRequestException, context: str) ->
     (auth vs not-found vs throttle vs other) instead of one opaque label. Preserving the
     real signal *before* labeling is the fix for the downloader that previously re-raised
     every upstream failure as ``SourceConnectionError("Site not found")``.
+
+    The chosen typed class keeps useful semantics (auth vs throttle vs not-found, and which
+    errors retry), but the real HTTP status code and response body are *also* passed through
+    on the raised error itself — the ``status_code`` is stamped on the instance (shadowing the
+    class default, e.g. so a 403 surfaces as 403 rather than ``UserAuthError``'s default 401)
+    and a truncated body is appended to the message — so callers/users see the true condition,
+    not just the logs.
     """
     response = getattr(e, "response", None)
     status_code = getattr(response, "status_code", None)
+    body = getattr(response, "text", None) if response is not None else None
 
     # Preserve the real HTTP signal BEFORE applying any label.
     if response is not None:
@@ -126,32 +138,42 @@ def _handle_client_request_exception(e: ClientRequestException, context: str) ->
             "SharePoint upstream error for %s: status_code=%s body=%r correlation=%s",
             context,
             status_code,
-            getattr(response, "text", None),
+            body,
             correlation,
         )
     else:
         logger.error("SharePoint upstream error for %s: %s", context, e)
 
+    def _raise(error_cls: type[UnstructuredIngestError], summary: str) -> NoReturn:
+        prefix = f"[HTTP {status_code}] " if status_code is not None else ""
+        if body:
+            snippet = body if len(body) <= _MAX_BODY_CHARS else f"{body[:_MAX_BODY_CHARS]}…"
+            message = f"{prefix}{summary}: {snippet}"
+        else:
+            message = f"{prefix}{summary}"
+        err = error_cls(message)
+        # Shadow the class-level default with the real upstream status so it flows through to
+        # whatever surfaces the error (e.g. 403 stays a UserAuthError but reports HTTP 403).
+        err.status_code = status_code
+        raise err from e
+
     if status_code == 401:
-        raise UserAuthError(
-            f"Unauthorized access to {context}. Check client credentials and permissions"
-        )
+        _raise(UserAuthError, f"Unauthorized access to {context}. Check client credentials")
     if status_code == 403:
-        raise UserAuthError(
-            f"Access forbidden to {context}. Check app permissions (Sites.Read.All required)"
+        _raise(
+            UserAuthError,
+            f"Access forbidden to {context}. Check app permissions (Sites.Read.All required)",
         )
     if status_code == 404:
-        raise NotFoundError(f"Not found: {context}")
+        _raise(NotFoundError, f"Not found: {context}")
     if status_code == 429:
-        raise RateLimitError(f"Rate limited by SharePoint for {context}")
+        _raise(RateLimitError, f"Rate limited by SharePoint for {context}")
     if status_code is not None and status_code >= 500:
         # Upstream/provider outage (5xx) is transient — keep it a connection-class error
         # (as the downloader did before) rather than a non-retriable user fault.
-        raise SourceConnectionNetworkError(
-            f"Upstream SharePoint error {status_code} for {context}: {e}"
-        )
+        _raise(SourceConnectionNetworkError, f"Upstream SharePoint error for {context}")
 
-    raise UserError(f"Failed to access {context}: {e}")
+    _raise(UserError, f"Failed to access {context}")
 
 
 @dataclass
@@ -293,14 +315,13 @@ class SharepointDownloader(OnedriveDownloader):
     @staticmethod
     def retry_on_status_code(exc):
         # Retry genuine throttles (429) and transient upstream outages (5xx, esp. 503),
-        # matching OneDrive's throttle-retry set. Inspect the typed error first — the
-        # previous string-only match never fired once the status was masked upstream.
-        # Both RateLimitError and SourceConnectionNetworkError are raised only by the
-        # shared mapper inside the retry-wrapped `_get_item_by_path`, so within this
-        # scope a RateLimitError uniquely means a 429 and a SourceConnectionNetworkError
-        # uniquely means a 5xx; retrying on them is therefore precise. (The outer
-        # catch-all's SourceConnectionNetworkError is outside the retry scope and never
-        # reaches this classifier.)
+        # matching OneDrive's throttle-retry set. Prefer the real HTTP status the shared
+        # mapper now stamps on the typed error (every exception raised inside the
+        # retry-wrapped `_get_item_by_path` carries it), then fall back to type/string
+        # checks for exceptions that didn't come through the mapper.
+        status_code = getattr(exc, "status_code", None)
+        if isinstance(status_code, int) and (status_code == 429 or status_code >= 500):
+            return True
         if isinstance(exc, (RateLimitError, SourceConnectionNetworkError)):
             return True
         error_msg = str(exc).lower()

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, NoReturn, Optional
@@ -118,6 +119,49 @@ def _truncate_body(body: Optional[str]) -> Optional[str]:
     return body if len(body) <= _MAX_BODY_CHARS else f"{body[:_MAX_BODY_CHARS]}…"
 
 
+# Upper bound on how long we'll honor a throttle's Retry-After, so a pathological or
+# hostile header can't stall a download far beyond a real throttle window.
+_MAX_RETRY_AFTER_WAIT = 300.0
+
+
+def _parse_retry_after(headers: Any) -> Optional[float]:
+    """Parse a ``Retry-After`` header (delta-seconds or HTTP-date) into seconds.
+
+    Returns ``None`` if the header is absent or unparseable. SharePoint/Graph send the
+    delta-seconds form on throttles; the HTTP-date form is handled for completeness.
+    """
+    value = headers.get("Retry-After") if headers else None
+    if not value:
+        return None
+    # NB: this module shadows the builtin ``ValueError`` with a custom error class (imported
+    # from unstructured_ingest.error), so catch the builtin explicitly here.
+    try:
+        return max(0.0, float(value))  # delta-seconds form
+    except (builtins.TypeError, builtins.ValueError):
+        pass
+    try:
+        from datetime import datetime, timezone
+        from email.utils import parsedate_to_datetime
+
+        dt = parsedate_to_datetime(value)
+        if dt is not None:
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return max(0.0, (dt - datetime.now(timezone.utc)).total_seconds())
+    except (builtins.TypeError, builtins.ValueError):
+        pass
+    return None
+
+
+def _honor_retry_after(base_seconds: float, exc: BaseException) -> float:
+    """Backoff for a retry: the server's ``Retry-After`` (stamped on the typed error)
+    when it exceeds the exponential backoff, capped at ``_MAX_RETRY_AFTER_WAIT``."""
+    retry_after = getattr(exc, "retry_after", None)
+    if isinstance(retry_after, (int, float)) and retry_after > base_seconds:
+        return min(float(retry_after), _MAX_RETRY_AFTER_WAIT)
+    return base_seconds
+
+
 def _handle_client_request_exception(e: ClientRequestException, context: str) -> NoReturn:
     """Map a SharePoint ``ClientRequestException`` to a typed error from its real HTTP
     status, preserving the status/body/Microsoft correlation headers for diagnosis first.
@@ -137,10 +181,11 @@ def _handle_client_request_exception(e: ClientRequestException, context: str) ->
     response = getattr(e, "response", None)
     status_code = getattr(response, "status_code", None)
     body = getattr(response, "text", None) if response is not None else None
+    headers = (getattr(response, "headers", None) or {}) if response is not None else {}
+    retry_after = _parse_retry_after(headers)
 
     # Preserve the real HTTP signal BEFORE applying any label.
     if response is not None:
-        headers = getattr(response, "headers", None) or {}
         correlation = {k: headers.get(k) for k in _MS_CORRELATION_HEADERS if headers.get(k)}
         logger.error(
             "SharePoint upstream error for %s: status_code=%s body=%r correlation=%s",
@@ -159,6 +204,10 @@ def _handle_client_request_exception(e: ClientRequestException, context: str) ->
         # Shadow the class-level default with the real upstream status so it flows through to
         # whatever surfaces the error (e.g. 403 stays a UserAuthError but reports HTTP 403).
         err.status_code = status_code
+        # Carry the throttle backoff so the downloader's retry can honor it (the retry sees
+        # this typed error, not the original ClientRequestException with its headers).
+        if retry_after is not None:
+            err.retry_after = retry_after
         raise err from e
 
     if status_code == 401:
@@ -351,9 +400,19 @@ class SharepointDownloader(OnedriveDownloader):
         server_relative_path = file_data.source_identifiers.fullpath
         client = self.connection_config.get_client()
 
+        _exp_wait = wait_exponential(exp_base=2, multiplier=1, min=2, max=10)
+
+        def _wait(retry_state) -> float:
+            # Honor a throttle's Retry-After (stamped on the typed error by the mapper)
+            # when it exceeds the exponential backoff, so we don't retry before the
+            # server's requested window; fall back to exponential otherwise.
+            base = _exp_wait(retry_state)
+            exc = retry_state.outcome.exception() if retry_state.outcome else None
+            return _honor_retry_after(base, exc) if exc is not None else base
+
         @retry(
             stop=stop_after_attempt(self.download_config.max_retries),
-            wait=wait_exponential(exp_base=2, multiplier=1, min=2, max=10),
+            wait=_wait,
             retry=retry_if_exception(self.retry_on_status_code),
             before=before_log(logger, logging.DEBUG),
             reraise=True,


### PR DESCRIPTION
## Summary

`SharepointDownloader._fetch_file` caught every `ClientRequestException` from the site/file lookup and re-raised it as `SourceConnectionError("Site not found")`, discarding the underlying HTTP status and body. Every upstream failure — `401`, `403`, `404`, `429`, or `5xx` — therefore surfaced identically to users as `400 ... Site not found`, making auth / permission / throttle problems indistinguishable and undiagnosable. The retry classifier also matched on that already-rewritten string, so genuine `429` throttles never retried.

## Changes

- **Shared status→typed-error mapping.** Extracted the status handling into a module-level helper used by `SharepointIndexer` and `SharepointDownloader`: `401`/`403` → `UserAuthError`, `404` → `NotFoundError`, `429` → `RateLimitError`, `5xx` → `SourceConnectionNetworkError` (transient/connection-class, not a user fault). It logs the real `status_code`, response body, and Microsoft correlation headers (`request-id`, `client-request-id`, `x-ms-ags-diagnostic`, `SPRequestGuid`, `Retry-After`, `WWW-Authenticate`) **before** applying any label.
- **Pass the real status through on the error, not just the logs.** The raised error carries the true HTTP status code stamped on the instance (shadowing the typed class's default, so e.g. a `403` reports `403` rather than `UserAuthError`'s `401`, and an unmapped `4xx` reports its real code rather than `422`) and a truncated response body in its message — so the true condition is visible to callers, not only in logs.
- **Stop masking in the downloader.** `_fetch_file` no longer wraps with `@SourceConnectionNetworkError.wrap` (which coerced sibling typed errors back to `400`); the catch-all is replicated inline so genuinely unrecognized failures still surface as a `SourceConnectionNetworkError`, while typed errors carry their real status.
- **Indexer parity.** The indexer's site lookup, path resolution (`_get_target_drive_item`), and file listing (`get_files`) in `run_async` now route through the same shared helper instead of re-raising a generic `SourceConnectionError`, so index-time auth/throttle/not-found failures are classified consistently with the downloader.
- **Fix retry.** `retry_on_status_code` now reads the real status code stamped on the typed error (with type/string checks as fallback) instead of the masked message, so genuine `429`s and `503`s retry (matching the OneDrive downloader's throttle set) and then surface with their true status.

## Tests

- Downloader: real status passes through — `403` → `UserAuthError` reporting `403` (not `401`), an unmapped `4xx` (`409`) → `UserError` reporting its real code, `404` → `NotFoundError`, `429` → retries then `RateLimitError`, `5xx` → `SourceConnectionNetworkError` (not `UserError`) reporting `503`; `401` does not retry; an unknown non-HTTP exception → `SourceConnectionNetworkError` (the inline catch-all). The response body is carried on the error and truncated when long, and the real status + correlation headers are logged.
- Retry boundary: a retriable `503` followed by a non-retriable `403` stops on the `403` (two attempts) and surfaces it.
- Indexer `run_async`: site `401` → `UserAuthError`, `429` → `RateLimitError`, path-resolution `404` → `NotFoundError`, file-listing `429` → `RateLimitError`.
- Existing SharePoint + OneDrive unit tests pass (76 total); `ruff format`/`check` clean.

## Follow-ups (not in this PR)

- `UnstructuredIngestError.wrap` only re-raises the exact wrapped class, so a sibling typed error raised under **any** `.wrap` gets coerced to that class. A broader fix would let it pass through any `UnstructuredIngestError` (this would also fix the already-coerced `NotFoundError` in this file and OneDrive's `FileNotFoundError`).
- `run_async` makes blocking Office365 SDK calls (site resolution and `get_files().execute_query()`) on the event-loop thread. This predates this PR and is also present in the OneDrive path; wrapping them in `asyncio.to_thread` is orthogonal to this masking fix and best done as its own change.
- Classify the indexer's permissions batch fetch (`_fetch_permissions_raw`) — a raw `requests.post` to the Graph `$batch` endpoint (a different error surface: `requests` errors + per-item batch statuses) living in the shared `OnedriveIndexer` parent, so it needs its own classifier plus OneDrive coverage.
- Cache site resolution across files in a pipeline (currently one `get_by_url` per file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
