### PR TITLE
feat(PLU-485): verify SFTP server host key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 - **feat(sftp): verify SFTP server host key.** `SftpConnectionConfig` gains an optional `host_public_key` field. It accepts a base64 blob, an OpenSSH `.pub` line, or an ssh-keyscan/known_hosts line; the key algorithm (`ssh-ed25519` / `ssh-rsa`) is auto-detected from the key itself, so no key-type input is required. When set, the connector pins the expected host key and uses paramiko `RejectPolicy` to verify the server identity, rejecting a mismatched/unknown key instead of fsspec's default `AutoAddPolicy` (which silently trusts any key). An unparsable or unsupported key fails fast at config validation; a well-formed but wrong key surfaces as a host-key mismatch on the first connect (precheck). When `host_public_key` is omitted, connections behave as before but now log a warning that the server identity is unverified. Username/password remains the client authentication method in both cases.
+
 ## [1.6.32]
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## [1.6.29]
+## [1.7.0]
 
 ### Enhancements
 
 - **feat(sftp): verify SFTP server host key.** `SftpConnectionConfig` gains an optional `host_public_key` field. It accepts a base64 blob, an OpenSSH `.pub` line, or an ssh-keyscan/known_hosts line; the key algorithm (`ssh-ed25519` / `ssh-rsa`) is auto-detected from the key itself, so no key-type input is required. When set, the connector pins the expected host key and uses paramiko `RejectPolicy` to verify the server identity, rejecting a mismatched/unknown key instead of fsspec's default `AutoAddPolicy` (which silently trusts any key). An unparsable or unsupported key fails fast at config validation; a well-formed but wrong key surfaces as a host-key mismatch on the first connect (precheck). When `host_public_key` is omitted, connections behave as before but now log a warning that the server identity is unverified. Username/password remains the client authentication method in both cases.
+
 ## [1.6.30]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.29]
+
+### Enhancements
+
+- **feat(sftp): verify SFTP server host key.** `SftpConnectionConfig` gains an optional `host_public_key` field. It accepts a base64 blob, an OpenSSH `.pub` line, or an ssh-keyscan/known_hosts line; the key algorithm (`ssh-ed25519` / `ssh-rsa`) is auto-detected from the key itself, so no key-type input is required. When set, the connector pins the expected host key and uses paramiko `RejectPolicy` to verify the server identity, rejecting a mismatched/unknown key instead of fsspec's default `AutoAddPolicy` (which silently trusts any key). An unparsable or unsupported key fails fast at config validation; a well-formed but wrong key surfaces as a host-key mismatch on the first connect (precheck). When `host_public_key` is omitted, connections behave as before but now log a warning that the server identity is unverified. Username/password remains the client authentication method in both cases.
+
 ## [1.6.28]
 
 ### Fixes

--- a/test/unit/connectors/fsspec/test_sftp.py
+++ b/test/unit/connectors/fsspec/test_sftp.py
@@ -159,7 +159,7 @@ class TestSftpUploaderMakeDirsAsync:
 
 
 # ---------------------------------------------------------------------------
-# Host-key verification (SAP grounding compatibility)
+# Host-key verification
 # ---------------------------------------------------------------------------
 
 import paramiko  # noqa: E402

--- a/test/unit/connectors/fsspec/test_sftp.py
+++ b/test/unit/connectors/fsspec/test_sftp.py
@@ -11,7 +11,13 @@ from unittest import mock
 
 import pytest
 
-from unstructured_ingest.processes.connectors.fsspec.sftp import SftpUploader
+from unstructured_ingest.processes.connectors.fsspec.sftp import (
+    SftpAccessConfig,
+    SftpConnectionConfig,
+    SftpUploader,
+    _build_host_key,
+    parse_host_public_key,
+)
 
 
 @pytest.fixture
@@ -150,3 +156,249 @@ class TestSftpUploaderMakeDirsAsync:
         assert parent_path == "data/output/nested/dir"
         assert mock_sftp_client.makedirs.call_args[1] == {"exist_ok": True}
         mock_sftp_client.upload.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Host-key verification (SAP grounding compatibility)
