### PR TITLE
Close Zendesk and Notion HTTP clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.11]
+
+### Fixes
+
+- **Close Zendesk and Notion HTTP clients after connector operations.** Connector prechecks, indexing, downloads, context-manager exits, and constructor-failure paths now release their underlying HTTP connection pools.
+
 ## [1.7.10]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **Close Zendesk and Notion HTTP clients after connector operations.** Connector prechecks, indexing, downloads, context-manager exits, and constructor-failure paths now release their underlying HTTP connection pools.
+- **Close Zendesk and Notion HTTP clients after connector operations.** Connector prechecks, indexing, downloads, context-manager entry failures and exits, and constructor-failure paths now release their underlying HTTP connection pools.
 
 ## [1.7.10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **Close Zendesk and Notion HTTP clients after connector operations.** Connector prechecks, indexing, downloads, context-manager entry failures and exits, and constructor-failure paths now release their underlying HTTP connection pools.
+- **Close Zendesk and Notion HTTP clients after connector operations.** Connector prechecks, indexing, downloads, and constructor-failure paths now release their underlying HTTP connection pools.
 
 ## [1.7.11]
 

--- a/test/unit/connectors/notion/test_connector.py
+++ b/test/unit/connectors/notion/test_connector.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import Secret
+
+from unstructured_ingest.processes.connectors.notion.connector import (
+    NotionAccessConfig,
+    NotionConnectionConfig,
+    NotionDownloader,
+    NotionDownloaderConfig,
+)
+
+
+@pytest.fixture()
+def connection_config() -> NotionConnectionConfig:
+    return NotionConnectionConfig(
+        access_config=Secret(NotionAccessConfig(notion_api_key="fake-key")),
+    )
+
+
+def test_downloader_closes_the_client_connection_pool(connection_config):
+    downloader = NotionDownloader(
+        connection_config=connection_config,
+        download_config=NotionDownloaderConfig(),
+    )
+    file_data = MagicMock()
+    file_data.metadata.record_locator = {"page_id": "page-id"}
+
+    clients = []
+    build_client = NotionConnectionConfig.get_client
+
+    def record_client(self):
+        client = build_client(self)
+        clients.append(client)
+        return client
+
+    with (
+        patch.object(NotionConnectionConfig, "get_client", record_client),
+        patch.object(NotionDownloader, "download_page", return_value="response"),
+    ):
+        assert downloader.run(file_data=file_data) == "response"
+
+    assert len(clients) == 1
+    assert clients[0].client.is_closed

--- a/test/unit/connectors/notion/test_connector.py
+++ b/test/unit/connectors/notion/test_connector.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import Secret
+from pytest_mock import MockerFixture
 
 from unstructured_ingest.processes.connectors.notion.connector import (
     NotionAccessConfig,
@@ -18,7 +19,7 @@ def connection_config() -> NotionConnectionConfig:
     )
 
 
