### PR TITLE
feat(PLU-511): ACL digest (permissions_version) for OneDrive/SharePoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 - **feat(PLU-511): add ACL digest (`permissions_version`) for OneDrive/SharePoint.** Compute a stable SHA-256 digest over a record's `permissions_data` at index time and expose it on `FileDataSourceMetadata.permissions_version`, so an ACL-only change (content unchanged) can trigger reprocessing under incremental. OneDrive/SharePoint emit it over the permissions they already batch-fetch, so there are no additional Graph calls; a call-count telemetry line is logged per index run.
+- **fix(PLU-511): distinguish a failed permission fetch from genuine revocation.** The batch permission fetch now maps an unavailable fetch (error sub-response / exhausted retries) to `None` and a genuine empty result (200 with no permissions) to `[]`. Only `None` skips the digest; an empty list flows through to a stable digest so full access revocation is detected instead of being conflated with a fetch error.
 
 ## [1.7.16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.17]
+
+### Enhancements
+
+- **feat(PLU-511): add ACL digest (`permissions_version`) for OneDrive/SharePoint.** Compute a stable SHA-256 digest over a record's `permissions_data` at index time and expose it on `FileDataSourceMetadata.permissions_version`, so an ACL-only change (content unchanged) can trigger reprocessing under incremental. OneDrive/SharePoint emit it over the permissions they already batch-fetch, so there are no additional Graph calls; a call-count telemetry line is logged per index run.
+
 ## [1.7.16]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-## [1.7.17]
+## [1.8.0]
 
 ### Enhancements
 
-- **feat(PLU-511): add ACL digest (`permissions_version`) for OneDrive/SharePoint.** Compute a stable SHA-256 digest over a record's `permissions_data` at index time and expose it on `FileDataSourceMetadata.permissions_version`, so an ACL-only change (content unchanged) can trigger reprocessing under incremental. OneDrive/SharePoint emit it over the permissions they already batch-fetch, so there are no additional Graph calls; a call-count telemetry line is logged per index run.
-- **fix(PLU-511): distinguish a failed permission fetch from genuine revocation.** The batch permission fetch now maps an unavailable fetch (error sub-response / exhausted retries) to `None` and a genuine empty result (200 with no permissions) to `[]`. Only `None` skips the digest; an empty list flows through to a stable digest so full access revocation is detected instead of being conflated with a fetch error.
-- **fix(PLU-511): SharePoint ACL-digest telemetry + None-default parity.** `SharepointIndexer.run_async` overrides OneDrive's, so it emitted no ACL-digest telemetry and still defaulted a missing permission entry to `[]` (which could fabricate a revocation). Both `run_async` paths now share an `_AclDigestTelemetry` helper (so they can't drift), and SharePoint defaults a missing entry to `None` per the fetch-vs-revocation contract.
+- **feat(PLU-511): ACL digest (`permissions_version`) for OneDrive/SharePoint incremental reprocessing.** Add a `permissions_version` field on `FileDataSourceMetadata` and a new `unstructured_ingest/utils/acl` module that computes a stable SHA-256 digest over a record's permissions at index time, so an ACL-only change (content unchanged) can trigger reprocessing under incremental. OneDrive and SharePoint emit it over the permissions they already batch-fetch, so there are no additional Graph calls. An unavailable permission fetch (error sub-response, exhausted retries, null/malformed body) is kept distinct from a genuinely empty permission set: only the latter (all access revoked) produces a digest, so a fetch failure is never mistaken for a revocation.
 
 ## [1.7.16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **feat(PLU-511): add ACL digest (`permissions_version`) for OneDrive/SharePoint.** Compute a stable SHA-256 digest over a record's `permissions_data` at index time and expose it on `FileDataSourceMetadata.permissions_version`, so an ACL-only change (content unchanged) can trigger reprocessing under incremental. OneDrive/SharePoint emit it over the permissions they already batch-fetch, so there are no additional Graph calls; a call-count telemetry line is logged per index run.
 - **fix(PLU-511): distinguish a failed permission fetch from genuine revocation.** The batch permission fetch now maps an unavailable fetch (error sub-response / exhausted retries) to `None` and a genuine empty result (200 with no permissions) to `[]`. Only `None` skips the digest; an empty list flows through to a stable digest so full access revocation is detected instead of being conflated with a fetch error.
+- **fix(PLU-511): SharePoint ACL-digest telemetry + None-default parity.** `SharepointIndexer.run_async` overrides OneDrive's, so it emitted no ACL-digest telemetry and still defaulted a missing permission entry to `[]` (which could fabricate a revocation). Both `run_async` paths now share an `_AclDigestTelemetry` helper (so they can't drift), and SharePoint defaults a missing entry to `None` per the fetch-vs-revocation contract.
 
 ## [1.7.16]
 

--- a/test/unit/connectors/test_onedrive.py
+++ b/test/unit/connectors/test_onedrive.py
@@ -350,9 +350,7 @@ class TestDriveItemToFileDataSync:
                 "grantedToV2": {"user": {"id": "user-1"}},
             }
         ]
-        file_data = indexer.drive_item_to_file_data_sync(
-            drive_item, raw_permissions=raw_perms
-        )
+        file_data = indexer.drive_item_to_file_data_sync(drive_item, raw_permissions=raw_perms)
         assert file_data.metadata.permissions_data is not None
         assert len(file_data.metadata.permissions_data) == 3
 
@@ -362,13 +360,24 @@ class TestDriveItemToFileDataSync:
         file_data = indexer.drive_item_to_file_data_sync(drive_item)
         assert file_data.metadata.permissions_data is None
 
-    def test_permissions_none_when_empty_list_passed(self):
-        # empty list (e.g. 403 fall-back) leaves the field as None rather than
-        # writing an all-empty placeholder
+    def test_permissions_captured_when_empty_list_passed(self):
+        # Empty list is a genuine "all access revoked" state (distinct from a
+        # failed fetch, which is now None): it produces permissions_data plus a
+        # stable digest so revocation is detected (S9).
         indexer = _make_indexer()
         drive_item = _make_drive_item()
         file_data = indexer.drive_item_to_file_data_sync(drive_item, raw_permissions=[])
+        assert file_data.metadata.permissions_data is not None
+        assert file_data.metadata.permissions_version is not None
+
+    def test_permissions_none_when_fetch_unavailable(self):
+        # None means the permission fetch was unavailable this run; leave the
+        # ACL fields unset rather than fabricating a revocation.
+        indexer = _make_indexer()
+        drive_item = _make_drive_item()
+        file_data = indexer.drive_item_to_file_data_sync(drive_item, raw_permissions=None)
         assert file_data.metadata.permissions_data is None
+        assert file_data.metadata.permissions_version is None
 
 
 def _batch_response(status_code: int = 200, responses: list[dict[str, Any]] | None = None) -> Mock:
@@ -430,7 +439,7 @@ class TestFetchPermissionsRaw:
             "item-f2.docx": "c",
         }
 
