### PR TITLE
bug(PLU-526): user error classification for postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **Surface mid-upload SQL destination failures as connection errors.** SQL uploaders only wrapped connection failures in `precheck()`; a destination reachable at precheck could still drop during the write loop (e.g. a customer's tunnel to a private database going down), letting a raw driver exception surface as a 500/platform fault. `upload_dataframe` now re-raises such failures as `DestinationConnectionError` (matching `precheck()`), so they are classified as user/downstream faults. Applied to the base SQL uploader (postgres, sqlite, singlestore) and the snowflake, vastdb, duckdb, and motherduck uploaders; teradata already had equivalent handling.
+- **fix(PLU-526): classify SQL/postgres mid-upload connection failures as user errors.** The SQL uploader only wrapped connection failures in `precheck()`; a destination reachable at precheck could still drop during the write loop (e.g. a customer's tunnel to a private Postgres going down), letting the raw driver exception surface as a 500/platform fault. `SQLUploader.upload_dataframe` now re-raises such failures as `DestinationConnectionError` (matching `precheck()`), so they are classified as 4xx/user faults instead.
 
 ## [1.7.15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.16]
+
+### Fixes
+
+- **Surface mid-upload SQL destination failures as connection errors.** SQL uploaders only wrapped connection failures in `precheck()`; a destination reachable at precheck could still drop during the write loop (e.g. a customer's tunnel to a private database going down), letting a raw driver exception surface as a 500/platform fault. `upload_dataframe` now re-raises such failures as `DestinationConnectionError` (matching `precheck()`), so they are classified as user/downstream faults. Applied to the base SQL uploader (postgres, sqlite, singlestore) and the snowflake, vastdb, duckdb, and motherduck uploaders; teradata already had equivalent handling.
+
 ## [1.7.15]
 
 ### Fixes

--- a/test/unit/connectors/sql/test_sql.py
+++ b/test/unit/connectors/sql/test_sql.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from unstructured_ingest.data_types.file_data import BatchItem, FileData, SourceIdentifiers
+from unstructured_ingest.error import DestinationConnectionError, UserError
 from unstructured_ingest.interfaces import DownloadResponse
 from unstructured_ingest.processes.connectors.sql.sql import (
     SqlAdditionalMetadata,
@@ -242,6 +243,67 @@ class TestCanDelete:
         mocker.patch.object(mock_uploader, "get_table_columns", return_value=["id", "text"])
         mock_uploader.upload_config.record_id_key = "record_id"
         assert mock_uploader.can_delete() is False
+
+
+class TestUploadDataframeConnectionErrors:
+    """A destination reachable at precheck() can still drop mid-upload (e.g. a
+    customer's tunnel to a private DB going down). The write path must surface
+    that as DestinationConnectionError (status_code 400 / user fault) rather
+    than letting a raw driver exception read as a 500 / platform fault."""
+
+    def _prepare(self, mocker: MockerFixture, uploader: SQLUploader) -> None:
+        mocker.patch.object(uploader, "can_delete", return_value=False)
+        mocker.patch.object(uploader, "_fit_to_schema", side_effect=lambda df: df)
+        uploader.upload_config.table_name = "elements"
+        uploader.upload_config.batch_size = 50
+        uploader.upload_config.record_id_key = "record_id"
+
+    def _cursor_raising(self, exc: Exception) -> MagicMock:
+        cm = MagicMock()
+        cm.__enter__.side_effect = exc
+        return cm
+
+    def _file_data(self) -> FileData:
+        return FileData(
+            identifier="rec1",
+            connector_type="test",
+            source_identifiers=SourceIdentifiers(filename="rec1.json", fullpath="rec1.json"),
+        )
+
+    def test_raw_driver_error_wrapped_as_destination_connection_error(
+        self, mocker: MockerFixture, mock_uploader: SQLUploader
+    ):
+        self._prepare(mocker, mock_uploader)
+        mocker.patch.object(
+            mock_uploader,
+            "get_cursor",
+            return_value=self._cursor_raising(OSError("connection refused")),
+        )
+
+        with pytest.raises(DestinationConnectionError) as exc_info:
+            mock_uploader.upload_dataframe(
+                df=pd.DataFrame({"col1": [1, 2]}),
+                file_data=self._file_data(),
+            )
+        # 400 is what routes the failure to the 4xx/user bucket downstream.
+        assert exc_info.value.status_code == 400
+
+    def test_typed_ingest_error_passes_through_unwrapped(
+        self, mocker: MockerFixture, mock_uploader: SQLUploader
+    ):
+        self._prepare(mocker, mock_uploader)
+        mocker.patch.object(
+            mock_uploader,
+            "get_cursor",
+            return_value=self._cursor_raising(UserError("bad input")),
+        )
+
+        # Connector-authored typed errors keep their own taxonomy/status_code.
+        with pytest.raises(UserError):
+            mock_uploader.upload_dataframe(
+                df=pd.DataFrame({"col1": [1, 2]}),
+                file_data=self._file_data(),
+            )
 
 
 class TestResolveColumnName:

--- a/test/unit/connectors/sql/test_sql.py
+++ b/test/unit/connectors/sql/test_sql.py
@@ -305,6 +305,43 @@ class TestUploadDataframeConnectionErrors:
                 file_data=self._file_data(),
             )
 
+    def test_schema_probe_failure_wrapped(
+        self, mocker: MockerFixture, mock_uploader: SQLUploader
+    ):
+        # can_delete()/_fit_to_schema() hit the DB (schema probe) before any
+        # INSERT batch; a connection drop there must be wrapped too.
+        mock_uploader.upload_config.table_name = "elements"
+        mock_uploader.upload_config.batch_size = 50
+        mock_uploader.upload_config.record_id_key = "record_id"
+        mocker.patch.object(
+            mock_uploader, "get_table_columns", side_effect=OSError("connection refused")
+        )
+
+        with pytest.raises(DestinationConnectionError) as exc_info:
+            mock_uploader.upload_dataframe(
+                df=pd.DataFrame({"col1": [1, 2]}),
+                file_data=self._file_data(),
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_delete_failure_wrapped(self, mocker: MockerFixture, mock_uploader: SQLUploader):
+        # The pre-INSERT DELETE also hits the DB; a connection drop there must
+        # be wrapped too.
+        mock_uploader.upload_config.table_name = "elements"
+        mock_uploader.upload_config.batch_size = 50
+        mock_uploader.upload_config.record_id_key = "record_id"
+        mocker.patch.object(mock_uploader, "can_delete", return_value=True)
+        mocker.patch.object(
+            mock_uploader, "delete_by_record_id", side_effect=OSError("connection refused")
+        )
+
+        with pytest.raises(DestinationConnectionError) as exc_info:
+            mock_uploader.upload_dataframe(
+                df=pd.DataFrame({"col1": [1, 2]}),
+                file_data=self._file_data(),
+            )
+        assert exc_info.value.status_code == 400
+
 
 class TestResolveColumnName:
     def test_exact_match(self):

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.15"  # pragma: no cover
+__version__ = "1.7.16"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/sql/sql.py
+++ b/unstructured_ingest/processes/connectors/sql/sql.py
@@ -418,51 +418,53 @@ class SQLUploader(Uploader):
     def upload_dataframe(self, df: "DataFrame", file_data: FileData) -> None:
         import numpy as np
 
-        if self.can_delete():
-            self.delete_by_record_id(file_data=file_data)
-        else:
-            logger.warning(
-                f"table doesn't contain expected "
-                f"record id column "
-                f"{self.upload_config.record_id_key}, skipping delete"
-            )
-        df = self._fit_to_schema(df=df)
-        df.replace({np.nan: None}, inplace=True)
+        # A destination reachable at precheck() can still become unreachable
+        # mid-upload (e.g. a network tunnel or the DB endpoint going down). Every
+        # DB interaction below can trip on that: the schema probe (via
+        # can_delete()/_fit_to_schema() -> get_table_columns()), the DELETE, and
+        # the INSERT batches. Wrap the whole workflow so any such failure surfaces
+        # as the same typed connection error precheck() raises (4xx/user) instead
+        # of a bare driver exception that reads as 500/platform.
+        try:
+            if self.can_delete():
+                self.delete_by_record_id(file_data=file_data)
+            else:
+                logger.warning(
+                    f"table doesn't contain expected "
+                    f"record id column "
+                    f"{self.upload_config.record_id_key}, skipping delete"
+                )
+            df = self._fit_to_schema(df=df)
+            df.replace({np.nan: None}, inplace=True)
 
-        columns = list(df.columns)
-        stmt = "INSERT INTO {table_name} ({columns}) VALUES({values})".format(
-            table_name=self.upload_config.table_name,
-            columns=",".join(columns),
-            values=",".join([self.values_delimiter for _ in columns]),
-        )
-        logger.info(
-            f"writing a total of {len(df)} elements via"
-            f" document batches to destination"
-            f" table named {self.upload_config.table_name}"
-            f" with batch size {self.upload_config.batch_size}"
-        )
-        for rows in split_dataframe(df=df, chunk_size=self.upload_config.batch_size):
-            try:
+            columns = list(df.columns)
+            stmt = "INSERT INTO {table_name} ({columns}) VALUES({values})".format(
+                table_name=self.upload_config.table_name,
+                columns=",".join(columns),
+                values=",".join([self.values_delimiter for _ in columns]),
+            )
+            logger.info(
+                f"writing a total of {len(df)} elements via"
+                f" document batches to destination"
+                f" table named {self.upload_config.table_name}"
+                f" with batch size {self.upload_config.batch_size}"
+            )
+            for rows in split_dataframe(df=df, chunk_size=self.upload_config.batch_size):
                 with self.get_cursor() as cursor:
                     values = self.prepare_data(
                         columns, tuple(rows.itertuples(index=False, name=None))
                     )
                     logger.debug(f"running query: {stmt}")
                     cursor.executemany(stmt, values)
-            except (ImportError, UnstructuredIngestError):
-                # Preserve dependency-install guidance and connector-authored typed
-                # errors; only unexpected exceptions are redacted below.
-                raise
-            except Exception as e:
-                # A destination reachable at precheck() can still become
-                # unreachable mid-upload (e.g. a network tunnel or the DB
-                # endpoint going down). Surface it as the same typed connection
-                # error precheck() raises so the platform classifies it 4xx/user
-                # rather than a bare driver exception that reads as 500/platform.
-                logger.error(f"failed to upload batch: {safe_error_summary(e)}")
-                raise DestinationConnectionError(
-                    f"failed to upload batch: {safe_error_summary(e)}"
-                ) from None
+        except (ImportError, UnstructuredIngestError):
+            # Preserve dependency-install guidance and connector-authored typed
+            # errors; only unexpected exceptions are redacted below.
+            raise
+        except Exception as e:
+            logger.error(f"failed to upload: {safe_error_summary(e)}")
+            raise DestinationConnectionError(
+                f"failed to upload: {safe_error_summary(e)}"
+            ) from None
 
     def get_table_columns(self) -> list[str]:
         if self._columns is None:

--- a/unstructured_ingest/processes/connectors/sql/sql.py
+++ b/unstructured_ingest/processes/connectors/sql/sql.py
@@ -442,17 +442,27 @@ class SQLUploader(Uploader):
             f" with batch size {self.upload_config.batch_size}"
         )
         for rows in split_dataframe(df=df, chunk_size=self.upload_config.batch_size):
-            with self.get_cursor() as cursor:
-                values = self.prepare_data(columns, tuple(rows.itertuples(index=False, name=None)))
-                # For debugging purposes:
-                # for val in values:
-                #     try:
-                #         cursor.execute(stmt, val)
-                #     except Exception as e:
-                #         print(f"Error: {e}")
-                #         print(f"failed to write {len(columns)}, {len(val)}: {stmt} -> {val}")
-                logger.debug(f"running query: {stmt}")
-                cursor.executemany(stmt, values)
+            try:
+                with self.get_cursor() as cursor:
+                    values = self.prepare_data(
+                        columns, tuple(rows.itertuples(index=False, name=None))
+                    )
+                    logger.debug(f"running query: {stmt}")
+                    cursor.executemany(stmt, values)
+            except (ImportError, UnstructuredIngestError):
+                # Preserve dependency-install guidance and connector-authored typed
+                # errors; only unexpected exceptions are redacted below.
+                raise
+            except Exception as e:
+                # A destination that is reachable at precheck() can still drop
+                # mid-upload (e.g. a customer's ngrok/SSH tunnel to a private DB
+                # going down). Surface it as the same typed connection error
+                # precheck() raises so the platform classifies it 4xx/user rather
+                # than a bare driver exception that reads as a 500/platform fault.
+                logger.error(f"failed to upload batch: {safe_error_summary(e)}")
+                raise DestinationConnectionError(
+                    f"failed to upload batch: {safe_error_summary(e)}"
+                ) from None
 
     def get_table_columns(self) -> list[str]:
         if self._columns is None:

--- a/unstructured_ingest/processes/connectors/sql/sql.py
+++ b/unstructured_ingest/processes/connectors/sql/sql.py
@@ -454,11 +454,11 @@ class SQLUploader(Uploader):
                 # errors; only unexpected exceptions are redacted below.
                 raise
             except Exception as e:
-                # A destination that is reachable at precheck() can still drop
-                # mid-upload (e.g. a customer's ngrok/SSH tunnel to a private DB
-                # going down). Surface it as the same typed connection error
-                # precheck() raises so the platform classifies it 4xx/user rather
-                # than a bare driver exception that reads as a 500/platform fault.
+                # A destination reachable at precheck() can still become
+                # unreachable mid-upload (e.g. a network tunnel or the DB
+                # endpoint going down). Surface it as the same typed connection
+                # error precheck() raises so the platform classifies it 4xx/user
+                # rather than a bare driver exception that reads as 500/platform.
                 logger.error(f"failed to upload batch: {safe_error_summary(e)}")
                 raise DestinationConnectionError(
                     f"failed to upload batch: {safe_error_summary(e)}"


### PR DESCRIPTION
A user's ngrok tunnel to their private Postgres keeps dropping mid-run.
`precheck()` already wraps connection errors, but `SQLUploader.upload_dataframe`
called `get_cursor()` bare — so a `psycopg2.OperationalError` at write time
bubbled up unwrapped and the plugin host mapped it to a **500** (platform fault,
retryable). It's a customer-side outage, not ours.
### Change
- Wrap the write loop the same way `precheck()` does: pass through
  `ImportError` / typed `UnstructuredIngestError`, otherwise re-raise as
  `DestinationConnectionError` (status_code 400 → 4xx/user, non-retryable).
- Regression tests: raw driver error → `DestinationConnectionError(400)`;
  typed ingest error passes through unwrapped.
### Scope
Base `SQLUploader` covers postgres, sqlite, and singlestore. The same latent
gap in snowflake / vastdb / duckdb / motherduck is deferred to a follow-up
hardening PR; teradata already handles it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

