### PR TITLE
docs(security): note safe_error_summary allowlist rests on attr names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.1]
+
+### Fixes
+
+- **docs(security): document that `safe_error_summary`'s allowlist rests on attribute names.** Adds a comment in `error.py` recording that `_MACHINE_CODE_RE` is a shape filter, not a secret detector, so the guarantee depends on keeping `_SAFE_ERROR_ATTRS` limited to fields that never carry free text. Comment-only; no runtime change.
+
 ## [1.7.0]
 
 ### Enhancements

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.0"  # pragma: no cover
+__version__ = "1.7.1"  # pragma: no cover

--- a/unstructured_ingest/error.py
+++ b/unstructured_ingest/error.py
@@ -25,6 +25,14 @@ _SAFE_ERROR_ATTRS = (
 # Enum-like machine codes are short tokens with no whitespace (e.g. "invalid_auth",
 # "Neo.ClientError.Security.Unauthorized"). Free text virtually always
 # contains whitespace or punctuation outside this set and is rejected.
+#
+# NOTE: this is a shape filter, not a secret detector. A credential shaped
+# like a machine code (an API key "sk-live-...", an AWS key, a hex token)
+# would pass it. The safety guarantee therefore rests on the
+# _SAFE_ERROR_ATTRS *name* allowlist above: only attributes SDKs use for
+# statuses, error codes, and request IDs are ever read. If an SDK stashed a
+# secret under one of those names it would surface verbatim -- so keep
+# _SAFE_ERROR_ATTRS limited to fields that never carry free text.
 _MACHINE_CODE_RE = re.compile(r"[A-Za-z0-9_.\-]{1,64}")
 
 


### PR DESCRIPTION
## Summary

Follow-up to #749 ([FIE-197](https://linear.app/unstructured/issue/FIE-197)). Documents the one residual hole the review flagged: `safe_error_summary` is safe by construction of the `_SAFE_ERROR_ATTRS` **name** allowlist, not by value shape — `_MACHINE_CODE_RE` would pass a credential shaped like a machine code (`sk-live-...`, an AWS key, a hex token). The added comment records that the guarantee rests on keeping the attr list limited to fields that never carry free text. Comment-only; no runtime change.

The `wrap()` sibling-family branch (formats an already-sanitized `UnstructuredIngestError` message rather than a summary) is intentional and pinned by #749's guard test, so it is left unchanged.

## Verification

- `ruff check` clean (pinned 0.15.1); **14 error unit tests pass**.
- codex + cubic: no issues.

> Part of the FIE-197 connector-redaction follow-up set. No version bump yet — versioning across the 7 parallel PRs is being handled together (only the first-merged can bump cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




> **Update since opening:** bumped to 1.7.1 + CHANGELOG entry and added a redaction unit test (guarded with `pytest.importorskip` where needed). Supersedes the earlier "no version bump yet" note.