### PR TITLE
fix(security): redact provider text from fsspec/watsonx wrap_error branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.5]
+
+### Fixes
+
+- **fix(security): redact provider text from fsspec/watsonx wrap_error classified branches.** Dropbox/Box/Azure/GCS/watsonx `wrap_error` route classified-branch messages through `safe_error_summary` instead of raw provider text (`e.body`/`e.message`/`e.reason`/full request URL); watsonx strips the URL query string from logs and now classifies HTTP 500 as `ProviderError` (was `> 500`).
+
 ## [1.7.4]
 
 ### Enhancements

--- a/test/unit/connectors/fsspec/test_azure.py
+++ b/test/unit/connectors/fsspec/test_azure.py
@@ -1,3 +1,4 @@
+import pytest
 from pydantic import Secret
 
 from unstructured_ingest.processes.connectors.fsspec.azure import (
@@ -54,3 +55,57 @@ class TestAzureConnectionConfig:
             "connection_string": "UseDevelopmentStorage=true",
             "anon": False,
         }
+
+
+_SECRET = "leaked-azure-reason-abc123XYZ"
+
+
+class TestAzureWrapErrorRedaction:
+    def _connection_config(self) -> AzureConnectionConfig:
+        return AzureConnectionConfig(
+            access_config=Secret(AzureAccessConfig(account_name="azureunstructured1"))
+        )
+
+    def test_client_auth_error_redacts_reason(self):
+        pytest.importorskip("azure.core")
+        from azure.core.exceptions import ClientAuthenticationError
+
+        from unstructured_ingest.error import UserAuthError
+
+        error = ClientAuthenticationError()
+        error.reason = f"auth failed {_SECRET}"
+
+        wrapped = self._connection_config().wrap_error(error)
+
+        assert isinstance(wrapped, UserAuthError)
+        assert _SECRET not in str(wrapped)
+
+    def test_client_error_redacts_reason(self):
+        pytest.importorskip("azure.core")
+        from azure.core.exceptions import HttpResponseError
+
+        from unstructured_ingest.error import UserError
+
+        error = HttpResponseError()
+        error.status_code = 403
+        error.reason = f"forbidden {_SECRET}"
+
+        wrapped = self._connection_config().wrap_error(error)
+
+        assert isinstance(wrapped, UserError)
+        assert _SECRET not in str(wrapped)
+
+    def test_server_error_redacts_reason(self):
+        pytest.importorskip("azure.core")
+        from azure.core.exceptions import HttpResponseError
+
+        from unstructured_ingest.error import ProviderError
+
+        error = HttpResponseError()
+        error.status_code = 500
+        error.reason = f"server error {_SECRET}"
+
+        wrapped = self._connection_config().wrap_error(error)
+
+        assert isinstance(wrapped, ProviderError)
+        assert _SECRET not in str(wrapped)

--- a/test/unit/connectors/fsspec/test_box.py
+++ b/test/unit/connectors/fsspec/test_box.py
@@ -56,3 +56,45 @@ class TestBoxAccessConfigValidation:
         )
         assert ac.box_app_config is None
         assert ac.access_token == "ya29.access"
+
+
+_SECRET = "leaked-box-message-abc123XYZ"
+
+
+def _box_connection_config():
+    from pydantic import Secret
+
+    from unstructured_ingest.processes.connectors.fsspec.box import BoxConnectionConfig
+
+    return BoxConnectionConfig(
+        access_config=Secret(BoxAccessConfig(access_token="ya29.access")),
+        remote_url="box://test",
+    )
+
+
+class TestBoxWrapErrorRedaction:
+    def test_client_error_redacts_message(self):
+        pytest.importorskip("boxsdk")
+        from boxsdk.exception import BoxAPIException
+
+        from unstructured_ingest.error import UserError
+
+        error = BoxAPIException(401, message=f"unauthorized {_SECRET}")
+
+        wrapped = _box_connection_config().wrap_error(error)
+
+        assert isinstance(wrapped, UserError)
+        assert _SECRET not in str(wrapped)
+
+    def test_server_error_redacts_message(self):
+        pytest.importorskip("boxsdk")
+        from boxsdk.exception import BoxAPIException
+
+        from unstructured_ingest.error import ProviderError
+
+        error = BoxAPIException(500, message=f"server error {_SECRET}")
+
+        wrapped = _box_connection_config().wrap_error(error)
+
+        assert isinstance(wrapped, ProviderError)
+        assert _SECRET not in str(wrapped)