-    def test_per_item_403_yields_empty_for_that_item(self):
+    def test_per_item_403_yields_none_for_that_item(self):
         indexer = _make_indexer()
         items = [_make_drive_item(f"f{i}.docx") for i in range(2)]
         body = _batch_response(
@@ -447,7 +456,19 @@ class TestFetchPermissionsRaw:
             result = indexer._fetch_permissions_raw(items, access_token="tok")
 
         assert result["item-f0.docx"][0]["grantedToV2"]["user"]["id"] == "a"
-        assert result["item-f1.docx"] == []
+        # A forbidden sub-response is "unavailable", not "no permissions": None,
+        # so it is never mistaken for a revocation.
+        assert result["item-f1.docx"] is None
+
+    def test_per_item_200_empty_value_is_empty_list(self):
+        # A 200 with an empty value list is a genuine "no permissions" state
+        # (all access revoked): represented as [] and kept distinct from None.
+        indexer = _make_indexer()
+        items = [_make_drive_item("f.docx")]
+        body = _batch_response(responses=[{"id": "0", "status": 200, "body": {"value": []}}])
+        with patch("requests.post", return_value=body):
+            result = indexer._fetch_permissions_raw(items, access_token="tok")
+        assert result == {"item-f.docx": []}
 
     def test_envelope_401_raises_user_auth_error(self):
         indexer = _make_indexer()
@@ -466,7 +487,7 @@ class TestFetchPermissionsRaw:
         body.text = "internal server error"
         with patch("requests.post", return_value=body):
             result = indexer._fetch_permissions_raw(items, access_token="tok")
-        assert result == {"item-f0.docx": [], "item-f1.docx": []}
+        assert result == {"item-f0.docx": None, "item-f1.docx": None}
 
     def test_429_triggers_retry_then_succeeds(self):
         indexer = _make_indexer()
@@ -481,8 +502,10 @@ class TestFetchPermissionsRaw:
                 }
             ]
         )
-        with patch("requests.post", side_effect=[throttled, success]) as mock_post, \
-             patch("tenacity.wait_exponential.__call__", return_value=0):
+        with (
+            patch("requests.post", side_effect=[throttled, success]) as mock_post,
+            patch("tenacity.wait_exponential.__call__", return_value=0),
+        ):
             result = indexer._fetch_permissions_raw(items, access_token="tok")
         assert mock_post.call_count == 2
         assert result["item-f.docx"][0]["grantedToV2"]["user"]["id"] == "x"
@@ -490,14 +513,16 @@ class TestFetchPermissionsRaw:
     def test_network_errors_exhaust_retries_then_degrade(self):
         indexer = _make_indexer()
         items = [_make_drive_item(f"f{i}.docx") for i in range(2)]
-        with patch(
-            "requests.post",
-            side_effect=requests.exceptions.ConnectionError("dns down"),
-        ) as mock_post, \
-             patch("tenacity.wait_exponential.__call__", return_value=0):
+        with (
+            patch(
+                "requests.post",
+                side_effect=requests.exceptions.ConnectionError("dns down"),
+            ) as mock_post,
+            patch("tenacity.wait_exponential.__call__", return_value=0),
+        ):
             result = indexer._fetch_permissions_raw(items, access_token="tok")
         assert mock_post.call_count == 5  # stop_after_attempt(5)
-        assert result == {"item-f0.docx": [], "item-f1.docx": []}
+        assert result == {"item-f0.docx": None, "item-f1.docx": None}
 
     def test_malformed_sub_response_id_skipped(self):
         indexer = _make_indexer()
@@ -510,8 +535,9 @@ class TestFetchPermissionsRaw:
         )
         with patch("requests.post", return_value=body):
             result = indexer._fetch_permissions_raw(items, access_token="tok")
-        # malformed entries are skipped; default empty list remains
-        assert result == {"item-f.docx": []}
+        # malformed entries are skipped; the item never got a 200, so it stays
+        # None (unavailable), not [] (which would imply a genuine revocation)
+        assert result == {"item-f.docx": None}
 
 
 class TestSingletonBleedRegression:
@@ -557,20 +583,14 @@ class TestSingletonBleedRegression:
                 {
                     "id": str(i),
                     "status": 200,
-                    "body": {
-                        "value": [
-                            {"roles": ["read"], "grantedToV2": {"user": {"id": uid}}}
-                        ]
-                    },
+                    "body": {"value": [{"roles": ["read"], "grantedToV2": {"user": {"id": uid}}}]},
                 }
                 for i, uid in enumerate(["alice", "bob", "carol"])
             ]
         }
 
         by_id = indexer._parse_batch_response(batch_payload, items)
-        seen_ids = [
-            by_id[di.id][0]["grantedToV2"]["user"]["id"] for di in items
-        ]
+        seen_ids = [by_id[di.id][0]["grantedToV2"]["user"]["id"] for di in items]
         assert seen_ids == ["alice", "bob", "carol"]
 
         # And running them through extract_permissions yields three distinct users

--- a/test/unit/connectors/test_onedrive.py
+++ b/test/unit/connectors/test_onedrive.py
@@ -12,7 +12,6 @@ from unstructured_ingest.processes.connectors.onedrive import (
     OnedriveConnectionConfig,
     OnedriveIndexer,
     OnedriveIndexerConfig,
-    _AclDigestTelemetry,
 )
 
 
@@ -648,26 +647,3 @@ class TestRoleMapping:
         write_ops = set(MICROSOFT_ROLE_MAPPING["write"])
         owner_ops = set(MICROSOFT_ROLE_MAPPING["owner"])
         assert write_ops.issubset(owner_ops)
-
-
-class TestAclDigestTelemetry:
-    """PLU-511: the shared counter used by both OneDrive and SharePoint run_async."""
-
-    def test_digest_counted_for_permissions_and_revocation(self):
-        t = _AclDigestTelemetry()
-        t.record_batch()
-        t.record_item([{"read": {"users": ["a"], "groups": []}}])  # has perms -> digest
-        t.record_item([])  # genuine empty (revoked) -> still a digest
-        t.record_item(None)  # fetch unavailable -> no digest
-        assert t.permission_batch_calls == 1
-        assert t.items_indexed == 3
-        assert t.digests_computed == 2
-
-    def test_only_batch_calls_are_counted(self):
-        # record_batch is the only ACL-attributable call; nothing else increments it.
-        t = _AclDigestTelemetry()
-        for _ in range(5):
-            t.record_item(None)
-        assert t.permission_batch_calls == 0
-        assert t.digests_computed == 0
-        assert t.items_indexed == 5

--- a/test/unit/connectors/test_onedrive.py
+++ b/test/unit/connectors/test_onedrive.py
@@ -502,6 +502,26 @@ class TestFetchPermissionsRaw:
             result = indexer._fetch_permissions_raw(items, access_token="tok")
         assert result == {"item-f.docx": None}
 
+    @pytest.mark.parametrize(
+        "malformed_body",
+        [
+            [],  # non-dict body (list)
+            "invalid",  # non-dict body (string)
+            {"value": "invalid"},  # value present but not a list
+            {"value": {}},  # value present but not a list
+        ],
+    )
+    def test_per_item_malformed_200_body_degrades_to_none(self, malformed_body):
+        # A 200 can still carry a malformed body. Any non-dict body or non-list
+        # value must degrade to None (skip the digest), never crash the run or
+        # fabricate a revocation.
+        indexer = _make_indexer()
+        items = [_make_drive_item("f.docx")]
+        body = _batch_response(responses=[{"id": "0", "status": 200, "body": malformed_body}])
+        with patch("requests.post", return_value=body):
+            result = indexer._fetch_permissions_raw(items, access_token="tok")
+        assert result == {"item-f.docx": None}
+
     def test_envelope_401_raises_user_auth_error(self):
         indexer = _make_indexer()
         items = [_make_drive_item("f.docx")]

