### PR TITLE
fix(security): redact provider text from Zendesk/S3/Databricks wrap_error returns

### DIFF
--- a/unstructured_ingest/processes/connectors/databricks/volumes.py
+++ b/unstructured_ingest/processes/connectors/databricks/volumes.py
@@ -81,18 +81,18 @@ class DatabricksVolumesConnectionConfig(ConnectionConfig, ABC):
             if (message_split[0].endswith("auth")) or (
                 "Client authentication failed" in error_message
             ):
-                return UserAuthError(e)
+                return UserAuthError(safe_error_summary(e))
         if isinstance(e, DatabricksError):
             reverse_mapping = {v: k for k, v in STATUS_CODE_MAPPING.items()}
             if status_code := reverse_mapping.get(type(e)):
                 if status_code in [401, 403]:
-                    return UserAuthError(e)
+                    return UserAuthError(safe_error_summary(e))
                 if status_code == 429:
-                    return RateLimitError(e)
+                    return RateLimitError(safe_error_summary(e))
                 if 400 <= status_code < 500:
-                    return UserError(e)
+                    return UserError(safe_error_summary(e))
                 if 500 <= status_code < 600:
-                    return ProviderError(e)
+                    return ProviderError(safe_error_summary(e))
         logger.error(f"unhandled exception from databricks: {safe_error_summary(e)}")
         return e
 

--- a/unstructured_ingest/processes/connectors/fsspec/s3.py
+++ b/unstructured_ingest/processes/connectors/fsspec/s3.py
@@ -138,14 +138,14 @@ class S3ConnectionConfig(FsspecConnectionConfig):
         # s3fs maps botocore errors into python ones using mapping here:
         # https://github.com/fsspec/s3fs/blob/main/s3fs/errors.py
         if isinstance(e, PermissionError):
-            return UserAuthError(e)
+            return UserAuthError(safe_error_summary(e))
         if isinstance(e, FileNotFoundError):
             return UserError(f"File not found: {e}")
         if cause := getattr(e, "__cause__", None):
             error_response = cause.response
             error_meta = error_response["ResponseMetadata"]
             http_code = error_meta["HTTPStatusCode"]
-            message = error_response["Error"].get("Message", str(e))
+            message = safe_error_summary(e)
             if 400 <= http_code < 500:
                 return UserError(message)
             if http_code >= 500:

--- a/unstructured_ingest/processes/connectors/zendesk/client.py
+++ b/unstructured_ingest/processes/connectors/zendesk/client.py
@@ -218,7 +218,7 @@ class ZendeskClient:
 
         if not isinstance(e, httpx.HTTPStatusError):
             logger.error(f"unhandled exception from Zendesk client: {safe_error_summary(e)}")
-            return UnstructuredIngestError(str(e))
+            return UnstructuredIngestError(safe_error_summary(e))
         url = e.request.url
         response_code = e.response.status_code
         if response_code == 401:
@@ -226,23 +226,23 @@ class ZendeskClient:
                 f"Failed to connect via auth,"
                 f"{url} using zendesk response, status code {response_code}"
             )
-            return UserAuthError(e)
+            return UserAuthError(safe_error_summary(e))
         if response_code == 429:
             logger.error(
                 f"Failed to connect via rate limits"
                 f"{url} using zendesk response, status code {response_code}"
             )
-            return RateLimitError(e)
+            return RateLimitError(safe_error_summary(e))
         if 400 <= response_code < 500:
             logger.error(
                 f"Failed to connect to {url} using zendesk response, status code {response_code}"
             )
-            return UserError(e)
+            return UserError(safe_error_summary(e))
         if response_code > 500:
             logger.error(
                 f"Failed to connect to {url} using zendesk response, status code {response_code}"
             )
-            return ProviderError(e)
+            return ProviderError(safe_error_summary(e))
         logger.error(f"unhandled http status error from Zendesk client: {safe_error_summary(e)}")
         return e
 


### PR DESCRIPTION
## Summary

Follow-up to #749 ([FIE-197](https://linear.app/unstructured/issue/FIE-197)). Companion to `pk/redact-connector-logging-leaks`: those `wrap_error` methods also returned typed errors carrying the raw provider exception into the API response — Zendesk `UnstructuredIngestError(str(e))` plus its classified `UserAuthError`/`RateLimitError`/`UserError`/`ProviderError(e)`, S3's provider `Error.Message`, and Databricks' classified branches. Routes each through `safe_error_summary`, mirroring the fsspec/watsonx classified-branch fix. The "File not found" guidance string and the unclassified `return e` escape hatches are left intact.

## Stacking

Based on `pk/redact-connector-logging-leaks` (same three files), so this PR targets that branch as its base. Merge that PR first, or fold this in.

## Verification

- `ruff check` clean (pinned 0.15.1); all 3 modules import.
- codex + cubic: no issues.

> Part of the FIE-197 connector-redaction follow-up set. No version bump yet — versioning across the 7 parallel PRs is being handled together (only the first-merged can bump cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