--- a/test/unit/connectors/fsspec/test_dropbox.py
+++ b/test/unit/connectors/fsspec/test_dropbox.py
@@ -1,0 +1,64 @@
+"""Unit tests for the Dropbox connector's wrap_error redaction."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import Secret
+
+from unstructured_ingest.error import ProviderError, UserAuthError, UserError
+from unstructured_ingest.processes.connectors.fsspec.dropbox import (
+    DropboxAccessConfig,
+    DropboxConnectionConfig,
+)
+
+_SECRET = "leaked-dropbox-body-abc123XYZ"
+
+
+@pytest.fixture
+def connection_config() -> DropboxConnectionConfig:
+    return DropboxConnectionConfig(
+        access_config=Secret(DropboxAccessConfig(token="test-token")),
+        remote_url="dropbox://test",
+    )
+
+
+def test_dropbox_wrap_error_auth_error_redacts_body(
+    connection_config: DropboxConnectionConfig,
+):
+    pytest.importorskip("dropbox")
+    from dropbox.exceptions import AuthError
+
+    error = AuthError("req-123", f"auth failed {_SECRET}")
+
+    with pytest.raises(UserAuthError) as exc_info:
+        connection_config.wrap_error(error)
+
+    assert _SECRET not in str(exc_info.value)
+
+
+def test_dropbox_wrap_error_client_error_redacts_body(
+    connection_config: DropboxConnectionConfig,
+):
+    pytest.importorskip("dropbox")
+    from dropbox.exceptions import HttpError
+
+    error = HttpError("req-123", 400, f"bad request {_SECRET}")
+
+    wrapped = connection_config.wrap_error(error)
+
+    assert isinstance(wrapped, UserError)
+    assert _SECRET not in str(wrapped)
+
+
+def test_dropbox_wrap_error_server_error_redacts_body(
+    connection_config: DropboxConnectionConfig,
+):
+    pytest.importorskip("dropbox")
+    from dropbox.exceptions import HttpError
+
+    error = HttpError("req-123", 500, f"server exploded {_SECRET}")
+
+    wrapped = connection_config.wrap_error(error)
+
+    assert isinstance(wrapped, ProviderError)
+    assert _SECRET not in str(wrapped)

--- a/test/unit/connectors/fsspec/test_gcs.py
+++ b/test/unit/connectors/fsspec/test_gcs.py
@@ -1,0 +1,50 @@
+"""Unit tests for the GCS connector's wrap_error redaction."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import Secret
+
+from unstructured_ingest.error import ProviderError, UserError
+from unstructured_ingest.processes.connectors.fsspec.gcs import (
+    GcsAccessConfig,
+    GcsConnectionConfig,
+)
+
+_SECRET = "leaked-gcs-message-abc123XYZ"
+
+
+@pytest.fixture
+def connection_config() -> GcsConnectionConfig:
+    return GcsConnectionConfig(
+        access_config=Secret(GcsAccessConfig()),
+        remote_url="gs://test",
+    )
+
+
+def test_gcs_wrap_error_client_error_redacts_message(
+    connection_config: GcsConnectionConfig,
+):
+    pytest.importorskip("gcsfs")
+    from gcsfs.retry import HttpError
+
+    error = HttpError({"code": 403, "message": f"forbidden {_SECRET}"})
+
+    with pytest.raises(UserError) as exc_info:
+        connection_config.wrap_error(error)
+
+    assert _SECRET not in str(exc_info.value)
+
+
+def test_gcs_wrap_error_server_error_redacts_message(
+    connection_config: GcsConnectionConfig,
+):
+    pytest.importorskip("gcsfs")
+    from gcsfs.retry import HttpError
+
+    error = HttpError({"code": 500, "message": f"server error {_SECRET}"})
+
+    with pytest.raises(ProviderError) as exc_info:
+        connection_config.wrap_error(error)
+
+    assert _SECRET not in str(exc_info.value)