-def test_downloader_closes_the_client_connection_pool(connection_config):
+def test_downloader_closes_the_client_connection_pool(connection_config, mocker: MockerFixture):
     downloader = NotionDownloader(
         connection_config=connection_config,
         download_config=NotionDownloaderConfig(),
@@ -26,19 +27,10 @@ def test_downloader_closes_the_client_connection_pool(connection_config):
     file_data = MagicMock()
     file_data.metadata.record_locator = {"page_id": "page-id"}
 
-    clients = []
-    build_client = NotionConnectionConfig.get_client
+    get_client = mocker.spy(NotionConnectionConfig, "get_client")
 
-    def record_client(self):
-        client = build_client(self)
-        clients.append(client)
-        return client
-
-    with (
-        patch.object(NotionConnectionConfig, "get_client", record_client),
-        patch.object(NotionDownloader, "download_page", return_value="response"),
-    ):
+    with patch.object(NotionDownloader, "download_page", return_value="response"):
         assert downloader.run(file_data=file_data) == "response"
 
-    assert len(clients) == 1
-    assert clients[0].client.is_closed
+    get_client.assert_called_once()
+    assert get_client.spy_return.client.is_closed

--- a/test/unit/connectors/notion/test_connector.py
+++ b/test/unit/connectors/notion/test_connector.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock, patch
-
 import pytest
 from pydantic import Secret
 from pytest_mock import MockerFixture
@@ -24,13 +22,17 @@ def test_downloader_closes_the_client_connection_pool(connection_config, mocker:
         connection_config=connection_config,
         download_config=NotionDownloaderConfig(),
     )
-    file_data = MagicMock()
+    file_data = mocker.MagicMock()
     file_data.metadata.record_locator = {"page_id": "page-id"}
 
-    get_client = mocker.spy(NotionConnectionConfig, "get_client")
+    clients = []
+    mocker.patch.object(
+        NotionDownloader,
+        "download_page",
+        side_effect=lambda client, page_id, file_data: clients.append(client) or "response",
+    )
 
-    with patch.object(NotionDownloader, "download_page", return_value="response"):
-        assert downloader.run(file_data=file_data) == "response"
+    assert downloader.run(file_data=file_data) == "response"
 
-    get_client.assert_called_once()
-    assert get_client.spy_return.client.is_closed
+    assert len(clients) == 1
+    assert clients[0].client.is_closed

--- a/test/unit/connectors/zendesk/test_zendesk_client.py
+++ b/test/unit/connectors/zendesk/test_zendesk_client.py
@@ -100,6 +100,19 @@ async def test_async_context_closes_both_http_clients(mocker: MockerFixture):
     assert sync_client.is_closed
 
 
+@pytest.mark.asyncio
+async def test_async_context_entry_failure_closes_sync_client(mocker: MockerFixture):
+    client = _client(mocker)
+    sync_client = client._client
+    mocker.patch("httpx.AsyncClient.__init__", side_effect=RuntimeError("cannot open"))
+
+    with pytest.raises(RuntimeError):
+        async with client:
+            pass
+
+    assert sync_client.is_closed
+
+
 def test_close_releases_sync_client(mocker: MockerFixture):
     client = _client(mocker)
     sync_client = client._client

--- a/test/unit/connectors/zendesk/test_zendesk_client.py
+++ b/test/unit/connectors/zendesk/test_zendesk_client.py
@@ -79,61 +79,43 @@ def _track_instances(mocker: MockerFixture, cls: type) -> list:
     return instances
 
 
-def test_constructor_opens_only_a_sync_client_that_close_releases(mocker: MockerFixture):
-    async_clients = _track_instances(mocker, httpx.AsyncClient)
-    client = _client(mocker)
-    sync_client = client._client
-
-    assert async_clients == []
-
-    client.close()
-
-    assert sync_client.is_closed
-
-
-@pytest.mark.asyncio
-async def test_async_context_closes_both_http_clients(mocker: MockerFixture):
-    client = _client(mocker)
-    sync_client = client._client
-
-    async with client:
-        async_client = client._async_client
-        assert not async_client.is_closed
-
-    assert async_client.is_closed
-    assert sync_client.is_closed
-
-
-@pytest.mark.asyncio
-async def test_async_context_entry_failure_closes_sync_client(mocker: MockerFixture):
-    client = _client(mocker)
-    sync_client = client._client
-    mocker.patch("httpx.AsyncClient.__init__", side_effect=RuntimeError("cannot open"))
-
-    with pytest.raises(RuntimeError):
-        async with client:
-            pass
-
-    assert sync_client.is_closed
-
-
-def test_constructor_closes_sync_client_when_precheck_fails(mocker: MockerFixture):
-    mocker.patch("httpx.Client.head", side_effect=RuntimeError("connection failed"))
+def test_constructor_closes_the_client_used_for_its_connection_check(mocker: MockerFixture):
+    mocker.patch("httpx.Client.head", return_value=mocker.MagicMock())
     sync_clients = _track_instances(mocker, httpx.Client)
     async_clients = _track_instances(mocker, httpx.AsyncClient)
 
-    with pytest.raises(UnstructuredIngestError):
-        ZendeskClient(token="tok", subdomain="sub", email="user@example.com")
+    ZendeskClient(token="tok", subdomain="sub", email="user@example.com")
 
     assert len(sync_clients) == 1
     assert sync_clients[0].is_closed
     assert async_clients == []
 
 
+def test_constructor_closes_its_client_when_the_connection_check_fails(mocker: MockerFixture):
+    mocker.patch("httpx.Client.head", side_effect=RuntimeError("connection failed"))
+    sync_clients = _track_instances(mocker, httpx.Client)
+
+    with pytest.raises(UnstructuredIngestError):
+        ZendeskClient(token="tok", subdomain="sub", email="user@example.com")
+
+    assert len(sync_clients) == 1
+    assert sync_clients[0].is_closed
+
+
+@pytest.mark.asyncio
+async def test_async_context_closes_the_async_client(mocker: MockerFixture):
+    client = _client(mocker)
+
+    async with client:
+        async_client = client._async_client
+        assert not async_client.is_closed
+
+    assert async_client.is_closed
+
+
 def test_precheck_leaves_no_open_clients(mocker: MockerFixture):
     mocker.patch("httpx.Client.head", return_value=mocker.MagicMock())
     sync_clients = _track_instances(mocker, httpx.Client)
-    async_clients = _track_instances(mocker, httpx.AsyncClient)
 
     indexer = ZendeskIndexer(
         connection_config=ZendeskConnectionConfig(
@@ -147,4 +129,3 @@ def test_precheck_leaves_no_open_clients(mocker: MockerFixture):
 
     assert len(sync_clients) == 1
     assert sync_clients[0].is_closed
-    assert async_clients == []

--- a/test/unit/connectors/zendesk/test_zendesk_client.py
+++ b/test/unit/connectors/zendesk/test_zendesk_client.py
@@ -9,6 +9,12 @@ from unstructured_ingest.error import (
     UserError,
 )
 from unstructured_ingest.processes.connectors.zendesk.client import ZendeskClient
+from unstructured_ingest.processes.connectors.zendesk.zendesk import (
+    ZendeskAccessConfig,
+    ZendeskConnectionConfig,
+    ZendeskIndexer,
+    ZendeskIndexerConfig,
+)
 
 SECRET = "SECRETpassword=hunter2 key=AKIAEXAMPLE"
 
@@ -58,3 +64,79 @@ def test_wrap_error_non_http_status_redacts(mocker: MockerFixture):
     assert isinstance(wrapped, UnstructuredIngestError)
     assert SECRET not in str(wrapped)
     assert "hunter2" not in str(wrapped)
+
+
+def _track_instances(mocker: MockerFixture, cls: type) -> list:
+    """Records every instance of ``cls`` constructed after this call."""
+    instances = []
+    original_init = cls.__init__
+
+    def record(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        instances.append(self)
+
+    mocker.patch.object(cls, "__init__", record)
+    return instances
+
+
+def test_constructor_does_not_open_an_async_client(mocker: MockerFixture):
+    async_clients = _track_instances(mocker, httpx.AsyncClient)
+    client = _client(mocker)
+
+    assert async_clients == []
+    client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_context_closes_both_http_clients(mocker: MockerFixture):
+    client = _client(mocker)
+    sync_client = client._client
+
+    async with client:
+        async_client = client._async_client
+        assert not async_client.is_closed
+
+    assert async_client.is_closed
+    assert sync_client.is_closed
+
+
+def test_close_releases_sync_client(mocker: MockerFixture):
+    client = _client(mocker)
+    sync_client = client._client
+
+    client.close()
+
+    assert sync_client.is_closed
+
+
+def test_constructor_closes_sync_client_when_precheck_fails(mocker: MockerFixture):
+    mocker.patch("httpx.Client.head", side_effect=RuntimeError("connection failed"))
+    sync_clients = _track_instances(mocker, httpx.Client)
+    async_clients = _track_instances(mocker, httpx.AsyncClient)
+
+    with pytest.raises(UnstructuredIngestError):
+        ZendeskClient(token="tok", subdomain="sub", email="user@example.com")
+
+    assert len(sync_clients) == 1
+    assert sync_clients[0].is_closed
+    assert async_clients == []
+
+
+def test_precheck_leaves_no_open_clients(mocker: MockerFixture):
+    mocker.patch("httpx.Client.head", return_value=mocker.MagicMock())
+    sync_clients = _track_instances(mocker, httpx.Client)
+    async_clients = _track_instances(mocker, httpx.AsyncClient)
+
+    indexer = ZendeskIndexer(
+        connection_config=ZendeskConnectionConfig(
+            subdomain="sub",
+            email="user@example.com",
+            access_config=ZendeskAccessConfig(api_token="tok"),
+        ),
+        index_config=ZendeskIndexerConfig(),
+    )
+    indexer.precheck()
+
+    assert len(sync_clients) == 1
+    assert sync_clients[0].is_closed
+    assert async_clients == []

--- a/test/unit/connectors/zendesk/test_zendesk_client.py
+++ b/test/unit/connectors/zendesk/test_zendesk_client.py
@@ -79,12 +79,16 @@ def _track_instances(mocker: MockerFixture, cls: type) -> list:
     return instances
 
 
-def test_constructor_does_not_open_an_async_client(mocker: MockerFixture):
+def test_constructor_opens_only_a_sync_client_that_close_releases(mocker: MockerFixture):
     async_clients = _track_instances(mocker, httpx.AsyncClient)
     client = _client(mocker)
+    sync_client = client._client
 
     assert async_clients == []
+
     client.close()
+
+    assert sync_client.is_closed
 
 
 @pytest.mark.asyncio
@@ -109,15 +113,6 @@ async def test_async_context_entry_failure_closes_sync_client(mocker: MockerFixt
     with pytest.raises(RuntimeError):
         async with client:
             pass
-
-    assert sync_client.is_closed
-
-
-def test_close_releases_sync_client(mocker: MockerFixture):
-    client = _client(mocker)
-    sync_client = client._client
-
-    client.close()
 
     assert sync_client.is_closed
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.10"  # pragma: no cover
+__version__ = "1.7.11"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/notion/connector.py
+++ b/unstructured_ingest/processes/connectors/notion/connector.py
@@ -1,4 +1,4 @@
-from contextlib import closing
+from contextlib import contextmanager
 from dataclasses import dataclass
 from time import time
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator, Optional
@@ -43,16 +43,21 @@ class NotionAccessConfig(AccessConfig):
 class NotionConnectionConfig(ConnectionConfig):
     access_config: Secret[NotionAccessConfig]
 
+    @contextmanager
     @requires_dependencies(["notion_client"], extras="notion")
-    def get_client(self) -> "Client":
+    def get_client(self) -> Generator["Client", None, None]:
         from unstructured_ingest.processes.connectors.notion.client import Client
 
-        return Client(
+        client = Client(
             notion_version=NOTION_API_VERSION,
             auth=self.access_config.get_secret_value().notion_api_key,
             logger=logger,
             log_level=logger.level,
         )
+        try:
+            yield client
+        finally:
+            client.close()
 
 
 class NotionIndexerConfig(IndexerConfig):
@@ -86,7 +91,7 @@ class NotionIndexer(Indexer):
     def precheck(self) -> None:
         """Check the connection to the Notion API."""
         try:
-            with closing(self.connection_config.get_client()) as client:
+            with self.connection_config.get_client() as client:
                 # Perform a simple request to verify connection
                 request = client._build_request("HEAD", "users")
                 response = client.client.send(request)
@@ -103,7 +108,7 @@ class NotionIndexer(Indexer):
             ) from None
 
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
-        with closing(self.connection_config.get_client()) as client:
+        with self.connection_config.get_client() as client:
             processed_pages: set[str] = set()
             processed_databases: set[str] = set()
 
@@ -285,23 +290,22 @@ class NotionDownloader(Downloader):
     connector_type: str = CONNECTOR_TYPE
 
     def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        with closing(self.connection_config.get_client()) as client:
-            record_locator = file_data.metadata.record_locator
+        record_locator = file_data.metadata.record_locator
+        if "page_id" not in record_locator and "database_id" not in record_locator:
+            raise ValueError("Invalid record_locator in file_data")
 
+        with self.connection_config.get_client() as client:
             if "page_id" in record_locator:
                 return self.download_page(
                     client=client,
                     page_id=record_locator["page_id"],
                     file_data=file_data,
                 )
-            elif "database_id" in record_locator:
-                return self.download_database(
-                    client=client,
-                    database_id=record_locator["database_id"],
-                    file_data=file_data,
-                )
-            else:
-                raise ValueError("Invalid record_locator in file_data")
+            return self.download_database(
+                client=client,
+                database_id=record_locator["database_id"],
+                file_data=file_data,
+            )
 
     def download_page(self, client, page_id: str, file_data: FileData) -> DownloadResponse:
         from unstructured_ingest.processes.connectors.notion.helpers import extract_page_html

--- a/unstructured_ingest/processes/connectors/notion/connector.py
+++ b/unstructured_ingest/processes/connectors/notion/connector.py
@@ -1,3 +1,4 @@
+from contextlib import closing
 from dataclasses import dataclass
 from time import time
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator, Optional
@@ -85,11 +86,11 @@ class NotionIndexer(Indexer):
     def precheck(self) -> None:
         """Check the connection to the Notion API."""
         try:
-            client = self.connection_config.get_client()
-            # Perform a simple request to verify connection
-            request = client._build_request("HEAD", "users")
-            response = client.client.send(request)
-            response.raise_for_status()
+            with closing(self.connection_config.get_client()) as client:
+                # Perform a simple request to verify connection
+                request = client._build_request("HEAD", "users")
+                response = client.client.send(request)
+                response.raise_for_status()
 
         except (ImportError, UnstructuredIngestError):
             # Preserve dependency-install guidance and connector-authored typed
@@ -102,56 +103,56 @@ class NotionIndexer(Indexer):
             ) from None
 
     def run(self, **kwargs: Any) -> Generator[FileData, None, None]:
-        client = self.connection_config.get_client()
-        processed_pages: set[str] = set()
-        processed_databases: set[str] = set()
+        with closing(self.connection_config.get_client()) as client:
+            processed_pages: set[str] = set()
+            processed_databases: set[str] = set()
 
-        pages_to_process: set[str] = set(self.index_config.page_ids or [])
-        databases_to_process: set[str] = set(self.index_config.database_ids or [])
+            pages_to_process: set[str] = set(self.index_config.page_ids or [])
+            databases_to_process: set[str] = set(self.index_config.database_ids or [])
 
-        while pages_to_process or databases_to_process:
-            # Process pages
-            for page_id in list(pages_to_process):
-                if page_id in processed_pages:
-                    continue
+            while pages_to_process or databases_to_process:
+                # Process pages
+                for page_id in list(pages_to_process):
+                    if page_id in processed_pages:
+                        continue
 
-                processed_pages.add(page_id)
-                pages_to_process.remove(page_id)
-                file_data = self.get_page_file_data(page_id=page_id, client=client)
-                if file_data:
-                    yield file_data
+                    processed_pages.add(page_id)
+                    pages_to_process.remove(page_id)
+                    file_data = self.get_page_file_data(page_id=page_id, client=client)
+                    if file_data:
+                        yield file_data
 
-                if self.index_config.recursive:
-                    (child_pages, child_databases) = self.get_child_pages_and_databases(
-                        page_id=page_id,
-                        client=client,
-                        processed_pages=processed_pages,
-                        processed_databases=processed_databases,
-                    )
-                    pages_to_process.update(child_pages)
-                    databases_to_process.update(child_databases)
+                    if self.index_config.recursive:
+                        (child_pages, child_databases) = self.get_child_pages_and_databases(
+                            page_id=page_id,
+                            client=client,
+                            processed_pages=processed_pages,
+                            processed_databases=processed_databases,
+                        )
+                        pages_to_process.update(child_pages)
+                        databases_to_process.update(child_databases)
 
-            # Process databases
-            for database_id in list(databases_to_process):
-                if database_id in processed_databases:
-                    continue
-                processed_databases.add(database_id)
-                databases_to_process.remove(database_id)
-                file_data = self.get_database_file_data(database_id=database_id, client=client)
-                if file_data:
-                    yield file_data
-                if self.index_config.recursive:
-                    (
-                        child_pages,
-                        child_databases,
-                    ) = self.get_child_pages_and_databases_from_database(
-                        database_id=database_id,
-                        client=client,
-                        processed_pages=processed_pages,
-                        processed_databases=processed_databases,
-                    )
-                    pages_to_process.update(child_pages)
-                    databases_to_process.update(child_databases)
+                # Process databases
+                for database_id in list(databases_to_process):
+                    if database_id in processed_databases:
+                        continue
+                    processed_databases.add(database_id)
+                    databases_to_process.remove(database_id)
+                    file_data = self.get_database_file_data(database_id=database_id, client=client)
+                    if file_data:
+                        yield file_data
+                    if self.index_config.recursive:
+                        (
+                            child_pages,
+                            child_databases,
+                        ) = self.get_child_pages_and_databases_from_database(
+                            database_id=database_id,
+                            client=client,
+                            processed_pages=processed_pages,
+                            processed_databases=processed_databases,
+                        )
+                        pages_to_process.update(child_pages)
+                        databases_to_process.update(child_databases)
 
     @requires_dependencies(["notion_client"], extras="notion")
     def get_page_file_data(self, page_id: str, client: "Client") -> Optional[FileData]:
@@ -284,23 +285,23 @@ class NotionDownloader(Downloader):
     connector_type: str = CONNECTOR_TYPE
 
     def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
-        client = self.connection_config.get_client()
-        record_locator = file_data.metadata.record_locator
+        with closing(self.connection_config.get_client()) as client:
+            record_locator = file_data.metadata.record_locator
 
-        if "page_id" in record_locator:
-            return self.download_page(
-                client=client,
-                page_id=record_locator["page_id"],
-                file_data=file_data,
-            )
-        elif "database_id" in record_locator:
-            return self.download_database(
-                client=client,
-                database_id=record_locator["database_id"],
-                file_data=file_data,
-            )
-        else:
-            raise ValueError("Invalid record_locator in file_data")
+            if "page_id" in record_locator:
+                return self.download_page(
+                    client=client,
+                    page_id=record_locator["page_id"],
+                    file_data=file_data,
+                )
+            elif "database_id" in record_locator:
+                return self.download_database(
+                    client=client,
+                    database_id=record_locator["database_id"],
+                    file_data=file_data,
+                )
+            else:
+                raise ValueError("Invalid record_locator in file_data")
 
     def download_page(self, client, page_id: str, file_data: FileData) -> DownloadResponse:
         from unstructured_ingest.processes.connectors.notion.helpers import extract_page_html

--- a/unstructured_ingest/processes/connectors/zendesk/client.py
+++ b/unstructured_ingest/processes/connectors/zendesk/client.py
@@ -17,7 +17,7 @@ from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.utils.string_and_date_utils import fix_unescaped_unicode
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient, Client
+    from httpx import AsyncClient
 
 
 class Attachment(BaseModel):
@@ -186,29 +186,16 @@ class ZendeskClient:
     email: str
     max_page_size: int = 100
     _async_client: "AsyncClient" = field(init=False, default=None)
-    _client: "Client" = field(init=False, default=None)
     _base_url: str = field(init=False, default=None)
 
     async def __aenter__(self) -> "ZendeskClient":
         import httpx
 
-        try:
-            self._async_client = httpx.AsyncClient(auth=self._auth())
-        except Exception:
-            self.close()
-            raise
+        self._async_client = httpx.AsyncClient(auth=self._auth())
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        try:
-            if self._async_client is not None:
-                await self._async_client.aclose()
-                self._async_client = None
-        finally:
-            self.close()
-
-    def close(self) -> None:
-        self._client.close()
+        await self._async_client.aclose()
 
     def _auth(self) -> tuple[str, str]:
         return f"{self.email}/token", self.token
@@ -217,16 +204,15 @@ class ZendeskClient:
     def __post_init__(self):
         import httpx
 
-        self._client = httpx.Client(auth=self._auth())
         self._base_url = f"https://{self.subdomain}.zendesk.com/api/v2"
 
         # Run check
         try:
             url_to_check = f"{self._base_url}/groups.json"
-            resp = self._client.head(url_to_check)
-            resp.raise_for_status()
+            with httpx.Client(auth=self._auth()) as client:
+                resp = client.head(url_to_check)
+                resp.raise_for_status()
         except Exception as e:
-            self._client.close()
             raise self.wrap_error(e=e)
 
     @requires_dependencies(["httpx"], extras="zendesk")

--- a/unstructured_ingest/processes/connectors/zendesk/client.py
+++ b/unstructured_ingest/processes/connectors/zendesk/client.py
@@ -189,19 +189,33 @@ class ZendeskClient:
     _client: "Client" = field(init=False, default=None)
     _base_url: str = field(init=False, default=None)
 
+    @requires_dependencies(["httpx"], extras="zendesk")
     async def __aenter__(self) -> "ZendeskClient":
+        import httpx
+
+        self._async_client = httpx.AsyncClient(auth=self._auth())
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self._async_client.aclose()
+        try:
+            if self._async_client is not None:
+                await self._async_client.aclose()
+                self._async_client = None
+        finally:
+            self.close()
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+
+    def _auth(self) -> tuple[str, str]:
+        return f"{self.email}/token", self.token
 
     @requires_dependencies(["httpx"], extras="zendesk")
     def __post_init__(self):
         import httpx
 
-        auth = f"{self.email}/token", self.token
-        self._client = httpx.Client(auth=auth)
-        self._async_client = httpx.AsyncClient(auth=auth)
+        self._client = httpx.Client(auth=self._auth())
         self._base_url = f"https://{self.subdomain}.zendesk.com/api/v2"
 
         # Run check
@@ -210,6 +224,7 @@ class ZendeskClient:
             resp = self._client.head(url_to_check)
             resp.raise_for_status()
         except Exception as e:
+            self._client.close()
             raise self.wrap_error(e=e)
 
     @requires_dependencies(["httpx"], extras="zendesk")

--- a/unstructured_ingest/processes/connectors/zendesk/client.py
+++ b/unstructured_ingest/processes/connectors/zendesk/client.py
@@ -193,7 +193,11 @@ class ZendeskClient:
     async def __aenter__(self) -> "ZendeskClient":
         import httpx
 
-        self._async_client = httpx.AsyncClient(auth=self._auth())
+        try:
+            self._async_client = httpx.AsyncClient(auth=self._auth())
+        except Exception:
+            self.close()
+            raise
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/unstructured_ingest/processes/connectors/zendesk/client.py
+++ b/unstructured_ingest/processes/connectors/zendesk/client.py
@@ -189,7 +189,6 @@ class ZendeskClient:
     _client: "Client" = field(init=False, default=None)
     _base_url: str = field(init=False, default=None)
 
-    @requires_dependencies(["httpx"], extras="zendesk")
     async def __aenter__(self) -> "ZendeskClient":
         import httpx
 
@@ -209,8 +208,7 @@ class ZendeskClient:
             self.close()
 
     def close(self) -> None:
-        if self._client is not None:
-            self._client.close()
+        self._client.close()
 
     def _auth(self) -> tuple[str, str]:
         return f"{self.email}/token", self.token

--- a/unstructured_ingest/processes/connectors/zendesk/zendesk.py
+++ b/unstructured_ingest/processes/connectors/zendesk/zendesk.py
@@ -76,7 +76,7 @@ class ZendeskIndexer(Indexer):
 
     def precheck(self) -> None:
         """Validates connection to Zendesk API."""
-        self.connection_config.get_client().close()
+        self.connection_config.get_client()
 
     def is_async(self) -> bool:
         return True

--- a/unstructured_ingest/processes/connectors/zendesk/zendesk.py
+++ b/unstructured_ingest/processes/connectors/zendesk/zendesk.py
@@ -76,7 +76,7 @@ class ZendeskIndexer(Indexer):
 
     def precheck(self) -> None:
         """Validates connection to Zendesk API."""
-        self.connection_config.get_client()
+        self.connection_config.get_client().close()
 
     def is_async(self) -> bool:
         return True


### PR DESCRIPTION
## Summary

- close Zendesk sync and async clients on normal and exceptional exits
- avoid opening the Zendesk async client before entering its async context
- close Notion clients after precheck, indexing, and individual downloads
- add focused lifecycle regression coverage

## Why

These connector paths could leave HTTP connection pools open. The Notion downloader could create a new unclosed pool for each file, while Zendesk had leaks around constructor/precheck failures and context-manager exit.

## Impact

Connector operations now release their HTTP resources deterministically. Request behavior and connector output are unchanged.

## Validation

- `uv run --locked --no-sync pytest -q test/unit/connectors/notion/test_connector.py test/unit/connectors/zendesk/test_zendesk_client.py` — 11 passed
- Python 3.13 full unit suite — 1,130 passed, 50 skipped
- Ruff check and format check passed for all changed Python files
- changelog and package versions both set to 1.7.12 (ahead of main's 1.7.11)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