--- a/test/unit/connectors/test_onedrive.py
+++ b/test/unit/connectors/test_onedrive.py
@@ -12,6 +12,7 @@ from unstructured_ingest.processes.connectors.onedrive import (
     OnedriveConnectionConfig,
     OnedriveIndexer,
     OnedriveIndexerConfig,
+    _AclDigestTelemetry,
 )
 
 
@@ -615,3 +616,26 @@ class TestRoleMapping:
         write_ops = set(MICROSOFT_ROLE_MAPPING["write"])
         owner_ops = set(MICROSOFT_ROLE_MAPPING["owner"])
         assert write_ops.issubset(owner_ops)
+
+
+class TestAclDigestTelemetry:
+    """PLU-511: the shared counter used by both OneDrive and SharePoint run_async."""
+
+    def test_digest_counted_for_permissions_and_revocation(self):
+        t = _AclDigestTelemetry()
+        t.record_batch()
+        t.record_item([{"read": {"users": ["a"], "groups": []}}])  # has perms -> digest
+        t.record_item([])  # genuine empty (revoked) -> still a digest
+        t.record_item(None)  # fetch unavailable -> no digest
+        assert t.permission_batch_calls == 1
+        assert t.items_indexed == 3
+        assert t.digests_computed == 2
+
+    def test_only_batch_calls_are_counted(self):
+        # record_batch is the only ACL-attributable call; nothing else increments it.
+        t = _AclDigestTelemetry()
+        for _ in range(5):
+            t.record_item(None)
+        assert t.permission_batch_calls == 0
+        assert t.digests_computed == 0
+        assert t.items_indexed == 5

--- a/test/unit/connectors/test_onedrive.py
+++ b/test/unit/connectors/test_onedrive.py
@@ -177,9 +177,15 @@ class TestExtractPermissions:
         indexer._extract_identity_ids_from_raw = OnedriveIndexer._extract_identity_ids_from_raw
         return indexer
 
-    def test_empty_permissions_returns_empty_dict_list(self, indexer):
+    def test_empty_permissions_returns_normalized_all_empty_triple(self, indexer):
+        # A revoked/empty permission set normalizes to the same all-empty triple
+        # as permissions whose roles map to no operation, so both hash equally.
         result = indexer.extract_permissions([])