--- a/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
+++ b/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
@@ -8,7 +8,7 @@ from pyiceberg.exceptions import CommitFailedException, RESTError
 from pytest_mock import MockerFixture
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
-from unstructured_ingest.error import ProviderError, UserError
+from unstructured_ingest.error import ProviderError, UserAuthError, UserError
 from unstructured_ingest.processes.connectors.ibm_watsonx import IBM_WATSONX_S3_CONNECTOR_TYPE
 from unstructured_ingest.processes.connectors.ibm_watsonx.ibm_watsonx_s3 import (
     IbmWatsonxAccessConfig,
@@ -597,3 +597,64 @@ def test_ibm_watsonx_uploader_precheck_calls_get_catalog_with_max_retries_1(
     uploader.precheck()
 
     mock_get_catalog.assert_called_once_with(uploader.connection_config, max_retries=1)
+
+
+_SECRET = "leaked-bearer-token-abc123XYZ"
+
+
+def _http_status_error(status_code: int):
+    """Build an httpx.HTTPStatusError whose request URL and message carry a secret."""
+    import httpx
+
+    request = httpx.Request(
+        "GET", f"https://watsonx.example.com/data?token={_SECRET}&other=1"
+    )
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(f"boom {_SECRET}", request=request, response=response)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_type"),
+    [
+        (401, UserAuthError),
+        (403, UserAuthError),
+        (404, UserError),
+        (500, ProviderError),
+    ],
+)
+def test_ibm_watsonx_wrap_error_redacts_provider_text(
+    connection_config: IbmWatsonxConnectionConfig,
+    status_code: int,
+    expected_type: type,
+):
+    """wrap_error classifies by status and never surfaces the token from the URL/message."""
+    error = _http_status_error(status_code)
+
+    wrapped = connection_config.wrap_error(error)
+
+    assert isinstance(wrapped, expected_type)
+    assert _SECRET not in str(wrapped)
+
+
+def test_ibm_watsonx_wrap_error_500_is_provider_error(
+    connection_config: IbmWatsonxConnectionConfig,
+):
+    """Regression: HTTP 500 must map to ProviderError (was `> 500`, now `>= 500`)."""
+    wrapped = connection_config.wrap_error(_http_status_error(500))
+
+    assert isinstance(wrapped, ProviderError)
+
+
+def test_ibm_watsonx_wrap_error_strips_query_string_from_logs(
+    caplog: pytest.LogCaptureFixture,
+    connection_config: IbmWatsonxConnectionConfig,
+):
+    """The logged URL keeps the path but drops the token-bearing query string."""
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        connection_config.wrap_error(_http_status_error(401))
+
+    assert _SECRET not in caplog.text
+    assert "token=" not in caplog.text
+    assert "https://watsonx.example.com/data" in caplog.text

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.4"  # pragma: no cover
+__version__ = "1.7.5"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/fsspec/azure.py
+++ b/unstructured_ingest/processes/connectors/fsspec/azure.py
@@ -128,9 +128,9 @@ class AzureConnectionConfig(FsspecConnectionConfig):
             logger.error(f"unhandled exception from azure ({safe_error_summary(e)})")
             return e
         if isinstance(e, ClientAuthenticationError):
-            return UserAuthError(e.reason)
+            return UserAuthError(safe_error_summary(e))
         status_code = e.status_code
-        message = e.reason
+        message = safe_error_summary(e)
         if status_code is not None:
             if 400 <= status_code < 500:
                 return UserError(message)

--- a/unstructured_ingest/processes/connectors/fsspec/box.py
+++ b/unstructured_ingest/processes/connectors/fsspec/box.py
@@ -269,11 +269,11 @@ class BoxConnectionConfig(FsspecConnectionConfig):
         from boxsdk.exception import BoxAPIException, BoxOAuthException
 
         if isinstance(e, BoxOAuthException):
-            return UserAuthError(e.message)
+            return UserAuthError(safe_error_summary(e))
         if not isinstance(e, BoxAPIException):
             logger.error(f"unhandled exception from box ({safe_error_summary(e)})")
             return e
-        message = e.message or e
+        message = safe_error_summary(e)
         if error_code_status := e.status:
             if 400 <= error_code_status < 500:
                 return UserError(message)

--- a/unstructured_ingest/processes/connectors/fsspec/dropbox.py
+++ b/unstructured_ingest/processes/connectors/fsspec/dropbox.py
@@ -136,21 +136,15 @@ class DropboxConnectionConfig(FsspecConnectionConfig):
             return e
 
         if isinstance(e, AuthError):
-            raise UserAuthError(e.error)
+            raise UserAuthError(safe_error_summary(e))
         elif isinstance(e, RateLimitError):
             return CustomRateLimitError(e.error)
 
         status_code = e.status_code
         if 400 <= status_code < 500:
-            if body := getattr(e, "body", None):
-                return UserError(body)
-            else:
-                return UserError(e.body)
+            return UserError(safe_error_summary(e))
         if status_code >= 500:
-            if body := getattr(e, "body", None):
-                return ProviderError(body)
-            else:
-                return ProviderError(e.body)
+            return ProviderError(safe_error_summary(e))
 
         logger.error(f"Unhandled Dropbox HttpError: {safe_error_summary(e)}")
         return e

--- a/unstructured_ingest/processes/connectors/fsspec/gcs.py
+++ b/unstructured_ingest/processes/connectors/fsspec/gcs.py
@@ -137,7 +137,7 @@ class GcsConnectionConfig(FsspecConnectionConfig):
         if isinstance(e, ValueError) and "Bad Request" in str(e):
             raise UserError(e)
         if isinstance(e, HttpError) and (http_error_code := e.code):
-            message = e.message or e
+            message = safe_error_summary(e)
             if 400 <= http_error_code < 500:
                 raise UserError(message)
             if http_error_code >= 500:

--- a/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
+++ b/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
@@ -93,30 +93,31 @@ class IbmWatsonxConnectionConfig(ConnectionConfig):
                 f"Unhandled exception from IBM watsonx.data connector: {safe_error_summary(e)}"
             )
             return e