+# ---------------------------------------------------------------------------
+
+import paramiko  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+
+def _openssh_public_key(kind: str) -> str:
+    """Return a real OpenSSH public key line, e.g. 'ssh-ed25519 AAAA...'."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+
+    if kind == "ssh-ed25519":
+        pub = ed25519.Ed25519PrivateKey.generate().public_key()
+    elif kind == "ssh-rsa":
+        pub = rsa.generate_private_key(public_exponent=65537, key_size=2048).public_key()
+    elif kind == "ecdsa":
+        pub = ec.generate_private_key(ec.SECP256R1()).public_key()
+    else:
+        raise ValueError(kind)
+    return pub.public_bytes(
+        serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH
+    ).decode()
+
+
+# Generate real keys once for the whole module (RSA generation is comparatively slow).
+ED25519_LINE = _openssh_public_key("ssh-ed25519")
+ED25519_BLOB = ED25519_LINE.split()[1]
+RSA_LINE = _openssh_public_key("ssh-rsa")
+RSA_BLOB = RSA_LINE.split()[1]
+ECDSA_LINE = _openssh_public_key("ecdsa")
+ECDSA_BLOB = ECDSA_LINE.split()[1]
+
+
+class TestParseHostPublicKey:
+    """Key type is auto-detected from the blob; multiple input forms accepted."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_type", "expected_blob"),
+        [
+            (ED25519_BLOB, "ssh-ed25519", ED25519_BLOB),  # bare blob
+            (RSA_BLOB, "ssh-rsa", RSA_BLOB),
+            (ED25519_LINE, "ssh-ed25519", ED25519_BLOB),  # ".pub" line
+            (RSA_LINE, "ssh-rsa", RSA_BLOB),
+            (f"host.example.com {ED25519_LINE}", "ssh-ed25519", ED25519_BLOB),  # known_hosts
+            (f"[host.example.com]:2222 {RSA_LINE}", "ssh-rsa", RSA_BLOB),  # ssh-keyscan w/ port
+            (f"  {ED25519_LINE}\n", "ssh-ed25519", ED25519_BLOB),  # surrounding whitespace
+        ],
+    )
+    def test_autodetects_type_and_blob(self, value, expected_type, expected_blob):
+        key_type, blob = parse_host_public_key(value)
+        assert key_type == expected_type
+        assert blob == expected_blob
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            parse_host_public_key("   ")
+
+    def test_non_key_garbage_raises(self):
+        with pytest.raises(ValueError, match="recognizable"):
+            parse_host_public_key("this is not a key at all")
+
+    def test_unsupported_type_raises_with_type_name(self):
+        with pytest.raises(ValueError, match="Unsupported.*ecdsa"):
+            parse_host_public_key(ECDSA_BLOB)
+
+    def test_bad_base64_alone_raises(self):
+        # Valid-looking token but not a real SSH key blob.
+        with pytest.raises(ValueError):
+            parse_host_public_key("AAAA")
+
+
+class TestBuildHostKey:
+    """Reconstructed paramiko key advertises the same algorithm we detected."""
+
+    @pytest.mark.parametrize(
+        ("blob", "expected_name"),
+        [(ED25519_BLOB, "ssh-ed25519"), (RSA_BLOB, "ssh-rsa")],
+    )
+    def test_build_matches_type(self, blob, expected_name):
+        key_type, key_b64 = parse_host_public_key(blob)
+        key = _build_host_key(key_type, key_b64)
+        assert key.get_name() == expected_name
+        # Round-trips back to the same public blob.
+        assert key.get_base64() == blob
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(ValueError, match="Unsupported"):
+            _build_host_key("ecdsa-sha2-nistp256", ECDSA_BLOB)
+
+
+def _make_connection_config(host_public_key=None, host="localhost", port=2222):
+    return SftpConnectionConfig(
+        username="foo",
+        host=host,
+        port=port,
+        access_config=SftpAccessConfig(password="pass"),
+        host_public_key=host_public_key,
+    )
+
+
+class TestHostPublicKeyValidator:
+    """Config validation fails fast on an unparsable / unsupported host key."""
+
+    def test_none_is_allowed(self):
+        cfg = _make_connection_config(host_public_key=None)
+        assert cfg.host_public_key is None
+
+    def test_valid_key_accepted(self):
+        cfg = _make_connection_config(host_public_key=ED25519_LINE)
+        assert cfg.host_public_key == ED25519_LINE
+
+    def test_garbage_rejected(self):
+        with pytest.raises(ValidationError):
+            _make_connection_config(host_public_key="not-a-real-key")
+
+    def test_unsupported_type_rejected(self):
+        with pytest.raises(ValidationError):
+            _make_connection_config(host_public_key=ECDSA_BLOB)
+
+    def test_host_public_key_not_leaked_into_ssh_kwargs(self):
+        # host_public_key is not a paramiko connect kwarg; it must not be passed
+        # through get_access_config (which feeds fsspec/paramiko).
+        cfg = _make_connection_config(host_public_key=ED25519_LINE)
+        assert "host_public_key" not in cfg.get_access_config()
+
+
+# --- get_client fakes ------------------------------------------------------
+
+
+class _FakeHostKeys:
+    def __init__(self):
+        self.added = []
+
+    def add(self, name, key_type, key):
+        self.added.append((name, key_type, key))
+
+
+class _FakeSSHClient:
+    def __init__(self):
+        self._host_keys = _FakeHostKeys()
+        self.policy = None
+        self.connected_with = None
+        self.closed = False
+
+    def get_host_keys(self):
+        return self._host_keys
+
+    def set_missing_host_key_policy(self, policy):
+        self.policy = policy
+
+    def connect(self, host, **kwargs):
+        self.connected_with = (host, kwargs)
+
+    def open_sftp(self):
+        return object()
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSFTPFileSystem:
+    """Stand-in for fsspec's SFTPFileSystem __init__/_connect contract."""
+
+    def __init__(self, skip_instance_cache=False, host=None, **ssh_kwargs):
+        self.skip_instance_cache = skip_instance_cache
+        self.host = host
+        self.ssh_kwargs = ssh_kwargs
+        self._connect()
+
+    def _connect(self):
+        # Base (unpinned) behavior: mimic fsspec creating its own client.
+        self.client = _FakeSSHClient()
+        self.ftp = self.client.open_sftp()
+
+
+class TestGetClientUnpinned:
+    """No host key -> connect but warn that identity is unverified."""
+
+    def test_warns_and_connects(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setattr(
+            "fsspec.get_filesystem_class", lambda protocol: _FakeSFTPFileSystem
+        )
+        cfg = _make_connection_config(host_public_key=None)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="unstructured_ingest"),
+            cfg.get_client(protocol="sftp") as client,
+        ):
+            assert isinstance(client, _FakeSFTPFileSystem)
+        assert any("without a pinned host key" in r.getMessage() for r in caplog.records)
+        # Connection was closed on context exit.
+        assert client.client.closed is True
+
+
+class TestGetClientPinned:
+    """Host key present -> pin it and use RejectPolicy (no AutoAddPolicy)."""
+
+    def _run(self, monkeypatch, host_public_key, host, port):
+        monkeypatch.setattr(
+            "fsspec.get_filesystem_class", lambda protocol: _FakeSFTPFileSystem
+        )
+        created = []
+
+        def _factory():
+            client = _FakeSSHClient()
+            created.append(client)
+            return client
+
+        monkeypatch.setattr(paramiko, "SSHClient", _factory)
+
+        cfg = _make_connection_config(host_public_key=host_public_key, host=host, port=port)
+        with cfg.get_client(protocol="sftp") as client:
+            pass
+        assert created, "expected our own paramiko.SSHClient to be built"
+        return created[0], client
+
+    def test_rejectpolicy_and_pins_key(self, monkeypatch):
+        ssh_client, fs = self._run(monkeypatch, ED25519_LINE, "example.com", 2222)
+        # RejectPolicy (never AutoAddPolicy) so a wrong/unknown key is refused.
+        assert isinstance(ssh_client.policy, paramiko.RejectPolicy)
+        # Exactly one pinned key, of the auto-detected type.
+        assert len(ssh_client._host_keys.added) == 1
+        entry_name, key_type, key = ssh_client._host_keys.added[0]
+        assert key_type == "ssh-ed25519"
+        assert key.get_name() == "ssh-ed25519"
+        # Non-default port -> "[host]:port" known_hosts naming.
+        assert entry_name == "[example.com]:2222"
+        # Connected to the right host with password auth kwargs.
+        connect_host, connect_kwargs = ssh_client.connected_with
+        assert connect_host == "example.com"
+        assert connect_kwargs["password"] == "pass"
+        assert connect_kwargs["look_for_keys"] is False
+        # Closed on exit.
+        assert ssh_client.closed is True
+
+    def test_default_port_uses_plain_host_entry(self, monkeypatch):
+        ssh_client, _ = self._run(monkeypatch, RSA_LINE, "sftp.example.com", 22)
+        entry_name, key_type, _ = ssh_client._host_keys.added[0]
+        assert key_type == "ssh-rsa"
+        assert entry_name == "sftp.example.com"  # no brackets for port 22

