### PR TITLE
fix(security): redact MotherDuck token from precheck connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.2]
+
+### Fixes
+
+- **fix(security): redact MotherDuck token from precheck connection errors.** `MotherDuckUploader.precheck` now routes caught exceptions through `safe_error_summary` and drops `exc_info`, so a bad-token `OperationalError` no longer leaks `md:?motherduck_token=<token>` into logs or the API response.
+
 ## [1.7.1]
 
 ### Fixes

--- a/test/unit/connectors/motherduck/test_motherduck.py
+++ b/test/unit/connectors/motherduck/test_motherduck.py
@@ -1,0 +1,46 @@
+import io
+import logging
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from unstructured_ingest.error import DestinationConnectionError
+from unstructured_ingest.logger import logger
+from unstructured_ingest.processes.connectors.duckdb.motherduck import (
+    MotherDuckAccessConfig,
+    MotherDuckConnectionConfig,
+    MotherDuckUploader,
+    MotherDuckUploaderConfig,
+)
+
+
+def test_precheck_redacts_token():
+    secret = "md_token_SUPERSECRETVALUE123"
+    connection_config = MotherDuckConnectionConfig(
+        database="db",
+        access_config=MotherDuckAccessConfig(md_token=secret),
+    )
+    uploader = MotherDuckUploader(
+        upload_config=MotherDuckUploaderConfig(),
+        connection_config=connection_config,
+    )
+
+    @contextmanager
+    def boom(self):
+        raise Exception(f"OperationalError: md:?motherduck_token={secret}")
+        yield
+
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    logger.addHandler(handler)
+    try:
+        with (
+            patch.object(MotherDuckConnectionConfig, "get_cursor", boom),
+            pytest.raises(DestinationConnectionError) as exc_info,
+        ):
+            uploader.precheck()
+        assert secret not in str(exc_info.value)
+        assert secret not in buf.getvalue()
+    finally:
+        logger.removeHandler(handler)

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.1"  # pragma: no cover
+__version__ = "1.7.2"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/duckdb/motherduck.py
+++ b/unstructured_ingest/processes/connectors/duckdb/motherduck.py
@@ -7,7 +7,11 @@ from pydantic import Field, Secret
 
 from unstructured_ingest.__version__ import __version__ as unstructured_io_ingest_version
 from unstructured_ingest.data_types.file_data import FileData
-from unstructured_ingest.error import DestinationConnectionError
+from unstructured_ingest.error import (
+    DestinationConnectionError,
+    UnstructuredIngestError,
+    safe_error_summary,
+)
 from unstructured_ingest.interfaces import (
     AccessConfig,
     ConnectionConfig,
@@ -95,9 +99,15 @@ class MotherDuckUploader(Uploader):
         try:
             with self.connection_config.get_cursor() as cursor:
                 cursor.execute("SELECT 1;")
+        except (ImportError, UnstructuredIngestError):
+            # Preserve dependency-install guidance and connector-authored typed
+            # errors; only unexpected exceptions are redacted below.
+            raise
         except Exception as e:
-            logger.error(f"failed to validate connection: {e}", exc_info=True)
-            raise DestinationConnectionError(f"failed to validate connection: {e}")
+            logger.error(f"failed to validate connection: {safe_error_summary(e)}")
+            raise DestinationConnectionError(
+                f"failed to validate connection: {safe_error_summary(e)}"
+            ) from None
 
     def upload_dataframe(self, df: "DataFrame") -> None:
         logger.debug(f"uploading {len(df)} entries to {self.connection_config.database} ")


### PR DESCRIPTION
## Summary

Follow-up to #749 ([FIE-197](https://linear.app/unstructured/issue/FIE-197)). `MotherDuckUploader.precheck` overrode the base precheck that #749 fixed, so it still logged (with an `exc_info` traceback) and raised the caught exception — leaking `md:?motherduck_token=<token>` from the connection string into both logs and the API response. Routes the error through `safe_error_summary`, drops `exc_info`, and re-raises `from None`, matching the base `sql` precheck idiom; dependency-install hints and connector-authored typed errors are re-raised unchanged.

## Verification

- `ruff check` clean (pinned 0.15.1); module imports.
- End-to-end check: a token in the driver exception is absent from both the raised message and the logs.
- codex + cubic: no issues.

> Part of the FIE-197 connector-redaction follow-up set. No version bump yet — versioning across the 7 parallel PRs is being handled together (only the first-merged can bump cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




> **Update since opening:** bumped to 1.7.1 + CHANGELOG entry and added a redaction unit test (guarded with `pytest.importorskip` where needed). Supersedes the earlier "no version bump yet" note.