### PR TITLE
fix(stager): preserve single-record NDJSON partition output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.11]
+
+### Fixes
+
+- **fix(stager): preserve single-record NDJSON partition output.** Blob-storage staging now reads `.ndjson` inputs with an NDJSON-aware streaming reader instead of treating them as top-level JSON arrays, preventing single-record partition output from being silently dropped. Adds regression coverage for single- and multi-record inputs and updates the Google Drive expected output with the `drive_id` field introduced in 1.7.10.
+
 ## [1.7.10]
 
 ### Fixes

--- a/test/unit/processes/utils/test_blob_storage.py
+++ b/test/unit/processes/utils/test_blob_storage.py
@@ -1,17 +1,17 @@
 """Bounded-memory + output tests for ``BlobStoreUploadStager``.
 
 ``BlobStoreUploadStager.run`` overrides the base ``UploadStager.run`` and is the stager
-used by blob-store destinations (e.g. S3). It previously did ``get_json_data`` +
-``write_data`` (a whole-file load), which OOM-killed the stager on large partition
-outputs — and because it overrides ``run``, the base ``process_whole`` streaming fix did
-not cover it. It now streams the copy via the base ``process_whole`` (json_stream +
-write_data_streaming). These tests assert it still produces a correct ``.json`` copy and
-that peak memory stays flat as the input grows.
+used by blob-store destinations (e.g. S3). It always emits a ``.json`` copy, streaming
+NDJSON input element-by-element into a JSON array and routing JSON-array input through
+the base ``process_whole``. These tests assert it produces a correct ``.json`` copy for
+both input formats and that peak memory stays flat as the input grows.
 """
 
 import json
 import tracemalloc
 from pathlib import Path