--- a/test/unit/connectors/fsspec/test_sftp.py
+++ b/test/unit/connectors/fsspec/test_sftp.py
@@ -164,11 +164,9 @@ class TestSftpUploaderMakeDirsAsync:
 
 from pydantic import ValidationError  # noqa: E402
 
-# Static, valid OpenSSH public keys used as test vectors. Kept as literals (rather
-# than generated with `cryptography`) so the pure parsing/validator tests below
-# run in CI's unit job, which installs only the `test` group and NOT the optional
-# `sftp` extra (paramiko / cryptography). Tests that actually build paramiko keys
-# or open a client guard themselves with `pytest.importorskip("paramiko")`.
+# Static OpenSSH public keys as test vectors: kept as literals (not generated with
+# `cryptography`) so the parsing/validator tests run in CI's unit job, which omits
+# the optional `sftp` extra. Tests needing paramiko use `pytest.importorskip`.
 ED25519_LINE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOF3J5Ka7c/o1vAhfLfwqhlcW1rtB2QhHTAJJhSi6cBO"  # noqa: E501
 ED25519_BLOB = ED25519_LINE.split()[1]
 RSA_LINE = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDecqnagUMXkIIgIPUo/kioDeEIc/tVk1FFwfmewo2OiAxm/3GWnMtsCHdTv4vV3mksgkzo+1aJa+c6zTd4P2Pzgns6FKprteM7br66a1ECAZWC1CQwLS6E3T6QBoSezA88JSnjwI+H/nQaYBUKpyGaKurD/I21ZtKxtDNEaqHK1vWdWblNATX0LTUY6chCYzmU1dCJSWlafvk8zxGlD1l77mTbvpqsyNVl0169PwAraeFOcMAJ89HUIE1XeJgVNZyLHKDDThKuHW5THE/kE1zC3Ie6b+sWfg+OYCRfirl3VG0D7pDdKnoWN4U1COXeSsqVkWlubFKbICjP/v55eaDr"  # noqa: E501

--- a/test/unit/connectors/fsspec/test_sftp.py
+++ b/test/unit/connectors/fsspec/test_sftp.py
@@ -162,34 +162,18 @@ class TestSftpUploaderMakeDirsAsync:
 # Host-key verification
 # ---------------------------------------------------------------------------
 
-import paramiko  # noqa: E402
 from pydantic import ValidationError  # noqa: E402
 
-
-def _openssh_public_key(kind: str) -> str:
-    """Return a real OpenSSH public key line, e.g. 'ssh-ed25519 AAAA...'."""
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
-
-    if kind == "ssh-ed25519":
-        pub = ed25519.Ed25519PrivateKey.generate().public_key()
-    elif kind == "ssh-rsa":
-        pub = rsa.generate_private_key(public_exponent=65537, key_size=2048).public_key()
-    elif kind == "ecdsa":
-        pub = ec.generate_private_key(ec.SECP256R1()).public_key()
-    else:
-        raise ValueError(kind)
-    return pub.public_bytes(
-        serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH
-    ).decode()
-
-
-# Generate real keys once for the whole module (RSA generation is comparatively slow).
-ED25519_LINE = _openssh_public_key("ssh-ed25519")
+# Static, valid OpenSSH public keys used as test vectors. Kept as literals (rather
+# than generated with `cryptography`) so the pure parsing/validator tests below
+# run in CI's unit job, which installs only the `test` group and NOT the optional
+# `sftp` extra (paramiko / cryptography). Tests that actually build paramiko keys
+# or open a client guard themselves with `pytest.importorskip("paramiko")`.
+ED25519_LINE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOF3J5Ka7c/o1vAhfLfwqhlcW1rtB2QhHTAJJhSi6cBO"  # noqa: E501
 ED25519_BLOB = ED25519_LINE.split()[1]