-        assert result == [{}]
+        assert result == [
+            {"read": {"users": [], "groups": []}},
+            {"update": {"users": [], "groups": []}},
+            {"delete": {"users": [], "groups": []}},
+        ]
 
     def test_owner_role_maps_to_all_operations(self, indexer):
         result = indexer.extract_permissions(
@@ -362,13 +368,19 @@ class TestDriveItemToFileDataSync:
         assert file_data.metadata.permissions_data is None
 
     def test_permissions_captured_when_empty_list_passed(self):
-        # Empty list is a genuine "all access revoked" state (distinct from a
-        # failed fetch, which is now None): it produces permissions_data plus a
-        # stable digest so revocation is detected (S9).
+        # An empty list is a genuine "all access revoked" state (distinct from a
+        # failed fetch, which is None): it produces the normalized all-empty
+        # triple plus a stable digest so revocation is detected. Pinning the
+        # exact shape guards against representation drift that would look like an
+        # ACL change.
         indexer = _make_indexer()
         drive_item = _make_drive_item()
         file_data = indexer.drive_item_to_file_data_sync(drive_item, raw_permissions=[])
-        assert file_data.metadata.permissions_data is not None
+        assert file_data.metadata.permissions_data == [
+            {"read": {"users": [], "groups": []}},
+            {"update": {"users": [], "groups": []}},
+            {"delete": {"users": [], "groups": []}},
+        ]
         assert file_data.metadata.permissions_version is not None
 
     def test_permissions_none_when_fetch_unavailable(self):
@@ -470,6 +482,26 @@ class TestFetchPermissionsRaw:
         with patch("requests.post", return_value=body):
             result = indexer._fetch_permissions_raw(items, access_token="tok")
         assert result == {"item-f.docx": []}
+
+    def test_per_item_null_body_degrades_to_none(self):
+        # A 200 with a null body must not crash the index run; it degrades to
+        # None (unavailable), not [] (which would be a fabricated revocation).
+        indexer = _make_indexer()
+        items = [_make_drive_item("f.docx")]
+        body = _batch_response(responses=[{"id": "0", "status": 200, "body": None}])
+        with patch("requests.post", return_value=body):
+            result = indexer._fetch_permissions_raw(items, access_token="tok")
+        assert result == {"item-f.docx": None}
+
+    def test_per_item_200_missing_value_key_degrades_to_none(self):
+        # A 200 body with no "value" key is malformed/unavailable -> None, not a
+        # fabricated revocation.
+        indexer = _make_indexer()
+        items = [_make_drive_item("f.docx")]
+        body = _batch_response(responses=[{"id": "0", "status": 200, "body": {}}])
+        with patch("requests.post", return_value=body):
+            result = indexer._fetch_permissions_raw(items, access_token="tok")
+        assert result == {"item-f.docx": None}
 
     def test_envelope_401_raises_user_auth_error(self):
         indexer = _make_indexer()

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock, patch
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from pydantic import Secret
@@ -667,3 +668,55 @@ class TestSharepointInheritsPermissionMachinery:
         assert mock_post.call_args[0][0] == "https://graph.microsoft.com/v1.0/$batch"
         assert mock_post.call_args[1]["headers"]["Authorization"] == "Bearer tok"
         assert result["item-a.docx"][0]["grantedToV2"]["user"]["id"] == "u-1"
+
+
+def test_flush_missing_permission_entry_defaults_to_none():
+    """PLU-511: SharepointIndexer._flush must pass raw_permissions=None for a
+    drive item missing from the permission-fetch result (fetch unavailable ->
+    skip digest), not [] (which would fabricate a revocation). A present entry
+    still flows through unchanged. Mirrors OneDrive's perms_by_id.get(id) default.
+    """
+    conn = Mock(spec=SharepointConnectionConfig)
+    conn.site = "https://test.sharepoint.com/sites/test"
+    conn.get_token.return_value = {"access_token": "tok"}
+    conn.get_client.return_value = Mock()
+    conn._get_drive_item.return_value = Mock()
+
+    idx_config = Mock(spec=SharepointIndexerConfig)
+    idx_config.path = ""
+    idx_config.recursive = False
+
+    indexer = SharepointIndexer(connection_config=conn, index_config=idx_config)
+
+    di_present = Mock()
+    di_present.id = "present"
+    di_missing = Mock()
+    di_missing.id = "missing"
+
+    captured: dict = {}
+
+    async def _capture(drive_item, raw_permissions=None):
+        captured[drive_item.id] = raw_permissions
+        return Mock()
+
+    with (
+        patch.object(SharepointIndexer, "_get_target_drive_item") as mock_target,
+        patch.object(
+            indexer,
+            "_fetch_permissions_raw",
+            return_value={"present": [{"roles": ["read"]}]},  # "missing" omitted
+        ),
+        patch.object(indexer, "drive_item_to_file_data", new=AsyncMock(side_effect=_capture)),
+    ):
+        mock_target.return_value.get_files.return_value.execute_query.return_value = [
+            di_present,
+            di_missing,
+        ]
+
+        async def _drain():
+            return [fd async for fd in indexer.run_async()]
+
+        asyncio.run(_drain())
+
+    assert captured["present"] == [{"roles": ["read"]}]
+    assert captured["missing"] is None

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -671,10 +671,10 @@ class TestSharepointInheritsPermissionMachinery:
 
 
 def test_flush_missing_permission_entry_defaults_to_none():
-    """PLU-511: SharepointIndexer._flush must pass raw_permissions=None for a
-    drive item missing from the permission-fetch result (fetch unavailable ->
-    skip digest), not [] (which would fabricate a revocation). A present entry
-    still flows through unchanged. Mirrors OneDrive's perms_by_id.get(id) default.
+    """SharepointIndexer._flush must pass raw_permissions=None for a drive item
+    missing from the permission-fetch result (fetch unavailable -> skip digest),
+    not [] (which would fabricate a revocation). A present entry still flows
+    through unchanged. Mirrors OneDrive's perms_by_id.get(id) default.
     """
     conn = Mock(spec=SharepointConnectionConfig)
     conn.site = "https://test.sharepoint.com/sites/test"

--- a/test/unit/utils/test_acl.py
+++ b/test/unit/utils/test_acl.py
@@ -1,0 +1,69 @@
+"""PLU-511: ACL digest determinism and behavior (acceptance-test scenario S5)."""
+
+from unstructured_ingest.utils.acl import compute_permissions_version
+
+
+def _perms(read_users):
+    return [
+        {"read": {"users": read_users, "groups": []}},
+        {"update": {"users": [], "groups": []}},
+        {"delete": {"users": [], "groups": []}},
+    ]
+
+
+def test_none_permissions_returns_none():
+    # No ACL signal at all -> no digest (connector did not emit permissions).
+    assert compute_permissions_version(None) is None
+
+
+def test_empty_permissions_is_a_real_digest():
+    # Empty list is a real state (e.g. all access revoked), not "no signal".
+    digest = compute_permissions_version([])
+    assert digest is not None
+    assert compute_permissions_version(None) != digest
+
+
+def test_same_permissions_same_digest():
+    assert compute_permissions_version(_perms(["a", "b"])) == compute_permissions_version(
+        _perms(["a", "b"])
+    )
+
+
+def test_reordered_users_same_digest():
+    # S5: same permissions, different order -> identical digest, no false positive.
+    assert compute_permissions_version(_perms(["a", "b"])) == compute_permissions_version(
+        _perms(["b", "a"])
+    )
+
+
+def test_reordered_operations_same_digest():
+    # The list of operation dicts may come back in any order.
+    forward = [
+        {"read": {"users": ["a"], "groups": []}},
+        {"update": {"users": [], "groups": []}},
+    ]
+    reversed_order = [
+        {"update": {"users": [], "groups": []}},
+        {"read": {"users": ["a"], "groups": []}},
+    ]
+    assert compute_permissions_version(forward) == compute_permissions_version(reversed_order)
+
+
+def test_real_change_changes_digest():
+    # S2/S9: a genuine ACL change must move the digest.
+    assert compute_permissions_version(_perms(["a"])) != compute_permissions_version(
+        _perms(["a", "c"])
+    )
+
+
+def test_revocation_changes_digest():
+    # S9: going from granted to fully revoked (empty) must change the digest.
+    assert compute_permissions_version(_perms(["a", "b"])) != compute_permissions_version([])
+
+
+def test_denied_permissions_affect_digest():
+    # Deny-side changes (FileNet sibling keys) must also move the digest.
+    base = _perms(["a"])
+    assert compute_permissions_version(base, denied_permissions_data=None) != (
+        compute_permissions_version(base, denied_permissions_data=[{"read": {"deny_users": ["x"]}}])
+    )

--- a/test/unit/utils/test_acl.py
+++ b/test/unit/utils/test_acl.py
@@ -67,3 +67,18 @@ def test_denied_permissions_affect_digest():
     assert compute_permissions_version(base, denied_permissions_data=None) != (
         compute_permissions_version(base, denied_permissions_data=[{"read": {"deny_users": ["x"]}}])
     )
+
+
+def test_denied_only_permissions_have_digest():
+    # None allows + non-None denies is a distinct code path (the early-return
+    # guard requires BOTH args None). It must still yield a stable, non-None
+    # digest computed from the deny side alone.
+    digest = compute_permissions_version(
+        None, denied_permissions_data=[{"read": {"deny_users": ["x"]}}]
+    )
+    assert digest is not None
+    assert digest != compute_permissions_version(None, denied_permissions_data=None)
+    # And a deny-side change moves it.
+    assert digest != compute_permissions_version(
+        None, denied_permissions_data=[{"read": {"deny_users": ["y"]}}]
+    )

--- a/test/unit/utils/test_acl.py
+++ b/test/unit/utils/test_acl.py
@@ -1,4 +1,4 @@
-"""PLU-511: ACL digest determinism and behavior (acceptance-test scenario S5)."""
+"""ACL digest determinism and behavior."""
 
 from unstructured_ingest.utils.acl import compute_permissions_version
 
@@ -30,7 +30,7 @@ def test_same_permissions_same_digest():
 
 
 def test_reordered_users_same_digest():
-    # S5: same permissions, different order -> identical digest, no false positive.
+    # Same permissions, different order -> identical digest, no false positive.
     assert compute_permissions_version(_perms(["a", "b"])) == compute_permissions_version(
         _perms(["b", "a"])
     )
@@ -50,14 +50,14 @@ def test_reordered_operations_same_digest():
 
 
 def test_real_change_changes_digest():
-    # S2/S9: a genuine ACL change must move the digest.
+    # A genuine ACL change must move the digest.
     assert compute_permissions_version(_perms(["a"])) != compute_permissions_version(
         _perms(["a", "c"])
     )
 
 
 def test_revocation_changes_digest():
-    # S9: going from granted to fully revoked (empty) must change the digest.
+    # Going from granted to fully revoked (empty) must change the digest.
     assert compute_permissions_version(_perms(["a", "b"])) != compute_permissions_version([])
 
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.16"  # pragma: no cover
+__version__ = "1.7.17"  # pragma: no cover

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.17"  # pragma: no cover
+__version__ = "1.8.0"  # pragma: no cover

--- a/unstructured_ingest/data_types/file_data.py
+++ b/unstructured_ingest/data_types/file_data.py
@@ -30,6 +30,7 @@ class FileDataSourceMetadata(BaseModel):
     date_modified: Optional[str] = None
     date_processed: Optional[str] = None
     permissions_data: Optional[list[dict[str, Any]]] = None
+    permissions_version: Optional[str] = None
     filesize_bytes: Optional[int] = None
 
 

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -44,6 +44,7 @@ from unstructured_ingest.processes.utils.blob_storage import (
     BlobStoreUploadStager,
     BlobStoreUploadStagerConfig,
 )
+from unstructured_ingest.utils.acl import compute_permissions_version
 from unstructured_ingest.utils.dep_check import requires_dependencies
 
 if TYPE_CHECKING:
@@ -341,6 +342,9 @@ class OnedriveIndexer(Indexer):
         )
         if raw_permissions:
             file_data.metadata.permissions_data = self.extract_permissions(raw_permissions)
+            file_data.metadata.permissions_version = compute_permissions_version(
+                file_data.metadata.permissions_data
+            )
         return file_data
 
     async def drive_item_to_file_data(

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -81,47 +81,6 @@ class _RetriableBatchError(Exception):
     """Marker exception for transient Graph $batch failures (network, 429, 503)."""
 
 
-@dataclass
-class _AclDigestTelemetry:
-    """PLU-511 call-count telemetry, shared by the OneDrive and SharePoint
-    ``run_async`` paths so they report the digest's marginal API cost the same
-    way and can't drift apart. Only ``_fetch_permissions_raw`` batch calls are
-    counted (record_batch); site/drive-resolution calls are not, since they are
-    not attributable to the digest.
-    """
-
-    permission_batch_calls: int = 0
-    digests_computed: int = 0
-    items_indexed: int = 0
-
-    def record_batch(self) -> None:
-        """One Graph $batch permission fetch (the only ACL-attributable call)."""
-        self.permission_batch_calls += 1
-
-    def record_item(self, raw_permissions: Optional[list[dict[str, Any]]]) -> None:
-        """Account one indexed item. A digest is computed unless the permission
-        fetch was unavailable (None); an empty list is a real (revoked) digest."""
-        self.items_indexed += 1
-        if raw_permissions is not None:
-            self.digests_computed += 1
-
-    def log(self, connector_type: str) -> None:
-        # The count is permission-fetch batches (one per chunk / _fetch_permissions_raw
-        # invocation), not raw HTTP requests: that helper may retry the POST on
-        # throttling/network errors, which are not counted here. That's fine for the
-        # PLU-511 claim, which is that the digest itself makes no Graph calls of its
-        # own (it hashes permissions already fetched for ACL metadata) -- its marginal
-        # API cost is zero by construction, not a separately measured value.
-        logger.info(
-            f"ACL digest telemetry (PLU-511) [{connector_type}]: indexed "
-            f"{self.items_indexed} item(s), computed {self.digests_computed} "
-            f"permissions_version digest(s) over permissions fetched in "
-            f"{self.permission_batch_calls} batch(es) for ACL metadata (HTTP retries "
-            f"not counted separately); the digest hashes already-fetched data and "
-            f"makes no Graph calls of its own."
-        )
-
-
 class OnedriveAccessConfig(AccessConfig):
     client_cred: Optional[str] = Field(default=None, description="Microsoft App client secret")
     password: Optional[str] = Field(description="Service account password", default=None)
@@ -640,24 +599,15 @@ class OnedriveIndexer(Indexer):
         root = await self.get_root(client=client)
         drive_items = await self.list_objects(folder=root, recursive=self.index_config.recursive)
 
-        # Call-count telemetry for the ACL digest (PLU-511); shared with the
-        # SharePoint indexer via _AclDigestTelemetry so both paths report it
-        # identically. None = fetch unavailable (skip digest); [] = revoked
-        # (real digest).
-        telemetry = _AclDigestTelemetry()
         for i in range(0, len(drive_items), PERMISSIONS_BATCH_SIZE):
             chunk = drive_items[i : i + PERMISSIONS_BATCH_SIZE]
             perms_by_id = await asyncio.to_thread(self._fetch_permissions_raw, chunk, access_token)
-            telemetry.record_batch()
             for drive_item in chunk:
-                raw_permissions = perms_by_id.get(drive_item.id)
-                telemetry.record_item(raw_permissions)
+                # None = fetch unavailable (skip digest); [] = revoked (real digest).
                 yield await self.drive_item_to_file_data(
                     drive_item=drive_item,
-                    raw_permissions=raw_permissions,
+                    raw_permissions=perms_by_id.get(drive_item.id),
                 )
-
-        telemetry.log(self.connector_type)
 
 
 class OnedriveDownloaderConfig(DownloaderConfig):

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -457,8 +457,11 @@ class OnedriveIndexer(Indexer):
         """Normalize raw Graph permission dicts to the read/update/delete schema
         shared with Google Drive and Confluence connectors."""
         if not raw_permissions:
+            # A revoked/empty permission set normalizes to the same all-empty
+            # read/update/delete triple as permissions whose roles map to no
+            # operation, so both produce the same digest and drifting between the
+            # two representations doesn't look like an ACL change.
             logger.debug("no permissions found")
-            return [{}]
 
         normalized: dict[str, dict[str, set[str]]] = {
             "read": {"users": set(), "groups": set()},
@@ -518,7 +521,11 @@ class OnedriveIndexer(Indexer):
             di = drive_items[idx]
             status = sub.get("status")
             if status == 200:
-                by_id[di.id] = sub.get("body", {}).get("value", [])
+                # A present-but-empty value list is a genuine "no permissions"
+                # (revoked) state and stays []. A null/absent body or a missing
+                # value key is malformed/unavailable and degrades to None (skip
+                # the digest) rather than a fabricated revocation.
+                by_id[di.id] = (sub.get("body") or {}).get("value")
             elif status in (401, 403):
                 logger.error(f"forbidden fetching permissions for {di.name} (status {status})")
             elif status == 404:

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -340,7 +340,10 @@ class OnedriveIndexer(Indexer):
             additional_metadata=self.get_properties_sync(drive_item=drive_item),
             display_name=server_path,
         )
-        if raw_permissions:
+        # None means the permission fetch was unavailable this run (error / no
+        # sub-response); leave the ACL fields unset. An empty list is a real
+        # state (all access revoked) and flows through to a stable digest (S9).
+        if raw_permissions is not None:
             file_data.metadata.permissions_data = self.extract_permissions(raw_permissions)
             file_data.metadata.permissions_version = compute_permissions_version(
                 file_data.metadata.permissions_data
@@ -447,9 +450,16 @@ class OnedriveIndexer(Indexer):
     def _parse_batch_response(
         payload: dict[str, Any],
         drive_items: list["DriveItem"],
-    ) -> dict[str, list[dict[str, Any]]]:
-        """Map Graph $batch sub-responses to {drive_item.id: raw_permission_dicts}."""
-        by_id: dict[str, list[dict[str, Any]]] = {di.id: [] for di in drive_items}
+    ) -> dict[str, Optional[list[dict[str, Any]]]]:
+        """Map Graph $batch sub-responses to {drive_item.id: raw_permission_dicts}.
+
+        A value of None means permissions were not successfully fetched for that
+        item (error sub-response, or missing). An empty list means the item
+        genuinely has no permissions (all access revoked). Keeping the two
+        distinct lets the digest capture revocation (S9) without mistaking a
+        fetch error for one.
+        """
+        by_id: dict[str, Optional[list[dict[str, Any]]]] = {di.id: None for di in drive_items}
         for sub in payload.get("responses", []):
             sub_id = sub.get("id")
             # Builtin ValueError is shadowed in this module; use explicit
@@ -464,9 +474,7 @@ class OnedriveIndexer(Indexer):
             if status == 200:
                 by_id[di.id] = sub.get("body", {}).get("value", [])
             elif status in (401, 403):
-                logger.error(
-                    f"forbidden fetching permissions for {di.name} (status {status})"
-                )
+                logger.error(f"forbidden fetching permissions for {di.name} (status {status})")
             elif status == 404:
                 logger.warning(f"permissions not found for {di.name}")
             else:
@@ -481,15 +489,18 @@ class OnedriveIndexer(Indexer):
         self,
         drive_items: list["DriveItem"],
         access_token: str,
-    ) -> dict[str, list[dict[str, Any]]]:
+    ) -> dict[str, Optional[list[dict[str, Any]]]]:
         """Fetch raw permission JSON for a batch of drive items via Graph /$batch.
 
         Bypasses the office365 SDK because its IdentitySet/SharePointIdentitySet
         have a mutable-default-arg singleton that collapses all Permission
         identities to whichever user was deserialized last in the process.
 
-        Returns {drive_item.id: [raw_permission_dict, ...]}. Failed sub-requests
-        and exhausted retries (network / 429 / 503) degrade to empty lists.
+        Returns {drive_item.id: [raw_permission_dict, ...]}. A value of None means
+        the fetch was unavailable for that item (failed sub-request, or exhausted
+        retries on network / 429 / 503); an empty list means the item genuinely
+        has no permissions. The two are kept distinct so revocation is captured
+        while a fetch error is not mistaken for one.
         """
         import requests
         from tenacity import (
@@ -507,10 +518,7 @@ class OnedriveIndexer(Indexer):
                 {
                     "id": str(idx),
                     "method": "GET",
-                    "url": (
-                        f"/drives/{di.parent_reference.driveId}"
-                        f"/items/{di.id}/permissions"
-                    ),
+                    "url": (f"/drives/{di.parent_reference.driveId}/items/{di.id}/permissions"),
                 }
                 for idx, di in enumerate(drive_items)
             ]
@@ -547,7 +555,7 @@ class OnedriveIndexer(Indexer):
                 f"giving up after retries on Graph $batch: {exc}; "
                 f"skipping permissions for {len(drive_items)} items"
             )
-            return {di.id: [] for di in drive_items}
+            return {di.id: None for di in drive_items}
 
         if resp.status_code == 401:
             raise UserAuthError(
@@ -559,7 +567,7 @@ class OnedriveIndexer(Indexer):
                 f"Graph $batch returned {resp.status_code}; "
                 f"skipping permissions for {len(drive_items)} items: {resp.text[:200]}"
             )
-            return {di.id: [] for di in drive_items}
+            return {di.id: None for di in drive_items}
 
         return self._parse_batch_response(resp.json(), drive_items)
 
@@ -589,13 +597,12 @@ class OnedriveIndexer(Indexer):
         items_indexed = 0
         for i in range(0, len(drive_items), PERMISSIONS_BATCH_SIZE):
             chunk = drive_items[i : i + PERMISSIONS_BATCH_SIZE]
-            perms_by_id = await asyncio.to_thread(
-                self._fetch_permissions_raw, chunk, access_token
-            )
+            perms_by_id = await asyncio.to_thread(self._fetch_permissions_raw, chunk, access_token)
             permission_batch_calls += 1
             for drive_item in chunk:
-                raw_permissions = perms_by_id.get(drive_item.id, [])
-                if raw_permissions:
+                raw_permissions = perms_by_id.get(drive_item.id)
+                # None = fetch unavailable (no digest); [] = revoked (real digest).
+                if raw_permissions is not None:
                     digests_computed += 1
                 items_indexed += 1
                 yield await self.drive_item_to_file_data(

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -342,12 +342,11 @@ class OnedriveIndexer(Indexer):
         )
         # None means the permission fetch was unavailable this run (error / no
         # sub-response); leave the ACL fields unset. An empty list is a real
-        # state (all access revoked) and flows through to a stable digest (S9).
+        # state (all access revoked) and flows through to a stable digest.
         #
         # NOTE: the digest inherits permissions_data's coverage. SharePoint
-        # siteGroup grants are excluded (see _extract_identity_ids_from_raw /
-        # PLU-370), so site-group-mediated ACL changes don't move the digest.
-        # Known limitation.
+        # siteGroup grants are excluded (see _extract_identity_ids_from_raw), so
+        # site-group-mediated ACL changes don't move the digest. Known limitation.
         if raw_permissions is not None:
             file_data.metadata.permissions_data = self.extract_permissions(raw_permissions)
             file_data.metadata.permissions_version = compute_permissions_version(
@@ -464,8 +463,8 @@ class OnedriveIndexer(Indexer):
         A value of None means permissions were not successfully fetched for that
         item (error sub-response, or missing). An empty list means the item
         genuinely has no permissions (all access revoked). Keeping the two
-        distinct lets the digest capture revocation (S9) without mistaking a
-        fetch error for one.
+        distinct lets the digest capture revocation without mistaking a fetch
+        error for one.
         """
         by_id: dict[str, Optional[list[dict[str, Any]]]] = {di.id: None for di in drive_items}
         for sub in payload.get("responses", []):

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -579,16 +579,36 @@ class OnedriveIndexer(Indexer):
         root = await self.get_root(client=client)
         drive_items = await self.list_objects(folder=root, recursive=self.index_config.recursive)
 
+        # Call-count telemetry for the ACL digest (PLU-511). The digest is
+        # computed over permissions the connector already batch-fetches for
+        # ACL metadata, so it issues no Graph calls of its own. Counting the
+        # permission fetches against the digests computed proves the marginal
+        # API cost of the digest is zero.
+        permission_batch_calls = 0
+        digests_computed = 0
+        items_indexed = 0
         for i in range(0, len(drive_items), PERMISSIONS_BATCH_SIZE):
             chunk = drive_items[i : i + PERMISSIONS_BATCH_SIZE]
             perms_by_id = await asyncio.to_thread(
                 self._fetch_permissions_raw, chunk, access_token
             )
+            permission_batch_calls += 1
             for drive_item in chunk:
+                raw_permissions = perms_by_id.get(drive_item.id, [])
+                if raw_permissions:
+                    digests_computed += 1
+                items_indexed += 1
                 yield await self.drive_item_to_file_data(
                     drive_item=drive_item,
-                    raw_permissions=perms_by_id.get(drive_item.id, []),
+                    raw_permissions=raw_permissions,
                 )
+
+        logger.info(
+            f"ACL digest telemetry (PLU-511): indexed {items_indexed} item(s), "
+            f"computed {digests_computed} permissions_version digest(s) over "
+            f"permissions already fetched via {permission_batch_calls} Graph "
+            f"$batch call(s); 0 additional API calls attributable to the digest."
+        )
 
 
 class OnedriveDownloaderConfig(DownloaderConfig):

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -479,11 +479,16 @@ class OnedriveIndexer(Indexer):
             di = drive_items[idx]
             status = sub.get("status")
             if status == 200:
-                # A present-but-empty value list is a genuine "no permissions"
-                # (revoked) state and stays []. A null/absent body or a missing
-                # value key is malformed/unavailable and degrades to None (skip
-                # the digest) rather than a fabricated revocation.
-                by_id[di.id] = (sub.get("body") or {}).get("value")
+                # A 200 can still carry a malformed body, so validate the shape
+                # before trusting it: body must be a dict and value a list.
+                # Anything else (null/absent body, a non-dict body, a missing or
+                # non-list value) is unavailable -> None, so the item skips the
+                # digest instead of crashing the run or fabricating a revocation.
+                # A present-but-empty list is a genuine "no permissions" (revoked)
+                # state and stays [].
+                body = sub.get("body")
+                value = body.get("value") if isinstance(body, dict) else None
+                by_id[di.id] = value if isinstance(value, list) else None
             elif status in (401, 403):
                 logger.error(f"forbidden fetching permissions for {di.name} (status {status})")
             elif status == 404:

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -81,6 +81,44 @@ class _RetriableBatchError(Exception):
     """Marker exception for transient Graph $batch failures (network, 429, 503)."""
 
 
+@dataclass
+class _AclDigestTelemetry:
+    """PLU-511 call-count telemetry, shared by the OneDrive and SharePoint
+    ``run_async`` paths so they report the digest's marginal API cost the same
+    way and can't drift apart. Only ``_fetch_permissions_raw`` batch calls are
+    counted (record_batch); site/drive-resolution calls are not, since they are
+    not attributable to the digest.
+    """
+
+    permission_batch_calls: int = 0
+    digests_computed: int = 0
+    items_indexed: int = 0
+
+    def record_batch(self) -> None:
+        """One Graph $batch permission fetch (the only ACL-attributable call)."""
+        self.permission_batch_calls += 1
+
+    def record_item(self, raw_permissions: Optional[list[dict[str, Any]]]) -> None:
+        """Account one indexed item. A digest is computed unless the permission
+        fetch was unavailable (None); an empty list is a real (revoked) digest."""
+        self.items_indexed += 1
+        if raw_permissions is not None:
+            self.digests_computed += 1
+
+    def log(self, connector_type: str) -> None:
+        # Report the counts as the evidence themselves; the digest is computed
+        # over permissions already fetched for ACL metadata and issues no Graph
+        # calls of its own (it hashes already-fetched data), so its marginal API
+        # cost is zero by construction rather than by a separately measured value.
+        logger.info(
+            f"ACL digest telemetry (PLU-511) [{connector_type}]: indexed "
+            f"{self.items_indexed} item(s), computed {self.digests_computed} "
+            f"permissions_version digest(s) over permissions already fetched via "
+            f"{self.permission_batch_calls} Graph $batch call(s); the digest hashes "
+            f"already-fetched data and makes no Graph calls of its own."
+        )
+
+
 class OnedriveAccessConfig(AccessConfig):
     client_cred: Optional[str] = Field(default=None, description="Microsoft App client secret")
     password: Optional[str] = Field(description="Service account password", default=None)
@@ -343,6 +381,11 @@ class OnedriveIndexer(Indexer):
         # None means the permission fetch was unavailable this run (error / no
         # sub-response); leave the ACL fields unset. An empty list is a real
         # state (all access revoked) and flows through to a stable digest (S9).
+        #
+        # NOTE: the digest inherits permissions_data's coverage. SharePoint
+        # siteGroup grants are excluded (see _extract_identity_ids_from_raw /
+        # PLU-370), so site-group-mediated ACL changes don't move the digest.
+        # Known limitation.
         if raw_permissions is not None:
             file_data.metadata.permissions_data = self.extract_permissions(raw_permissions)
             file_data.metadata.permissions_version = compute_permissions_version(
@@ -587,35 +630,24 @@ class OnedriveIndexer(Indexer):
         root = await self.get_root(client=client)
         drive_items = await self.list_objects(folder=root, recursive=self.index_config.recursive)
 
-        # Call-count telemetry for the ACL digest (PLU-511). The digest is
-        # computed over permissions the connector already batch-fetches for
-        # ACL metadata, so it issues no Graph calls of its own. Counting the
-        # permission fetches against the digests computed proves the marginal
-        # API cost of the digest is zero.
-        permission_batch_calls = 0
-        digests_computed = 0
-        items_indexed = 0
+        # Call-count telemetry for the ACL digest (PLU-511); shared with the
+        # SharePoint indexer via _AclDigestTelemetry so both paths report it
+        # identically. None = fetch unavailable (skip digest); [] = revoked
+        # (real digest).
+        telemetry = _AclDigestTelemetry()
         for i in range(0, len(drive_items), PERMISSIONS_BATCH_SIZE):
             chunk = drive_items[i : i + PERMISSIONS_BATCH_SIZE]
             perms_by_id = await asyncio.to_thread(self._fetch_permissions_raw, chunk, access_token)
-            permission_batch_calls += 1
+            telemetry.record_batch()
             for drive_item in chunk:
                 raw_permissions = perms_by_id.get(drive_item.id)
-                # None = fetch unavailable (no digest); [] = revoked (real digest).
-                if raw_permissions is not None:
-                    digests_computed += 1
-                items_indexed += 1
+                telemetry.record_item(raw_permissions)
                 yield await self.drive_item_to_file_data(
                     drive_item=drive_item,
                     raw_permissions=raw_permissions,
                 )
 
-        logger.info(
-            f"ACL digest telemetry (PLU-511): indexed {items_indexed} item(s), "
-            f"computed {digests_computed} permissions_version digest(s) over "
-            f"permissions already fetched via {permission_batch_calls} Graph "
-            f"$batch call(s); 0 additional API calls attributable to the digest."
-        )
+        telemetry.log(self.connector_type)
 
 
 class OnedriveDownloaderConfig(DownloaderConfig):

--- a/unstructured_ingest/processes/connectors/onedrive.py
+++ b/unstructured_ingest/processes/connectors/onedrive.py
@@ -106,16 +106,19 @@ class _AclDigestTelemetry:
             self.digests_computed += 1
 
     def log(self, connector_type: str) -> None:
-        # Report the counts as the evidence themselves; the digest is computed
-        # over permissions already fetched for ACL metadata and issues no Graph
-        # calls of its own (it hashes already-fetched data), so its marginal API
-        # cost is zero by construction rather than by a separately measured value.
+        # The count is permission-fetch batches (one per chunk / _fetch_permissions_raw
+        # invocation), not raw HTTP requests: that helper may retry the POST on
+        # throttling/network errors, which are not counted here. That's fine for the
+        # PLU-511 claim, which is that the digest itself makes no Graph calls of its
+        # own (it hashes permissions already fetched for ACL metadata) -- its marginal
+        # API cost is zero by construction, not a separately measured value.
         logger.info(
             f"ACL digest telemetry (PLU-511) [{connector_type}]: indexed "
             f"{self.items_indexed} item(s), computed {self.digests_computed} "
-            f"permissions_version digest(s) over permissions already fetched via "
-            f"{self.permission_batch_calls} Graph $batch call(s); the digest hashes "
-            f"already-fetched data and makes no Graph calls of its own."
+            f"permissions_version digest(s) over permissions fetched in "
+            f"{self.permission_batch_calls} batch(es) for ACL metadata (HTTP retries "
+            f"not counted separately); the digest hashes already-fetched data and "
+            f"makes no Graph calls of its own."
         )
 
 

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -33,6 +33,7 @@ from unstructured_ingest.processes.connectors.onedrive import (
     OnedriveDownloaderConfig,
     OnedriveIndexer,
     OnedriveIndexerConfig,
+    _AclDigestTelemetry,
 )
 from unstructured_ingest.utils.dep_check import requires_dependencies
 
@@ -327,12 +328,22 @@ class SharepointIndexer(OnedriveIndexer):
             self._get_target_drive_item, site_drive_item, path
         )
 
+        # Shared ACL-digest telemetry (PLU-511); same helper OneDrive uses, so
+        # SharePoint reports the digest's marginal API cost identically. Only the
+        # _fetch_permissions_raw batch call is counted (record_batch), not the
+        # site/drive-resolution calls above. None = fetch unavailable (skip
+        # digest); [] = revoked (real digest).
+        telemetry = _AclDigestTelemetry()
+
         async def _flush(chunk: list[DriveItem]) -> AsyncIterator[FileData]:
             perms_by_id = await asyncio.to_thread(self._fetch_permissions_raw, chunk, access_token)
+            telemetry.record_batch()
             for di in chunk:
+                raw_permissions = perms_by_id.get(di.id)
+                telemetry.record_item(raw_permissions)
                 yield await self.drive_item_to_file_data(
                     drive_item=di,
-                    raw_permissions=perms_by_id.get(di.id, []),
+                    raw_permissions=raw_permissions,
                 )
 
         try:
@@ -353,6 +364,8 @@ class SharepointIndexer(OnedriveIndexer):
         if chunk:
             async for fd in _flush(chunk):
                 yield fd
+
+        telemetry.log(self.connector_type)
 
 
 class SharepointDownloaderConfig(OnedriveDownloaderConfig):

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -33,7 +33,6 @@ from unstructured_ingest.processes.connectors.onedrive import (
     OnedriveDownloaderConfig,
     OnedriveIndexer,
     OnedriveIndexerConfig,
-    _AclDigestTelemetry,
 )
 from unstructured_ingest.utils.dep_check import requires_dependencies
 
@@ -328,22 +327,13 @@ class SharepointIndexer(OnedriveIndexer):
             self._get_target_drive_item, site_drive_item, path
         )
 
