### PR TITLE
test(teradata): cover secret redaction at create/delete/insert log sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.9]
+
+### Fixes
+
+- **test(teradata): extend the log-redaction regression suite to all seven logger.error sites.** Adds secret-leak tests for the `create_destination`, `delete_by_record_id`, and insert-batch (`executemany`) driver-error branches, which previously had no coverage — each plants a credential in the driver exception and asserts it never reaches the logs.
+
 ## [1.7.8]
 
 ### Fixes

--- a/test/unit/connectors/sql/test_teradata.py
+++ b/test/unit/connectors/sql/test_teradata.py
@@ -665,9 +665,7 @@ def test_teradata_uploader_config_preserves_user_table_name_for_precheck(
     """User-provided table names are not modified; precheck passes them through as-is."""
     uploader = TeradataUploader(
         connection_config=teradata_connection_config,
-        upload_config=TeradataUploaderConfig(
-            table_name="my-bad-table", record_id_key="record_id"
-        ),
+        upload_config=TeradataUploaderConfig(table_name="my-bad-table", record_id_key="record_id"),
     )
     assert uploader.upload_config.table_name == "my-bad-table"
     uploader.precheck()  # must not raise
@@ -1045,7 +1043,13 @@ def test_teradata_stager_conform_dict_json_mode(
     )
 
     assert set(result.keys()) == {
-        "id", "record_id", "element_id", "text", "type", "embeddings", "metadata",
+        "id",
+        "record_id",
+        "element_id",
+        "text",
+        "type",
+        "embeddings",
+        "metadata",
     }
     assert result["element_id"] == "abc123"
     assert result["text"] == "Hello world"
@@ -1300,9 +1304,7 @@ def test_extract_teradata_error_code(message: str, expected_code: int | None):
         (5315, "user does not have any access to the database"),
     ],
 )
-def test_classified_teradata_error_user_fault_codes_raise_user_error(
-    code: int, fragment: str
-):
+def test_classified_teradata_error_user_fault_codes_raise_user_error(code: int, fragment: str):
     """Recognised user-fault codes → UserError with the code+descriptor only,
     never the raw driver text, and with the source exception unchained."""
     secret = "logon password=hunter2 host=td.internal"
@@ -1338,9 +1340,7 @@ def test_classified_teradata_error_unknown_code_source_fallback():
     """Unknown code on a source path → SourceConnectionError preserved."""
     exc = _FakeTeradataDriverError("connection reset by peer")
     with pytest.raises(SourceConnectionError):
-        _raise_classified_teradata_error(
-            exc, host="td.example.com", table="t", direction="source"
-        )
+        _raise_classified_teradata_error(exc, host="td.example.com", table="t", direction="source")
 
 
 def test_classified_teradata_error_no_code_falls_back():
@@ -1356,7 +1356,9 @@ def test_classified_teradata_error_rejects_invalid_direction():
     exc = _FakeTeradataDriverError("[Error 9999]")
     with pytest.raises(AssertionError, match="direction must be"):
         _raise_classified_teradata_error(
-            exc, host="td.example.com", direction="DESTINATION"  # type: ignore[arg-type]
+            exc,
+            host="td.example.com",
+            direction="DESTINATION",  # type: ignore[arg-type]
         )
 
 