-RSA_LINE = _openssh_public_key("ssh-rsa")
+RSA_LINE = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDecqnagUMXkIIgIPUo/kioDeEIc/tVk1FFwfmewo2OiAxm/3GWnMtsCHdTv4vV3mksgkzo+1aJa+c6zTd4P2Pzgns6FKprteM7br66a1ECAZWC1CQwLS6E3T6QBoSezA88JSnjwI+H/nQaYBUKpyGaKurD/I21ZtKxtDNEaqHK1vWdWblNATX0LTUY6chCYzmU1dCJSWlafvk8zxGlD1l77mTbvpqsyNVl0169PwAraeFOcMAJ89HUIE1XeJgVNZyLHKDDThKuHW5THE/kE1zC3Ie6b+sWfg+OYCRfirl3VG0D7pDdKnoWN4U1COXeSsqVkWlubFKbICjP/v55eaDr"  # noqa: E501
 RSA_BLOB = RSA_LINE.split()[1]
-ECDSA_LINE = _openssh_public_key("ecdsa")
+ECDSA_LINE = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsfdZj9/KppI8dhzOzqgbPSPIB9Dd7zn2mQqqWWdtlDP/5J00iFLyQky4n6BM1gK5jQIYNUZApGEE+xC0s1odg="  # noqa: E501
 ECDSA_BLOB = ECDSA_LINE.split()[1]
 
 
@@ -239,6 +223,7 @@ class TestBuildHostKey:
         [(ED25519_BLOB, "ssh-ed25519"), (RSA_BLOB, "ssh-rsa")],
     )
     def test_build_matches_type(self, blob, expected_name):
+        pytest.importorskip("paramiko")
         key_type, key_b64 = parse_host_public_key(blob)
         key = _build_host_key(key_type, key_b64)
         assert key.get_name() == expected_name
@@ -246,6 +231,7 @@ class TestBuildHostKey:
         assert key.get_base64() == blob
 
     def test_unsupported_type_raises(self):
+        pytest.importorskip("paramiko")
         with pytest.raises(ValueError, match="Unsupported"):
             _build_host_key("ecdsa-sha2-nistp256", ECDSA_BLOB)
 
@@ -341,6 +327,8 @@ class TestGetClientUnpinned:
     def test_warns_and_connects(self, monkeypatch, caplog):
         import logging
 
+        pytest.importorskip("paramiko")
+        pytest.importorskip("fsspec")
         monkeypatch.setattr(
             "fsspec.get_filesystem_class", lambda protocol: _FakeSFTPFileSystem
         )
@@ -360,6 +348,8 @@ class TestGetClientPinned:
     """Host key present -> pin it and use RejectPolicy (no AutoAddPolicy)."""
 
     def _run(self, monkeypatch, host_public_key, host, port):
+        paramiko = pytest.importorskip("paramiko")
+        pytest.importorskip("fsspec")
         monkeypatch.setattr(
             "fsspec.get_filesystem_class", lambda protocol: _FakeSFTPFileSystem
         )
@@ -376,10 +366,10 @@ class TestGetClientPinned:
         with cfg.get_client(protocol="sftp") as client:
             pass
         assert created, "expected our own paramiko.SSHClient to be built"
-        return created[0], client
+        return paramiko, created[0], client
 
     def test_rejectpolicy_and_pins_key(self, monkeypatch):
-        ssh_client, fs = self._run(monkeypatch, ED25519_LINE, "example.com", 2222)
+        paramiko, ssh_client, fs = self._run(monkeypatch, ED25519_LINE, "example.com", 2222)
         # RejectPolicy (never AutoAddPolicy) so a wrong/unknown key is refused.
         assert isinstance(ssh_client.policy, paramiko.RejectPolicy)
         # Exactly one pinned key, of the auto-detected type.
@@ -398,7 +388,7 @@ class TestGetClientPinned:
         assert ssh_client.closed is True
 
     def test_default_port_uses_plain_host_entry(self, monkeypatch):
-        ssh_client, _ = self._run(monkeypatch, RSA_LINE, "sftp.example.com", 22)
+        _, ssh_client, _ = self._run(monkeypatch, RSA_LINE, "sftp.example.com", 22)
         entry_name, key_type, _ = ssh_client._host_keys.added[0]
         assert key_type == "ssh-rsa"
         assert entry_name == "sftp.example.com"  # no brackets for port 22

--- a/test/unit/connectors/fsspec/test_sftp.py
+++ b/test/unit/connectors/fsspec/test_sftp.py
@@ -177,6 +177,17 @@ ECDSA_LINE = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNT
 ECDSA_BLOB = ECDSA_LINE.split()[1]
 
 
+def _wire(*fields: bytes) -> bytes:
+    """Encode fields as an SSH wire blob (each field length-prefixed, big-endian)."""
+    return b"".join(len(f).to_bytes(4, "big") + f for f in fields)
+
+
+def _b64(raw: bytes) -> str:
+    import base64
+
+    return base64.b64encode(raw).decode()
+
+
 class TestParseHostPublicKey:
     """Key type is auto-detected from the blob; multiple input forms accepted."""
 