-        url = e.request.url
+        # Drop the query string; it can carry tokens / presigned signatures.
+        url = str(e.request.url).split("?", 1)[0]
         response_code = e.response.status_code
         if response_code == 401:
             logger.error(
                 f"Failed to authenticate IBM watsonx.data user {url}, status code {response_code}"
             )
-            return UserAuthError(e)
+            return UserAuthError(safe_error_summary(e))
         if response_code == 403:
             logger.error(
                 f"Given IBM watsonx.data user is not authorized {url}, status code {response_code}"
             )
-            return UserAuthError(e)
+            return UserAuthError(safe_error_summary(e))
         if 400 <= response_code < 500:
             logger.error(
                 f"Request to {url} failed in IBM watsonx.data connector, "
                 f"status code {response_code}"
             )
-            return UserError(e)
+            return UserError(safe_error_summary(e))
         if response_code > 500:
             logger.error(
                 f"Request to {url} failed in IBM watsonx.data connector, "
                 f"status code {response_code}"
             )
-            return ProviderError(e)
+            return ProviderError(safe_error_summary(e))
         logger.error(
             f"Unhandled exception from IBM watsonx.data connector: {safe_error_summary(e)}"
         )

--- a/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
+++ b/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
@@ -112,7 +112,7 @@ class IbmWatsonxConnectionConfig(ConnectionConfig):
                 f"status code {response_code}"
             )
             return UserError(safe_error_summary(e))
-        if response_code > 500:
+        if response_code >= 500:
             logger.error(
                 f"Request to {url} failed in IBM watsonx.data connector, "
                 f"status code {response_code}"


### PR DESCRIPTION
## Summary

Follow-up to #749 ([FIE-197](https://linear.app/unstructured/issue/FIE-197)). #749 redacted only the fallback branches of these `wrap_error` methods; the classified 4xx/5xx branches still interpolated raw provider free-text into the typed errors returned to API callers — dropbox `e.body`/`e.error`, box `e.message`, azure `e.reason`, gcs `e.message`, and watsonx raw `e` plus the full request URL (query string can carry tokens/signatures). Routes the message payloads through `safe_error_summary` and strips the query string from the watsonx log URL. The dropbox 4xx/5xx if/else collapsed since both arms now return the same summary.

**Correctness:** watsonx now classifies HTTP 500 as `ProviderError` (was `> 500`, which dropped 500 to a raw `return e`) — flagged by cubic (P1).

gcs's `Forbidden`/`Bad Request`/`File-not-found` branches and dropbox's `RateLimitError` are left as connector-authored guidance.

> Part of the FIE-197 redaction follow-up set. Bumped to 1.7.1 + CHANGELOG entry; redaction unit tests added (guarded with `pytest.importorskip` where a connector SDK is not in the unit env, matching `test_sftp.py`). The six parallel `## [1.7.1]` entries will conflict at merge — only the first merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
