### PR TITLE
fix(google-drive): record drive_id in each file's record locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.10]
+
+### Fixes
+
+- **fix(google-drive): record the drive id in each file's record locator.** The indexer used an annotation statement (`record_locator["drive_id"]: object_id`) instead of an assignment, so `drive_id` was silently never written into `record_locator`. Changed to a real assignment so downstream consumers can resolve which drive a file came from.
+
 ## [1.7.9]
 
 ### Fixes

--- a/test/unit/connectors/test_google_drive.py
+++ b/test/unit/connectors/test_google_drive.py
@@ -511,3 +511,71 @@ class TestGoogleDriveExtensionFiltering:
         )
 
         assert count == 3
+
+
+class TestGoogleDriveRecordLocator:
+    """The indexer must stamp the source drive id onto every file's
+    record_locator so downstream consumers can resolve which drive a file
+    came from."""
+
+    @staticmethod
+    def _indexer() -> GoogleDriveIndexer:
+        return GoogleDriveIndexer(
+            connection_config=MagicMock(),
+            index_config=GoogleDriveIndexerConfig(),
+        )
+
+    def test_get_files_sets_drive_id_for_single_file(self):
+        indexer = self._indexer()
+        files_client = MagicMock()
+        files_client.get.return_value.execute.return_value = {
+            "id": "file-1",
+            "name": "doc.pdf",
+            "mimeType": "application/pdf",
+            "createdTime": "2024-01-01T00:00:00.000Z",
+            "modifiedTime": "2024-01-02T00:00:00.000Z",
+        }
+
+        data = indexer.get_files(files_client=files_client, object_id="drive-123")
+
+        assert len(data) == 1
+        assert data[0].metadata.record_locator["drive_id"] == "drive-123"
+        assert data[0].metadata.record_locator["file_id"] == "file-1"
+
+    def test_get_files_sets_drive_id_for_every_file_in_folder(self, monkeypatch):
+        indexer = self._indexer()
+
+        monkeypatch.setattr(
+            indexer,
+            "get_root_info",
+            lambda files_client, object_id: {
+                "id": object_id,
+                "name": "root",
+                "mimeType": "application/vnd.google-apps.folder",
+            },
+        )
+        monkeypatch.setattr(
+            indexer,
+            "get_paginated_results",
+            lambda **kwargs: [
+                {
+                    "id": "file-1",
+                    "name": "a.pdf",
+                    "mimeType": "application/pdf",
+                    "createdTime": "2024-01-01T00:00:00.000Z",
+                    "modifiedTime": "2024-01-02T00:00:00.000Z",
+                },
+                {
+                    "id": "file-2",
+                    "name": "b.pdf",
+                    "mimeType": "application/pdf",
+                    "createdTime": "2024-01-01T00:00:00.000Z",
+                    "modifiedTime": "2024-01-02T00:00:00.000Z",
+                },
+            ],
+        )
+
+        data = indexer.get_files(files_client=MagicMock(), object_id="drive-xyz")
+
+        assert len(data) == 2
+        assert all(d.metadata.record_locator["drive_id"] == "drive-xyz" for d in data)

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.9"  # pragma: no cover
+__version__ = "1.7.10"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/google_drive.py
+++ b/unstructured_ingest/processes/connectors/google_drive.py
@@ -545,7 +545,7 @@ class GoogleDriveIndexer(Indexer):
                 f["permissions"] = self.extract_permissions(f.get("permissions"))
                 data.append(self.map_file_data(root_info=f))
         for d in data:
-            d.metadata.record_locator["drive_id"]: object_id
+            d.metadata.record_locator["drive_id"] = object_id
         return data
 
     def extract_permissions(self, permissions: Optional[list[dict]]) -> list[dict]:


### PR DESCRIPTION
### Summary
`GoogleDriveIndexer.get_files` intended to stamp the source drive id onto every indexed file's `record_locator`, but used a type-annotation statement (`d.metadata.record_locator["drive_id"]: object_id`) instead of an assignment. Annotation statements are no-ops at runtime, so `drive_id` was silently never recorded — `record_locator` only ever contained `file_id`.

### Change
- Replace the annotation with a real assignment so `drive_id` is written for every file. `record_locator` is always initialized to a dict in `map_file_data`, so the assignment is safe.
- Bump version to 1.7.10 and add a CHANGELOG entry per repo convention.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