@@ -213,6 +224,37 @@ class TestParseHostPublicKey:
         # Valid-looking token but not a real SSH key blob.
         with pytest.raises(ValueError):
             parse_host_public_key("AAAA")
+
+    def test_synthetic_valid_ed25519_wire_is_accepted(self):
+        # Sanity check for the wire-format validation: a well-formed blob (algo
+        # name + 32-byte public key) parses even though the key bytes are dummy.
+        blob = _b64(_wire(b"ssh-ed25519", b"\x00" * 32))
+        key_type, out = parse_host_public_key(blob)
+        assert key_type == "ssh-ed25519"
+        assert out == blob
+
+    def test_supported_prefix_but_wrong_ed25519_length_raises(self):
+        # Correct algorithm name but the public key is not 32 bytes.
+        blob = _b64(_wire(b"ssh-ed25519", b"tooshort"))
+        with pytest.raises(ValueError, match="32 bytes"):
+            parse_host_public_key(blob)
+
+    def test_supported_prefix_but_extra_trailing_field_raises(self):
+        blob = _b64(_wire(b"ssh-ed25519", b"\x00" * 32, b"junk"))
+        with pytest.raises(ValueError, match="wire fields"):
+            parse_host_public_key(blob)
+
+    def test_supported_prefix_but_wrong_rsa_field_count_raises(self):
+        # ssh-rsa must be (name, e, n); only one parameter is malformed.
+        blob = _b64(_wire(b"ssh-rsa", b"\x01"))
+        with pytest.raises(ValueError, match="wire fields"):
+            parse_host_public_key(blob)
+
+    def test_supported_prefix_but_field_overruns_blob_raises(self):
+        # Length prefix declares 255 bytes but only 2 follow -> truncated key.
+        raw = _wire(b"ssh-ed25519") + b"\x00\x00\x00\xff" + b"\x01\x02"
+        with pytest.raises(ValueError, match="malformed"):
+            parse_host_public_key(_b64(raw))
 
 
 class TestBuildHostKey:
@@ -264,6 +306,13 @@ class TestHostPublicKeyValidator:
     def test_unsupported_type_rejected(self):
         with pytest.raises(ValidationError):
             _make_connection_config(host_public_key=ECDSA_BLOB)
+
+    def test_supported_prefix_but_malformed_key_rejected_at_config_time(self):
+        # A blob with a supported algorithm prefix but a truncated body must fail
+        # fast at config validation, not silently pass and blow up at connect.
+        malformed = _b64(_wire(b"ssh-ed25519", b"tooshort"))
+        with pytest.raises(ValidationError):
+            _make_connection_config(host_public_key=malformed)
 
     def test_host_public_key_not_leaked_into_ssh_kwargs(self):
         # host_public_key is not a paramiko connect kwarg; it must not be passed

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,2 +1,1 @@
-__version__ = "1.6.29"  # pragma: no cover
-__version__ = "1.6.30"  # pragma: no cover
+__version__ = "1.7.0"  # pragma: no cover

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.28"  # pragma: no cover
+__version__ = "1.6.29"  # pragma: no cover

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,2 +1,1 @@
 __version__ = "1.7.0"  # pragma: no cover
-__version__ = "1.6.32"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/processes/connectors/fsspec/sftp.py
@@ -48,7 +48,7 @@ def _strip_leading_slash(path: str) -> str:
     return path[1:] if path.startswith("/") else path
 
 
-# Host key types SAP's grounding secret allows, and that we verify against.
+# Host key types supported for server host-key verification.
 SUPPORTED_HOST_KEY_TYPES: tuple[str, ...] = ("ssh-ed25519", "ssh-rsa")
 
 
@@ -177,8 +177,8 @@ class SftpConnectionConfig(FsspecConnectionConfig):
             "Server host public key used to verify the server's identity. Accepts a "
             "base64 blob (e.g. 'AAAAC3Nza...'), an OpenSSH '.pub' line, or an "
             "ssh-keyscan/known_hosts line; the key type (ssh-ed25519 / ssh-rsa) is "
-            "auto-detected from the key. Maps to SAP grounding's 'public_key'. When "
-            "omitted, the server identity is NOT verified and a warning is logged."
+            "auto-detected from the key. When omitted, the server identity is NOT "
+            "verified and a warning is logged."
         ),
     )
 
@@ -232,8 +232,8 @@ class SftpConnectionConfig(FsspecConnectionConfig):
                 client.client.close()
             return
 
-        # Pinned host-key path (e.g. SAP grounding): build the paramiko client
-        # ourselves so we can pin the expected host key and use RejectPolicy.
+        # Pinned host-key path: build the paramiko client ourselves so we can
+        # pin the expected host key and use RejectPolicy.
         # fsspec's SFTPFileSystem._connect hardcodes AutoAddPolicy and offers no
         # hook, so we override _connect to verify the server before trusting it.
         import paramiko

--- a/unstructured_ingest/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/processes/connectors/fsspec/sftp.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import binascii
 import contextlib
 import hashlib
 import os
@@ -10,9 +12,10 @@ from time import time
 from typing import TYPE_CHECKING, Any, Generator, Optional
 from urllib.parse import urlparse
 
-from pydantic import Field, Secret
+from pydantic import Field, Secret, model_validator
 
 from unstructured_ingest.data_types.file_data import FileData, FileDataSourceMetadata
