### PR TITLE
Rewind files before NDJSON fallback parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.11]
+
+### Fixes
+
+- **Preserve NDJSON records after format detection.** The fallback parser now rewinds the input stream before reading line-delimited JSON, preventing valid records from being skipped after the detection pass.
+
 ## [1.7.10]
 
 ### Fixes

--- a/test/unit/utils/test_data_prep.py
+++ b/test/unit/utils/test_data_prep.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from unstructured_ingest.utils.data_prep import get_json_data
+
+
+def test_get_json_data_reads_ndjson_from_unrecognized_extension(tmp_path: Path):
+    path = tmp_path / "data.tmp"
+    path.write_text('{"a": 1}\n{"a": 2}\n')
+
+    assert get_json_data(path) == [{"a": 1}, {"a": 2}]

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.10"  # pragma: no cover
+__version__ = "1.7.11"  # pragma: no cover

--- a/unstructured_ingest/utils/data_prep.py
+++ b/unstructured_ingest/utils/data_prep.py
@@ -291,6 +291,7 @@ def get_json_data(path: Path) -> list[dict]:
             return json.load(f)
         except Exception as e:
             logger.warning(f"failed to read {path} as json: {e}")
+            f.seek(0)
         try:
             return ndjson.load(f)
         except Exception as e:


### PR DESCRIPTION
## Summary

- rewind the input stream before NDJSON fallback parsing
- add a regression test using valid two-record NDJSON with an unrecognized extension

## Why

Format detection reads from the file before the fallback parser iterates its lines. Without rewinding, valid NDJSON can be parsed from end-of-file and return zero records without an error.

## Impact

The fallback now reads from the beginning of the stream. Recognized JSON and NDJSON paths are unchanged.

## Validation

- `uv run --locked --no-sync pytest -q test/unit/utils/test_data_prep.py` — 1 passed
- Ruff check and format check passed for all changed Python files
- changelog and package versions both set to 1.7.11


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

