### PR TITLE
feat(slack): emit Slack indexer records newest-first within each channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.29]
+
+### Enhancements
+
+- **feat: Slack indexer emits records newest-first within each channel.** `SlackIndexer.run` sorts each channel's records (conversation-day packages and file attachments) by `metadata.version` descending before yielding, so the most recent content is indexed first.
+
 ## [1.6.28]
 
 ### Fixes

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -708,6 +708,58 @@ def test_slack_edited_message_bumps_version_via_edited_ts():
     assert conversations[0].metadata.version == edited_ts
 
 
+def test_slack_indexer_yields_days_most_recent_first():
+    """Within a channel, conversation-day packages are emitted newest day first."""
+    conversations = _conversations(
+        _run_indexer(
+            [
+                {"ts": _ts(DAY_1, hours=1)},
+                {"ts": _ts(DAY_2, hours=1)},
+            ]
+        )
+    )
+
+    assert [c.metadata.record_locator["day"] for c in conversations] == [
+        _day_str(DAY_2),
+        _day_str(DAY_1),
+    ]
+
+
+def test_slack_indexer_interleaves_recent_file_ahead_of_older_conversation():
+    """A file on a recent message sorts ahead of an older day's conversation package."""
+    old_ts = _ts(DAY_1, hours=1)
+    recent_ts = _ts(DAY_2, hours=1)
+    records = _run_indexer(
+        [
+            {"ts": old_ts, "text": "old message"},
+            {
+                "ts": recent_ts,
+                "text": "recent message with file",
+                "files": [
+                    {
+                        "id": "F123",
+                        "name": "report.pdf",
+                        "url_private_download": "https://files.slack.com/report.pdf",
+                    }
+                ],
+            },
+        ]
+    )
+
+    versions = [float(fd.metadata.version) for fd in records]
+    assert versions == sorted(versions, reverse=True)
+
+    file_index = next(
+        i for i, fd in enumerate(records) if fd.source_identifiers.filename == "F123-report.pdf"
+    )
+    old_conversation_index = next(
+        i
+        for i, fd in enumerate(records)
+        if fd.metadata.record_locator.get("day") == _day_str(DAY_1)
+    )
+    assert file_index < old_conversation_index
+
+
 def test_slack_new_day_creates_new_identifier():
     """Messages on a new UTC day create a separate package with a new identifier."""
     conversations = _conversations(

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -760,6 +760,29 @@ def test_slack_indexer_interleaves_recent_file_ahead_of_older_conversation():
     assert file_index < old_conversation_index
 
 
+def _file_data_with_version(version) -> FileData:
+    return FileData(
+        identifier="id",
+        connector_type="slack",
+        source_identifiers=SourceIdentifiers(filename="f.xml", fullpath="f.xml"),
+        metadata=FileDataSourceMetadata(version=version),
+    )
+
+
+def test_recency_key_parses_version_timestamp():
+    assert SlackIndexer._recency_key(_file_data_with_version("1710000000.000100")) == pytest.approx(
+        1710000000.000100
+    )
+
+
+def test_recency_key_falls_back_to_zero_for_missing_version():
+    assert SlackIndexer._recency_key(_file_data_with_version(None)) == 0.0
+
+
+def test_recency_key_falls_back_to_zero_for_unparseable_version():
+    assert SlackIndexer._recency_key(_file_data_with_version("not-a-timestamp")) == 0.0
+
+
 def test_slack_new_day_creates_new_identifier():
     """Messages on a new UTC day create a separate package with a new identifier."""
     conversations = _conversations(

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.28"  # pragma: no cover
+__version__ = "1.6.29"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -298,10 +298,9 @@ class SlackIndexer(Indexer):
     def _recency_key(file_data: FileData) -> float:
         # NOTE: version is set for both record kinds (conversation package and file), so it
         # orders them against each other.
-        version = file_data.metadata.version if file_data.metadata else None
         try:
-            return float(version)
-        except (TypeError, ValueError):
+            return float(file_data.metadata.version)
+        except (TypeError, builtins.ValueError):
             return 0.0
 
     def _messages_to_file_data(

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -248,11 +248,14 @@ class SlackIndexer(Indexer):
             if not messages:
                 continue
 
-            for day, day_messages in self._group_messages_by_day(messages).items():
-                yield self._messages_to_file_data(day_messages, channel, client, day)
-
-            for file_data in self._message_files_to_file_data(messages, channel):
-                yield file_data
+            # NOTE: Emit a channel's records newest-first so recent content is processed first.
+            records = [
+                self._messages_to_file_data(day_messages, channel, client, day)
+                for day, day_messages in self._group_messages_by_day(messages).items()
+            ]
+            records.extend(self._message_files_to_file_data(messages, channel))
+            records.sort(key=self._recency_key, reverse=True)
+            yield from records
 
     @staticmethod
     def _message_day(message: dict) -> Optional[str]:
@@ -290,6 +293,16 @@ class SlackIndexer(Indexer):
         if not candidates:
             return None
         return max(candidates, key=float)
+
+    @staticmethod
+    def _recency_key(file_data: FileData) -> float:
+        # NOTE: version is set for both record kinds (conversation package and file), so it
+        # orders them against each other.
+        version = file_data.metadata.version if file_data.metadata else None
+        try:
+            return float(version)
+        except (TypeError, ValueError):
+            return 0.0
 
     def _messages_to_file_data(
         self,


### PR DESCRIPTION
Sets default order in which indexer records are returned to most recently updated records within each channel first.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