+
+import pytest
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
 from unstructured_ingest.processes.utils.blob_storage import (
@@ -53,10 +53,13 @@ def test_blob_store_stager_streams_json_copy(tmp_path: Path) -> None:
     assert json.loads(out.read_text()) == ELEMENTS
 
 
-def test_blob_store_stager_outputs_json_for_ndjson_input(tmp_path: Path) -> None:
+@pytest.mark.parametrize("elements", [ELEMENTS[:1], ELEMENTS], ids=["single", "multiple"])
+def test_blob_store_stager_outputs_json_for_ndjson_input(
+    tmp_path: Path, elements: list[dict]
+) -> None:
     src = tmp_path / "in.ndjson"
     with src.open("w") as f:
-        f.write("\n".join(json.dumps(e) for e in ELEMENTS))
+        f.write("\n".join(json.dumps(e) for e in elements))
 
     out = _stager().run(
         elements_filepath=src,
@@ -66,7 +69,7 @@ def test_blob_store_stager_outputs_json_for_ndjson_input(tmp_path: Path) -> None
     )
 
     assert out.suffix == ".json"
-    assert json.loads(out.read_text()) == ELEMENTS
+    assert json.loads(out.read_text()) == elements
 
 
 def _make_large_json_array(path: Path, num_elements: int) -> None:

--- a/test_e2e/expected-structured-output/google-drive/fake.docx.json
+++ b/test_e2e/expected-structured-output/google-drive/fake.docx.json
@@ -12,7 +12,8 @@
       "data_source": {
         "url": null,
         "record_locator": {
-          "file_id": "1SpQuE7jHz9nMt5hfQXsiok1SgIdRYX5o"
+          "file_id": "1SpQuE7jHz9nMt5hfQXsiok1SgIdRYX5o",
+          "drive_id": "1OQZ66OHBE30rNsNa7dweGLfRmXvkT_jr"
         },
         "date_created": "1686809759.687",
         "date_modified": "1686809743.0",

--- a/test_e2e/expected-structured-output/google-drive/foo.txt.json
+++ b/test_e2e/expected-structured-output/google-drive/foo.txt.json
@@ -11,7 +11,8 @@
       "data_source": {
         "url": null,
         "record_locator": {
-          "file_id": "1cTKXAreuj-wYmL38nFnqKvz3X8UKcaMC"
+          "file_id": "1cTKXAreuj-wYmL38nFnqKvz3X8UKcaMC",
+          "drive_id": "1OQZ66OHBE30rNsNa7dweGLfRmXvkT_jr"
         },
         "date_created": "1686809759.687",
         "date_modified": "1686809739.0",

--- a/test_e2e/expected-structured-output/google-drive/test-drive-doc.docx.json
+++ b/test_e2e/expected-structured-output/google-drive/test-drive-doc.docx.json
@@ -17,7 +17,8 @@
       "data_source": {
         "url": null,
         "record_locator": {
-          "file_id": "117qrVqiCoR5EjYMsDHGdy3UMkEtKr9Q8"
+          "file_id": "117qrVqiCoR5EjYMsDHGdy3UMkEtKr9Q8",
+          "drive_id": "1OQZ66OHBE30rNsNa7dweGLfRmXvkT_jr"
         },
         "date_created": "1686809758.931",
         "date_modified": "1686809744.0",
@@ -76,7 +77,8 @@
       "data_source": {
         "url": null,
         "record_locator": {
-          "file_id": "117qrVqiCoR5EjYMsDHGdy3UMkEtKr9Q8"
+          "file_id": "117qrVqiCoR5EjYMsDHGdy3UMkEtKr9Q8",
+          "drive_id": "1OQZ66OHBE30rNsNa7dweGLfRmXvkT_jr"
         },
         "date_created": "1686809758.931",
         "date_modified": "1686809744.0",

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.10"  # pragma: no cover
+__version__ = "1.7.11"  # pragma: no cover

--- a/unstructured_ingest/processes/utils/blob_storage.py
+++ b/unstructured_ingest/processes/utils/blob_storage.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from unstructured_ingest.data_types.file_data import FileData
 from unstructured_ingest.interfaces import UploadStager, UploadStagerConfig
+from unstructured_ingest.utils import ndjson
+from unstructured_ingest.utils.data_prep import write_data_streaming
 
 
 class BlobStoreUploadStagerConfig(UploadStagerConfig):
@@ -24,16 +26,19 @@ class BlobStoreUploadStager(UploadStager):
         output_filename: str,
         **kwargs: Any,
     ) -> Path:
-        # Always emit .json. Stream the copy element-by-element instead of
-        # get_json_data + write_data (which loaded the whole file and held 3+ copies
-        # resident, OOM-killing the stager on large partition outputs). The base
-        # process_whole streams a .json array via json_stream + write_data_streaming,
-        # with a buffered fallback for the rare ijson-incompatible inputs; conform_dict
-        # is identity here, so this stays a pure format copy.
+        # Always emit .json. NDJSON input is streamed element-by-element into a JSON
+        # array; JSON-array input goes through process_whole (streaming with a buffered
+        # fallback). Both paths keep only one element resident at a time.
         output_file = self.get_output_path(
             output_filename=output_filename, output_dir=output_dir
         ).with_suffix(".json")
-        self.process_whole(
-            input_file=elements_filepath, output_file=output_file, file_data=file_data
-        )
+        if elements_filepath.suffix == ".ndjson":
+            with elements_filepath.open() as input_file:
+                write_data_streaming(path=output_file, data=ndjson.reader(input_file))
+        elif elements_filepath.suffix == ".json":
+            self.process_whole(
+                input_file=elements_filepath, output_file=output_file, file_data=file_data
+            )
+        else:
+            raise ValueError(f"Unsupported file extension: {elements_filepath}")
         return output_file


### PR DESCRIPTION
## Summary

Fix blob-storage staging when a partition produces an NDJSON file containing exactly one record.

The Google Drive E2E test exposed this because `foo.txt` produces a single partition element. The stager passed the NDJSON file to a streaming JSON-array parser, which treated the record as the root object and silently emitted zero elements.

## Changes

- Stream `.ndjson` inputs with an NDJSON-aware reader.
- Keep the existing streaming path for JSON-array inputs.
- Add regression coverage for both single-record and multi-record NDJSON.
- Update the Google Drive expected fixtures with the `drive_id` field introduced by #768.

## Root cause

The streaming implementation added in #735 expected a top-level JSON array. Single-record NDJSON is instead a single root object, so the parser returned no items. Multi-record NDJSON happened to trigger the existing fallback path, which is why the original unit test passed.

## Verification

- `uv run --locked --no-sync pytest -q test/unit/processes/utils/test_blob_storage.py`
- `uv run --locked --no-sync ruff check unstructured_ingest/processes/utils/blob_storage.py test/unit/processes/utils/test_blob_storage.py`
- `uv run --locked --no-sync ruff format --check unstructured_ingest/processes/utils/blob_storage.py test/unit/processes/utils/test_blob_storage.py`

The credentialed Google Drive E2E test was not run locally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