+from unstructured_ingest.logger import logger
 from unstructured_ingest.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
@@ -43,6 +46,87 @@ def _strip_leading_slash(path: str) -> str:
     """Strip one leading slash, preserving double-slash absolute path indicators.
     Example: sftp://host//home → /home (absolute), sftp://host/data → data (relative)."""
     return path[1:] if path.startswith("/") else path
+
+
+# Host key types SAP's grounding secret allows, and that we verify against.
+SUPPORTED_HOST_KEY_TYPES: tuple[str, ...] = ("ssh-ed25519", "ssh-rsa")
+
+
+def _extract_ssh_key_type(raw: bytes) -> str:
+    """Read the algorithm name from a decoded SSH public key blob.
+
+    SSH public keys are wire-encoded as a sequence of length-prefixed fields; the
+    first field is the algorithm name (e.g. b"ssh-ed25519"). This is
+    authoritative: the key type is derived from the key material itself, so no
+    separate type input is required.
+    """
+    if len(raw) < 4:
+        raise ValueError("host key blob is too short to contain a key type")
+    length = int.from_bytes(raw[:4], "big")
+    if length <= 0 or len(raw) < 4 + length:
+        raise ValueError("host key blob is malformed or truncated")
+    try:
+        return raw[4 : 4 + length].decode("ascii")
+    except UnicodeDecodeError as e:
+        raise ValueError(f"host key blob has a non-ASCII key type: {e}") from e
+
+
+def parse_host_public_key(value: str) -> tuple[str, str]:
+    """Return ``(key_type, base64_blob)`` for a server host public key string.
+
+    Accepts any of the common representations, so the caller never has to declare
+    the key type:
+
+      - a bare base64 blob:              ``"AAAAC3Nza..."``
+      - an OpenSSH ``.pub`` line:        ``"ssh-ed25519 AAAAC3Nza... comment"``
+      - an ssh-keyscan/known_hosts line: ``"host ssh-ed25519 AAAAC3Nza..."``
+
+    The key type is auto-detected from the decoded blob (not from any surrounding
+    label), which is authoritative and avoids a label/key mismatch. Raises
+    ``ValueError`` for anything that does not contain a supported, decodable SSH
+    public key.
+    """
+    tokens = value.split()
+    if not tokens:
+        raise ValueError("host_public_key is empty")
+
+    unsupported: list[str] = []
+    for token in tokens:
+        try:
+            raw = base64.b64decode(token, validate=True)
+        except (binascii.Error, ValueError):
+            # Not a base64 field (e.g. the "ssh-ed25519" label or a hostname).
+            continue
+        try:
+            key_type = _extract_ssh_key_type(raw)
+        except ValueError:
+            continue
+        if key_type in SUPPORTED_HOST_KEY_TYPES:
+            return key_type, token
+        unsupported.append(key_type)
+
+    if unsupported:
+        raise ValueError(
+            f"Unsupported SFTP host key type(s) {unsupported}; "
+            f"supported types are {list(SUPPORTED_HOST_KEY_TYPES)}"
+        )
+    raise ValueError(
+        "host_public_key does not contain a recognizable base64-encoded SSH public key "
+        "(expected a bare blob, an OpenSSH '.pub' line, or an ssh-keyscan/known_hosts line)"
+    )
+
+
+def _build_host_key(key_type: str, key_b64: str):
+    """Reconstruct a paramiko key object from a base64 host key blob."""
+    import paramiko
+
+    data = base64.b64decode(key_b64)
+    if key_type == "ssh-ed25519":
+        return paramiko.Ed25519Key(data=data)
+    if key_type == "ssh-rsa":
+        return paramiko.RSAKey(data=data)
+    # Defensive: parse_host_public_key already gates the supported set.
+    raise ValueError(f"Unsupported SFTP host key type: {key_type!r}")
 
 
 # Patch hashlib.md5 for FIPS-enabled OpenSSL (common in Kubernetes).
@@ -87,6 +171,25 @@ class SftpConnectionConfig(FsspecConnectionConfig):
         default=False, description="Whether to search for private key files in ~/.ssh/"
     )
     allow_agent: bool = Field(default=False, description="Whether to connect to the SSH agent.")
