### PR TITLE
fix(slack): Account for `xoxe.` prefix when classifying slack token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.7.14]
+
+### Fixes
+- **Correctly classify refreshed slack tokens** Slack token is prefixed with 'xoxe.' when obtained via a refresh, slack source now accounts for it when classifying provided token.
+
 ## [1.7.13]
 
 ### Fixes

--- a/test/unit/connectors/test_slack.py
+++ b/test/unit/connectors/test_slack.py
@@ -39,14 +39,17 @@ USER_TOKEN = "xoxp-user"
 
 def test_token_kind_user_prefix():
     assert _token_kind("xoxp-12345") == "user"
+    assert _token_kind("xoxe.xoxp-12345") == "user", "Refreshed variant incorrectly classified"
 
 
 def test_token_kind_bot_prefix():
     assert _token_kind("xoxb-12345") == "bot"
+    assert _token_kind("xoxe.xoxb-12345") == "bot", "Refreshed variant incorrectly classified"
 
 
 def test_token_kind_unknown_prefix_is_bot():
     assert _token_kind("xoxa-12345") == "bot"
+    assert _token_kind("xoxe.xoxa-12345") == "bot"
 
 
 def _ts(day: datetime, *, hours: int = 0, minutes: int = 0, micro: int = 0) -> str:

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.13"  # pragma: no cover
+__version__ = "1.7.14"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -73,6 +73,7 @@ def _slack_async_retry_handlers():
 
 def _token_kind(token: str) -> Literal["user", "bot"]:
     """Returns 'user' for xoxp- tokens, 'bot' for all others."""
+    token = token.removeprefix("xoxe.")
     return "user" if token.startswith("xoxp-") else "bot"
 
 


### PR DESCRIPTION
Slack token is prefixed with `"xoxe."` when obtained via refresh - as referenced in the documentation examples https://docs.slack.dev/authentication/using-token-rotation/#refresh. Update the token classification function to take the prefix into account.