-        # Shared ACL-digest telemetry (PLU-511); same helper OneDrive uses, so
-        # SharePoint reports the digest's marginal API cost identically. Only the
-        # _fetch_permissions_raw batch call is counted (record_batch), not the
-        # site/drive-resolution calls above. None = fetch unavailable (skip
-        # digest); [] = revoked (real digest).
-        telemetry = _AclDigestTelemetry()
-
         async def _flush(chunk: list[DriveItem]) -> AsyncIterator[FileData]:
             perms_by_id = await asyncio.to_thread(self._fetch_permissions_raw, chunk, access_token)
-            telemetry.record_batch()
             for di in chunk:
-                raw_permissions = perms_by_id.get(di.id)
-                telemetry.record_item(raw_permissions)
+                # None = fetch unavailable (skip digest); [] = revoked (real digest).
                 yield await self.drive_item_to_file_data(
                     drive_item=di,
-                    raw_permissions=raw_permissions,
+                    raw_permissions=perms_by_id.get(di.id),
                 )
 
         try:
@@ -364,8 +354,6 @@ class SharepointIndexer(OnedriveIndexer):
         if chunk:
             async for fd in _flush(chunk):
                 yield fd
-
-        telemetry.log(self.connector_type)
 
 
 class SharepointDownloaderConfig(OnedriveDownloaderConfig):