@@ -1414,9 +1416,7 @@ def test_teradata_uploader_delete_by_record_id_type_mismatch_raises_user_error(
     BIGINT instead of VARCHAR. Connector sends a string identifier, Teradata returns
     [Error 3754]. Without this mapping the customer sees 'Failed to connect…' (wrong);
     with it they see the actual type-mismatch message."""
-    mocker.patch.object(
-        teradata_uploader, "_get_db_column_name", return_value="record_id"
-    )
+    mocker.patch.object(teradata_uploader, "_get_db_column_name", return_value="record_id")
     mock_cursor.execute.side_effect = _FakeTeradataDriverError(
         "[Error 3754] Precision error in FLOAT type constant or during implicit conversions."
     )
@@ -1441,9 +1441,7 @@ def test_teradata_uploader_delete_by_record_id_missing_table_raises_user_error(
 ):
     """delete_by_record_id surfaces a 3807 as UserError, not a swallowed driver error."""
     # Skip the get_table_columns lookup that delete_by_record_id makes first.
-    mocker.patch.object(
-        teradata_uploader, "_get_db_column_name", return_value="record_id"
-    )
+    mocker.patch.object(teradata_uploader, "_get_db_column_name", return_value="record_id")
     mock_cursor.execute.side_effect = _FakeTeradataDriverError(
         "[Error 3807] Object 'test_table' does not exist"
     )
@@ -1535,7 +1533,12 @@ def test_teradata_uploader_create_destination_no_privilege_raises_user_error(
 # orchestrators that skip init() fail with Teradata 3807 ("object does not exist").
 
 _OPINIONATED_COLUMNS = [
-    ("id",), ("record_id",), ("element_id",), ("text",), ("type",), ("metadata",),
+    ("id",),
+    ("record_id",),
+    ("element_id",),
+    ("text",),
+    ("type",),
+    ("metadata",),
 ]
 
 
@@ -1608,9 +1611,7 @@ def test_teradata_uploader_upload_dataframe_auto_creates_default_table_when_name
     )
 
     assert teradata_uploader_auto_create.upload_config.table_name == DEFAULT_TABLE_NAME
-    assert any(
-        "CREATE MULTISET TABLE" in c[0][0] for c in mock_cursor.execute.call_args_list
-    )
+    assert any("CREATE MULTISET TABLE" in c[0][0] for c in mock_cursor.execute.call_args_list)
     assert any("INSERT INTO" in c[0][0] for c in mock_cursor.executemany.call_args_list)
 
 
@@ -1744,6 +1745,96 @@ def test_uploader_get_table_columns_failure_does_not_log_secret(
         pytest.raises(UserError),
     ):
         teradata_uploader.get_table_columns()
+
+    assert "SUPERSECRET123" not in caplog.text
+    assert "db.internal" not in caplog.text
+
+
+def test_uploader_create_destination_failure_does_not_log_secret(
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+    caplog,
+):
+    """The create_destination log site (CREATE TABLE driver-error branch) must not leak."""
+    # SELECT DATABASE -> current_db; table-exists probe -> None (missing); CREATE -> raises.
+    mock_cursor.fetchone.side_effect = [("test_db",), None]
+    mock_cursor.execute.side_effect = [
+        None,
+        None,
+        _FakeTeradataDriverError(f"[Error 3523] no CREATE privilege {_LEAKY_SECRET}"),
+    ]
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="unstructured_ingest"),
+        pytest.raises(UserError),
+    ):
+        teradata_uploader.create_destination()
+
+    assert "SUPERSECRET123" not in caplog.text
+    assert "db.internal" not in caplog.text
+
+
+def test_uploader_delete_by_record_id_failure_does_not_log_secret(
+    mocker: MockerFixture,
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+    caplog,
+):
+    """The delete_by_record_id log site (driver-error branch) must not leak driver text."""
+    mocker.patch.object(teradata_uploader, "_get_db_column_name", return_value="record_id")
+    mock_cursor.execute.side_effect = _FakeTeradataDriverError(
+        f"[Error 3807] Object 'test_table' does not exist {_LEAKY_SECRET}"
+    )
+
+    file_data = FileData(
+        identifier="test_file.txt",
+        connector_type="local",
+        source_identifiers=SourceIdentifiers(
+            filename="test_file.txt", fullpath="/path/to/test_file.txt"
+        ),
+    )
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="unstructured_ingest"),
+        pytest.raises(UserError),
+    ):
+        teradata_uploader.delete_by_record_id(file_data)
+
+    assert "SUPERSECRET123" not in caplog.text
+    assert "db.internal" not in caplog.text
+
+
+def test_uploader_insert_batch_failure_does_not_log_secret(
+    mocker: MockerFixture,
+    mock_cursor: MagicMock,
+    teradata_uploader: TeradataUploader,
+    mock_get_cursor: MagicMock,
+    caplog,
+):
+    """The insert-batch log site (executemany driver-error branch) must not leak driver text."""
+    df = pd.DataFrame({"id": [1], "text": ["hi"], "record_id": ["f1"]})
+    teradata_uploader._columns = ["id", "text", "record_id"]
+    mocker.patch.object(teradata_uploader, "_fit_to_schema", return_value=df)
+    mocker.patch.object(teradata_uploader, "can_delete", return_value=False)
+    mock_cursor.executemany.side_effect = _FakeTeradataDriverError(
+        f"[Error 3523] no INSERT privilege {_LEAKY_SECRET}"
+    )
+
+    file_data = FileData(
+        identifier="test_file.txt",
+        connector_type="local",
+        source_identifiers=SourceIdentifiers(
+            filename="test_file.txt", fullpath="/path/to/test_file.txt"
+        ),
+    )
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="unstructured_ingest"),
+        pytest.raises(UserError),
+    ):
+        teradata_uploader.upload_dataframe(df, file_data)
 
     assert "SUPERSECRET123" not in caplog.text
     assert "db.internal" not in caplog.text

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.8"  # pragma: no cover
+__version__ = "1.7.9"  # pragma: no cover


### PR DESCRIPTION
Follow-up to #762 (merged). That PR added log-redaction regression tests for 4 of the 7 `logger.error` sites in the Teradata connector; cubic flagged that `create_destination`, `delete_by_record_id`, and the insert-batch (`executemany`) driver-error branches were still uncovered. This adds those three.

## What

Each new test plants a credential-shaped secret (`password=... host=...`) in the driver exception raised at that site, drives the method, and asserts the secret never reaches `caplog` — mirroring the existing four redaction tests.

- `test_uploader_create_destination_failure_does_not_log_secret`
- `test_uploader_delete_by_record_id_failure_does_not_log_secret`
- `test_uploader_insert_batch_failure_does_not_log_secret`

All 7 `logger.error` sites in the connector are now covered.

## Verification

- `make test-unit`: 1116 passed, 50 skipped.
- ruff (pinned 0.15.1) clean; `check-version` consistent (1.7.9).

Tests only — no production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