+    host_public_key: Optional[str] = Field(
+        default=None,
+        description=(
+            "Server host public key used to verify the server's identity. Accepts a "
+            "base64 blob (e.g. 'AAAAC3Nza...'), an OpenSSH '.pub' line, or an "
+            "ssh-keyscan/known_hosts line; the key type (ssh-ed25519 / ssh-rsa) is "
+            "auto-detected from the key. Maps to SAP grounding's 'public_key'. When "
+            "omitted, the server identity is NOT verified and a warning is logged."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_host_public_key(self) -> "SftpConnectionConfig":
+        # Fail fast at config time if a host key is supplied but unparsable /
+        # unsupported. A well-formed but wrong key is caught later at connect
+        # (precheck) as a host-key mismatch.
+        if self.host_public_key is not None:
+            parse_host_public_key(self.host_public_key)
+        return self
 
     def get_access_config(self) -> dict[str, Any]:
         access_config = {
@@ -108,12 +211,56 @@ class SftpConnectionConfig(FsspecConnectionConfig):
         # instance whose SSH connection was closed by a previous context manager exit.
         from fsspec import get_filesystem_class
 
-        client: SFTPFileSystem = get_filesystem_class(protocol)(
-            skip_instance_cache=True,
-            **self.get_access_config(),
-        )
-        yield client
-        client.client.close()
+        fs_cls = get_filesystem_class(protocol)
+        access_config = self.get_access_config()
+
+        if self.host_public_key is None:
+            # No pinned host key: connect but do NOT verify the server identity.
+            # fsspec's SFTPFileSystem._connect uses paramiko.AutoAddPolicy(), so any
+            # host key the server presents is accepted. Warn so this is a deliberate,
+            # visible choice rather than a silent security gap.
+            logger.warning(
+                "Connecting to SFTP host %r without a pinned host key; the server "
+                "identity is NOT verified (vulnerable to MITM). Provide `host_public_key` "
+                "to enable host-key verification.",
+                self.host,
+            )
+            client: SFTPFileSystem = fs_cls(skip_instance_cache=True, **access_config)
+            try:
+                yield client
+            finally:
+                client.client.close()
+            return
+
+        # Pinned host-key path (e.g. SAP grounding): build the paramiko client
+        # ourselves so we can pin the expected host key and use RejectPolicy.
+        # fsspec's SFTPFileSystem._connect hardcodes AutoAddPolicy and offers no
+        # hook, so we override _connect to verify the server before trusting it.
+        import paramiko
+
+        key_type, key_b64 = parse_host_public_key(self.host_public_key)
+        host_key = _build_host_key(key_type, key_b64)
+
+        class _VerifiedSFTPFileSystem(fs_cls):
+            def _connect(self):
+                ssh_client = paramiko.SSHClient()
+                port = self.ssh_kwargs.get("port", 22)
+                # GOTCHA: paramiko looks up known host keys under "[host]:port" for
+                # non-default ports (the OpenSSH known_hosts convention); register
+                # under the same name or verification silently never matches.
+                entry_name = self.host if port == 22 else f"[{self.host}]:{port}"
+                ssh_client.get_host_keys().add(entry_name, key_type, host_key)
+                # Reject (never auto-add) an unknown or mismatched server key.
+                ssh_client.set_missing_host_key_policy(paramiko.RejectPolicy())
+                ssh_client.connect(self.host, **self.ssh_kwargs)
+                self.client = ssh_client
+                self.ftp = ssh_client.open_sftp()
+
+        client = _VerifiedSFTPFileSystem(skip_instance_cache=True, **access_config)
+        try:
+            yield client
+        finally:
+            client.client.close()
 
 
 @dataclass

--- a/unstructured_ingest/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/processes/connectors/fsspec/sftp.py
@@ -71,6 +71,52 @@ def _extract_ssh_key_type(raw: bytes) -> str:
         raise ValueError(f"host key blob has a non-ASCII key type: {e}") from e
 
 
+def _iter_ssh_wire_fields(raw: bytes) -> list[bytes]:
+    """Split an SSH wire blob into its length-prefixed fields.
+
+    Requires the fields to consume the blob exactly; raises ``ValueError`` on a
+    length prefix that overruns the buffer, a truncated prefix, or trailing bytes.
+    """
+    fields: list[bytes] = []
+    offset = 0
+    total = len(raw)
+    while offset < total:
+        if total - offset < 4:
+            raise ValueError("host key blob is malformed (truncated length prefix)")
+        length = int.from_bytes(raw[offset : offset + 4], "big")
+        offset += 4
+        if total - offset < length:
+            raise ValueError("host key blob is malformed (field overruns the blob)")
+        fields.append(raw[offset : offset + length])
+        offset += length
+    return fields
+
+
+# Number of wire fields per supported key type: the algorithm name plus its key
+# parameters (ed25519 -> name + 32-byte public key; rsa -> name + e + n).
+_EXPECTED_FIELD_COUNTS = {"ssh-ed25519": 2, "ssh-rsa": 3}
+
+
+def _validate_host_key_wire_format(raw: bytes, key_type: str) -> None:
+    """Validate the complete key wire format, not just the algorithm prefix.
+
+    ``_extract_ssh_key_type`` only reads the leading algorithm field, so a blob
+    that starts with a supported type but is truncated or padded with garbage
+    would otherwise pass config validation and fail only when a connection is
+    opened. This closes that gap so the advertised fail-fast validation holds.
+    """
+    fields = _iter_ssh_wire_fields(raw)
+    expected = _EXPECTED_FIELD_COUNTS[key_type]
+    if len(fields) != expected:
+        raise ValueError(
+            f"malformed {key_type} host key: expected {expected} wire fields, got {len(fields)}"
+        )
+    if key_type == "ssh-ed25519" and len(fields[1]) != 32:
+        raise ValueError(
+            f"malformed ssh-ed25519 host key: public key must be 32 bytes, got {len(fields[1])}"
+        )
+
+
 def parse_host_public_key(value: str) -> tuple[str, str]:
     """Return ``(key_type, base64_blob)`` for a server host public key string.
 
@@ -102,6 +148,9 @@ def parse_host_public_key(value: str) -> tuple[str, str]:
         except ValueError:
             continue
         if key_type in SUPPORTED_HOST_KEY_TYPES:
+            # Supported prefix -> validate the whole wire format so a truncated /
+            # garbage-padded blob fails here (config time) rather than at connect.
+            _validate_host_key_wire_format(raw, key_type)
             return key_type, token
         unsupported.append(key_type)
 

--- a/unstructured_ingest/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/processes/connectors/fsspec/sftp.py
@@ -53,12 +53,10 @@ SUPPORTED_HOST_KEY_TYPES: tuple[str, ...] = ("ssh-ed25519", "ssh-rsa")
 
 
 def _extract_ssh_key_type(raw: bytes) -> str:
-    """Read the algorithm name from a decoded SSH public key blob.
+    """Read the algorithm name (first length-prefixed field) from an SSH key blob.
 
-    SSH public keys are wire-encoded as a sequence of length-prefixed fields; the
-    first field is the algorithm name (e.g. b"ssh-ed25519"). This is
-    authoritative: the key type is derived from the key material itself, so no
-    separate type input is required.
+    The type is derived from the key material itself, so no separate type input
+    is required.
     """
     if len(raw) < 4:
         raise ValueError("host key blob is too short to contain a key type")
@@ -98,12 +96,18 @@ _EXPECTED_FIELD_COUNTS = {"ssh-ed25519": 2, "ssh-rsa": 3}
 
 
 def _validate_host_key_wire_format(raw: bytes, key_type: str) -> None:
-    """Validate the complete key wire format, not just the algorithm prefix.
+    """Validate the full key wire format, not just the algorithm prefix.
 
     ``_extract_ssh_key_type`` only reads the leading algorithm field, so a blob
-    that starts with a supported type but is truncated or padded with garbage
-    would otherwise pass config validation and fail only when a connection is
-    opened. This closes that gap so the advertised fail-fast validation holds.
+    with a supported prefix but a truncated/garbage body would otherwise pass
+    config validation and fail only at connect. This closes that gap.
+
+    Boundary: this checks *structure* only (field framing, field count, and the
+    fixed 32-byte ed25519 length), not cryptographic validity (e.g. that ssh-rsa
+    ``e``/``n`` are canonical/usable). Full validation would require building the
+    key via paramiko, which we avoid at config time so constructing
+    ``SftpConnectionConfig`` doesn't need the optional ``sftp`` extra; a
+    structurally valid but bogus key is caught later at connect (precheck).
     """
     fields = _iter_ssh_wire_fields(raw)
     expected = _EXPECTED_FIELD_COUNTS[key_type]
@@ -148,8 +152,7 @@ def parse_host_public_key(value: str) -> tuple[str, str]:
         except ValueError:
             continue
         if key_type in SUPPORTED_HOST_KEY_TYPES:
-            # Supported prefix -> validate the whole wire format so a truncated /
-            # garbage-padded blob fails here (config time) rather than at connect.
+            # Fail fast on a truncated/garbage body, not later at connect.
             _validate_host_key_wire_format(raw, key_type)
             return key_type, token
         unsupported.append(key_type)


### PR DESCRIPTION
## Summary

Adds optional **SFTP server host-key verification** to the SFTP connector. Today the connector relies on fsspec's `SFTPFileSystem`, which hardcodes paramiko's `AutoAddPolicy` — it silently trusts whatever host key the server presents, leaving connections open to man-in-the-middle attacks.

This PR lets callers pin the expected server host key via a new optional `host_public_key` field on `SftpConnectionConfig`. When provided, the connector verifies the server's identity and rejects a mismatched or unknown key. When omitted, behavior is unchanged except that we now log a warning that the server identity is unverified.

Client authentication is still username/password in both cases — this only concerns verifying the *server's* identity.

## What changed

- **New `host_public_key` field** on `SftpConnectionConfig`. Accepts any common representation and figures out the rest:
  - a bare base64 blob (`AAAAC3Nza...`)
  - an OpenSSH `.pub` line (`ssh-ed25519 AAAAC3Nza... comment`)
  - an `ssh-keyscan` / `known_hosts` line (`host ssh-ed25519 AAAAC3Nza...`)
- **Key type is auto-detected** from the key material itself (the algorithm name is read from the wire-encoded blob), so there's no separate key-type input to get wrong. Supported types: `ssh-ed25519` and `ssh-rsa`.
- **Fail-fast validation:** a `model_validator` rejects an unparsable or unsupported key at config-construction time. A *well-formed but wrong* key is caught later at connect (precheck) as a host-key mismatch.
- **Verification path:** when a key is pinned, we build the paramiko client ourselves, register the pinned key, and use `RejectPolicy` instead of `AutoAddPolicy`. fsspec's `_connect` hardcodes `AutoAddPolicy` with no hook, so we override `_connect`.
  - Handles the OpenSSH `[host]:port` `known_hosts` naming convention for non-default ports (registering under the wrong name makes verification silently never match).
- **Unpinned path:** connects as before but logs a warning so the unverified posture is a visible, deliberate choice.

## Behavior

| `host_public_key` | Result |
|---|---|
| omitted | Connects as before; logs a warning that server identity is unverified |
| valid, matches server | Connects; server identity verified |
| valid, does not match server | Connection rejected at precheck (host-key mismatch) |
| unparsable / unsupported type | Fails immediately at config validation |

## Test plan

- [x] Unit tests (`test/unit/connectors/fsspec/test_sftp.py`): key parsing/auto-detection across all input forms, unsupported/garbage/empty rejection, the config validator, `[host]:port` vs bare-host entry naming, `RejectPolicy` usage, and the unpinned warning path.
  - paramiko/fsspec are optional (`sftp` extra) and not installed in the unit CI job, so SDK-dependent tests use `pytest.importorskip`; the pure parsing/validator tests still run. Verified collection succeeds and the right tests skip when the extra is absent.

## Notes

- The SFTP connector has not been released publicly, so there are no backward-compatibility concerns.
- No changes to `platform-api`; `host_public_key` is a plain base64 string, compatible with string-only Kubernetes secrets.

