### PR TITLE
Apply tar extraction filters on supported Python runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.11]
+
+### Fixes
+
+- **fix(security): apply tar extraction filters on supported runtimes.** Tar extraction now detects the existing `tarfile.tar_filter` capability instead of gating it on the Python minor version, so supported Python 3.11 maintenance releases receive the same filtering already used on Python 3.12+. Older patch releases retain the existing warning-and-extract behavior.
+
 ## [1.7.10]
 
 ### Fixes

--- a/test/unit/utils/test_compression.py
+++ b/test/unit/utils/test_compression.py
@@ -1,0 +1,57 @@
+import io
+import logging
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from unstructured_ingest.utils.compression import uncompress_tar_file
+
+
+def _write_tar_member(archive_path: Path, member_name: str, content: bytes) -> None:
+    with tarfile.open(archive_path, "w") as archive:
+        member = tarfile.TarInfo(member_name)
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+
+
+def test_uncompress_tar_file_extracts_benign_members(tmp_path: Path) -> None:
+    archive_path = tmp_path / "benign.tar"
+    destination = tmp_path / "output"
+    _write_tar_member(archive_path, "nested/content.txt", b"content")
+
+    uncompress_tar_file(str(archive_path), str(destination))
+
+    assert (destination / "nested/content.txt").read_bytes() == b"content"
+
+
+@pytest.mark.skipif(
+    not hasattr(tarfile, "tar_filter"),
+    reason="tar extraction filters are unavailable in this Python patch release",
+)
+def test_uncompress_tar_file_rejects_path_traversal(tmp_path: Path) -> None:
+    archive_path = tmp_path / "unsafe.tar"
+    destination = tmp_path / "output"
+    _write_tar_member(archive_path, "../escaped.txt", b"must not escape")
+
+    with pytest.raises(tarfile.FilterError):
+        uncompress_tar_file(str(archive_path), str(destination))
+
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_uncompress_tar_file_warns_when_filter_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    archive_path = tmp_path / "benign.tar"
+    destination = tmp_path / "output"
+    _write_tar_member(archive_path, "content.txt", b"content")
+    monkeypatch.delattr(tarfile, "tar_filter", raising=False)
+
+    with caplog.at_level(logging.WARNING, logger="unstructured_ingest"):
+        uncompress_tar_file(str(archive_path), str(destination))
+
+    assert (destination / "content.txt").read_bytes() == b"content"
+    assert "Extraction filtering for tar files is unavailable" in caplog.text

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.10"  # pragma: no cover
+__version__ = "1.7.11"  # pragma: no cover

--- a/unstructured_ingest/utils/compression.py
+++ b/unstructured_ingest/utils/compression.py
@@ -56,9 +56,9 @@ def uncompress_tar_file(tar_filename: str, path: Optional[str] = None) -> str:
     logger.info(f"extracting tar {tar_filename} -> {path}")
     # NOTE: "r:*" mode opens both compressed (e.g ".tar.gz") and uncompressed ".tar" archives
     with tarfile.open(tar_filename, "r:*") as tfile:
-        # Extraction filters are available in Python 3.12 and in maintained Python 3.11
-        # patch releases. Detect the capability so every supported runtime that provides
-        # the existing mitigation uses it.
+        # NOTE(robinson): Mitigate against malicious content being extracted from the tar file.
+        # Extraction filters are available in Python 3.11.4 and later.
+        # Ref: https://docs.python.org/3/library/tarfile.html#extraction-filters
         if hasattr(tarfile, "tar_filter"):
             tfile.extraction_filter = tarfile.tar_filter
         else:

--- a/unstructured_ingest/utils/compression.py
+++ b/unstructured_ingest/utils/compression.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import tarfile
 import zipfile
 from pathlib import Path
@@ -57,15 +56,15 @@ def uncompress_tar_file(tar_filename: str, path: Optional[str] = None) -> str:
     logger.info(f"extracting tar {tar_filename} -> {path}")
     # NOTE: "r:*" mode opens both compressed (e.g ".tar.gz") and uncompressed ".tar" archives
     with tarfile.open(tar_filename, "r:*") as tfile:
-        # NOTE(robinson): Mitigate against malicious content being extracted from the tar file.
-        # This was added in Python 3.12
-        # Ref: https://docs.python.org/3/library/tarfile.html#extraction-filters
-        if sys.version_info >= (3, 12):
+        # Extraction filters are available in Python 3.12 and in maintained Python 3.11
+        # patch releases. Detect the capability so every supported runtime that provides
+        # the existing mitigation uses it.
+        if hasattr(tarfile, "tar_filter"):
             tfile.extraction_filter = tarfile.tar_filter
         else:
             logger.warning(
-                "Extraction filtering for tar files is available for Python 3.12 and above. "
-                "Consider upgrading your Python version to improve security. "
+                "Extraction filtering for tar files is unavailable in this Python patch "
+                "release. Consider upgrading to Python 3.11.4 or later to improve security. "
                 "See https://docs.python.org/3/library/tarfile.html#extraction-filters"
             )
         tfile.extractall(path=path)


### PR DESCRIPTION
## Summary

- detect the existing `tarfile.tar_filter` capability instead of gating it on the Python minor version
- apply the current tar extraction policy on supported Python 3.11 maintenance releases as well as Python 3.12+
- preserve the existing warning-and-extract behavior when extraction filters are unavailable
- add focused coverage for benign archives, path traversal rejection, and the compatibility fallback

## Why

Tar extraction filtering is currently enabled only when `sys.version_info >= (3, 12)`. Extraction filters are also available on maintained Python 3.11 patch releases supported by this package, so the version gate can leave available protection unused.

Capability detection applies the mitigation wherever the runtime provides it without changing the filter policy or breaking older Python 3.11 patch releases still permitted by the package metadata.

This draft intentionally does **not** switch from `tar_filter` to the stricter `data_filter`, fail closed on older patch releases, or change `requires-python`; those would be separate compatibility and product decisions.

## Impact

On Python runtimes exposing `tarfile.tar_filter`, archive extraction uses the same filter already selected for Python 3.12+. Runtimes without the API retain their current behavior and receive an updated warning recommending Python 3.11.4 or later.

## Validation

- `uv run --locked --no-sync pytest -q test/unit/utils/test_compression.py` — 3 passed
- `uv run --locked --no-sync ruff check unstructured_ingest/utils/compression.py test/unit/utils/test_compression.py`
- `uv run --locked --no-sync ruff format --check unstructured_ingest/utils/compression.py test/unit/utils/test_compression.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