--- a/unstructured_ingest/utils/acl.py
+++ b/unstructured_ingest/utils/acl.py
@@ -1,0 +1,42 @@
+"""Helpers for deriving a stable ACL digest from a record's permissions.
+
+PLU-511: the digest is compared alongside the content version token so that an
+ACL-only change at the source (content unchanged) still triggers a reprocess
+under incremental. It must be deterministic: the same permissions in a different
+order must produce the same digest, or reordering causes false-positive
+reprocesses (see acceptance-test scenario S5).
+"""
+
+import hashlib
+import json
+from typing import Any, Optional
+
+
+def _canonicalize(obj: Any) -> Any:
+    """Recursively sort dict keys and lists so equivalent permissions hash equally."""
+    if isinstance(obj, dict):
+        return {key: _canonicalize(obj[key]) for key in sorted(obj)}
+    if isinstance(obj, list):
+        canon_items = [_canonicalize(item) for item in obj]
+        return sorted(canon_items, key=lambda item: json.dumps(item, sort_keys=True))
+    return obj
+
+
+def compute_permissions_version(
+    permissions_data: Optional[list[dict[str, Any]]],
+    denied_permissions_data: Optional[list[dict[str, Any]]] = None,
+) -> Optional[str]:
+    """Return a stable SHA-256 digest of a record's ACL, or None if there is none.
+
+    Returns None only when there is no ACL signal at all (the connector did not
+    emit permissions). An empty list is a real state (e.g. all access revoked)
+    and produces a stable, non-None digest so revocation is detected.
+    """
+    if permissions_data is None and denied_permissions_data is None:
+        return None
+    payload = {
+        "permissions": _canonicalize(permissions_data or []),
+        "denied": _canonicalize(denied_permissions_data or []),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/unstructured_ingest/utils/acl.py
+++ b/unstructured_ingest/utils/acl.py
@@ -1,10 +1,10 @@
 """Helpers for deriving a stable ACL digest from a record's permissions.
 
-PLU-511: the digest is compared alongside the content version token so that an
-ACL-only change at the source (content unchanged) still triggers a reprocess
-under incremental. It must be deterministic: the same permissions in a different
-order must produce the same digest, or reordering causes false-positive
-reprocesses (see acceptance-test scenario S5).
+The digest is compared alongside the content version token so that an ACL-only
+change at the source (content unchanged) still triggers a reprocess under
+incremental. It must be deterministic: the same permissions in a different order
+must produce the same digest, or reordering would cause false-positive
+reprocesses.
 """
 
 import hashlib


### PR DESCRIPTION
## What

Adds a per-file **ACL digest** (`permissions_version`) so an ACL-only change can trigger reprocessing under incremental (`reprocess_all = false`), following the mechanism recommended in the [spike](https://app.notion.com/p/3a02c3765a0a805da24ce23761ceed82). This is the connector-layer slice of PLU-511; it pairs with the invoker changes in platform-plugins and the compare/write-back in platform-etl-orchestration (#1250).

- `utils/acl.py` — `compute_permissions_version(permissions_data, denied_permissions_data=None)`: canonicalizes (recursive sort) then `sha256`. Returns `None` only when there is no ACL signal at all; an empty list is a real state (all access revoked) and yields a stable digest.
- `data_types/file_data.py` — new `permissions_version` field on `FileDataSourceMetadata`.
- `processes/connectors/onedrive.py` — the indexer computes the digest over the permissions it already batch-fetches (SharePoint inherits this base class). Adds call-count telemetry proving the digest issues **0 additional Graph calls**.
- `test/unit/utils/test_acl.py` — determinism / order-independence / empty-vs-None behavior.

## Validated

Proven end to end on an SND against a real SharePoint site: an ACL-only change (content unchanged) reprocesses exactly the changed file (spike scenarios S2/S8). See PLU-511 for evidence.

## Notes

- **Draft.** Branch is behind `main` and needs a rebase before merge.
- Known limitation surfaced during validation: SharePoint `siteGroup` ACL changes are not captured (pre-existing PLU-370 `_extract_identity_ids_from_raw` exclusion), so a site-group-only change won't move the digest. Documented in the spike; follow-up TBD.

PLU-511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

