### PR TITLE
feat(vertexai): support Gemini-family embedding models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.9.0]
+
+### Enhancements
+
+- **feat: support Gemini-family Vertex AI embedding models (e.g. `gemini-embedding-2`).** These are served through `google-genai`'s `embed_content` rather than the legacy `TextEmbeddingModel` interface, which previously failed at client construction. Adds Gemini-only `region`, `dimensionality`, and `task` settings; legacy `text-embedding-00*` models are unchanged.
+
 ## [1.8.0]
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-- **feat: support Gemini-family Vertex AI embedding models (e.g. `gemini-embedding-2`).** These are served through `google-genai`'s `embed_content` rather than the legacy `TextEmbeddingModel` interface, which previously failed at client construction. Adds Gemini-only `region`, `dimensionality`, and `task` settings, reachable from the pipeline as `embedding_vertexai_region`/`embedding_vertexai_dimensionality`/`embedding_vertexai_task` on `EmbedderConfig`; legacy `text-embedding-00*` models are unchanged.
+- **feat: support Gemini-family Vertex AI embedding models (e.g. `gemini-embedding-2`).** These are served through `google-genai`'s `embed_content` rather than the legacy `TextEmbeddingModel` interface, which previously failed at client construction. Adds Gemini-only `region`, `dimensionality`, and `task` settings, reachable from the pipeline as `embedding_vertexai_region`/`embedding_vertexai_dimensionality`/`embedding_vertexai_task` on `EmbedderConfig`; legacy `text-embedding-00*` models are unchanged. Region defaults to `global`, the only location that serves both families.
 
 ## [1.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-- **feat: support Gemini-family Vertex AI embedding models (e.g. `gemini-embedding-2`).** These are served through `google-genai`'s `embed_content` rather than the legacy `TextEmbeddingModel` interface, which previously failed at client construction. Adds Gemini-only `region`, `dimensionality`, and `task` settings; legacy `text-embedding-00*` models are unchanged.
+- **feat: support Gemini-family Vertex AI embedding models (e.g. `gemini-embedding-2`).** These are served through `google-genai`'s `embed_content` rather than the legacy `TextEmbeddingModel` interface, which previously failed at client construction. Adds Gemini-only `region`, `dimensionality`, and `task` settings, reachable from the pipeline as `embedding_vertexai_region`/`embedding_vertexai_dimensionality`/`embedding_vertexai_task` on `EmbedderConfig`; legacy `text-embedding-00*` models are unchanged.
 
 ## [1.8.0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ mixedbreadai = ["mixedbread"]
 octoai = ["openai", "tiktoken"]
 openai = ["openai>=2.20,<3", "tiktoken"]
 togetherai = ["together"]
-vertexai = ["vertexai"]
+vertexai = ["vertexai", "google-genai"]
 voyageai = ["voyageai", "langchain-core>=1.2.22,<2.0.0"]
 
 # Remote
@@ -158,6 +158,7 @@ test = [
     "cryptography",
     "fsspec",
     "vertexai",
+    "google-genai",
     "pyiceberg",
     "pyarrow",
     "networkx",

--- a/test/unit/embed/test_vertexai.py
+++ b/test/unit/embed/test_vertexai.py
@@ -153,6 +153,21 @@ def test_genai_embed_batch_forwards_dimensionality_and_task(mocker):
     assert sent.task_type == "RETRIEVAL_DOCUMENT"
 
 
+def test_genai_embed_batch_forwards_zero_dimensionality(mocker):
+    """0 is a configured value, not "unset" — forward it and let the provider reject it, rather
+    than silently sending the model's full-width default."""
+    config = VertexAIEmbeddingConfig(
+        api_key=CREDENTIALS, model_name="gemini-embedding-2", dimensionality=0
+    )
+    client = _genai_client(mocker, [[0.1]])
+
+    config.embed_batch(client=client, batch=["a"])
+
+    sent = client.models.embed_content.call_args.kwargs["config"]
+    assert sent is not None
+    assert sent.output_dimensionality == 0
+
+
 def test_legacy_embed_batch_uses_text_embedding_model(mocker):
     config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="text-embedding-005")
     client = mocker.MagicMock()

--- a/test/unit/embed/test_vertexai.py
+++ b/test/unit/embed/test_vertexai.py
@@ -286,11 +286,18 @@ def test_genai_client_built_for_the_publisher_path_location(mocker, monkeypatch)
     assert client.models.embed_content.call_args.kwargs["model"] == model
 
 
-def test_missing_region_raises_user_error(monkeypatch):
+def test_missing_region_defaults_to_global(monkeypatch):
+    """Availability is per-model, not per-deployment: the Gemini embedding family is served from
+    'global' and 404s in ordinary regions like us-east1, so 'global' is the only safe default."""
     monkeypatch.delenv("VERTEXAI_REGION", raising=False)
     config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
-    with pytest.raises(UserError, match="Vertex AI region is required"):
-        config._resolve_location()
+    assert config._resolve_location() == "global"
+
+
+def test_env_region_still_wins_over_the_global_default(monkeypatch):
+    monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    assert config._resolve_location() == "us-east1"
 
 
 def test_genai_client_requires_project_id(monkeypatch):

--- a/test/unit/embed/test_vertexai.py
+++ b/test/unit/embed/test_vertexai.py
@@ -49,7 +49,13 @@ def test_embed_documents_does_not_break_element_to_dict(mocker):
         ("text-embedding-005", False),
         ("text-embedding-004", False),
         ("textembedding-gecko@001", False),
-        # A fine-tune resource path is not a Gemini embedding id and keeps the legacy transport.
+        # A publisher-style resource path names the model in its final segment, so it routes on
+        # that. This is the canonical way to pin a region, and embed_content accepts the full path.
+        ("projects/p/locations/global/publishers/google/models/gemini-embedding-2", True),
+        ("projects/p/locations/us-central1/publishers/google/models/gemini-embedding-001", True),
+        ("projects/p/locations/us-central1/publishers/google/models/text-embedding-005", False),
+        # A bare fine-tune endpoint path names no model, so it carries no signal about which family
+        # it serves and stays on the legacy transport.
         ("projects/p/locations/us-east1/endpoints/123", False),
     ],
 )
@@ -240,13 +246,44 @@ def test_explicit_region_wins_over_env(monkeypatch):
 
 
 def test_resource_path_region_wins_over_config_and_env(monkeypatch):
+    """A publisher path pins the location, and the client must be built for that same location or
+    the request 404s — so the path beats both the explicit region and the env var."""
     monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
     config = VertexAIEmbeddingConfig(
         api_key=CREDENTIALS,
-        model_name="projects/p/locations/europe-west1/endpoints/123",
+        model_name="projects/p/locations/europe-west1/publishers/google/models/gemini-embedding-2",
         region="us-central1",
     )
+    assert config.uses_genai_transport, "a publisher path must reach the genai transport"
     assert config._resolve_location() == "europe-west1"
+
+
+def test_genai_client_built_for_the_publisher_path_location(mocker, monkeypatch):
+    """End-to-end: the location in a publisher path reaches the genai client, and the full path is
+    still what gets sent as the model id."""
+    monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
+    model = "projects/p/locations/europe-west1/publishers/google/models/gemini-embedding-2"
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name=model)
+
+    mocker.patch(
+        "google.oauth2.service_account.Credentials.from_service_account_info",
+        return_value=mocker.sentinel.credentials,
+    )
+    client_cls = mocker.patch("google.genai.Client")
+
+    config.get_genai_client()
+
+    kwargs = client_cls.call_args.kwargs
+    assert kwargs["location"] == "europe-west1"
+    assert kwargs["project"] == "test-project"
+    assert kwargs["vertexai"] is True
+    # Routing unwraps the path, but the provider is still given the full resource path as the model.
+    client = mocker.MagicMock()
+    client.models.embed_content.return_value = mocker.MagicMock(
+        embeddings=[mocker.MagicMock(values=[0.1])]
+    )
+    config.embed_batch(client=client, batch=["a"])
+    assert client.models.embed_content.call_args.kwargs["model"] == model
 
 
 def test_missing_region_raises_user_error(monkeypatch):

--- a/test/unit/embed/test_vertexai.py
+++ b/test/unit/embed/test_vertexai.py
@@ -1,4 +1,16 @@
-from unstructured_ingest.embed.vertexai import VertexAIEmbeddingConfig, VertexAIEmbeddingEncoder
+import asyncio
+
+import pytest
+
+from unstructured_ingest.embed.vertexai import (
+    AsyncVertexAIEmbeddingEncoder,
+    VertexAIEmbeddingConfig,
+    VertexAIEmbeddingEncoder,
+    _vertex_multi_region_base_url,
+)
+from unstructured_ingest.error import ProviderError, UserError
+
+CREDENTIALS = {"project_id": "test-project", "type": "service_account"}
 
 
 def test_embed_documents_does_not_break_element_to_dict(mocker):
@@ -23,3 +35,228 @@ def test_embed_documents_does_not_break_element_to_dict(mocker):
     assert len(elements) == 2
     assert elements[0]["text"] == "This is sentence 1"
     assert elements[1]["text"] == "This is sentence 2"
+
+
+# --- transport routing -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("gemini-embedding-2", True),
+        ("gemini-embedding-001", True),
+        ("GEMINI-EMBEDDING-2", True),
+        ("text-embedding-005", False),
+        ("text-embedding-004", False),
+        ("textembedding-gecko@001", False),
+        # A fine-tune resource path is not a Gemini embedding id and keeps the legacy transport.
+        ("projects/p/locations/us-east1/endpoints/123", False),
+    ],
+)
+def test_uses_genai_transport(model_name: str, expected: bool):
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name=model_name)
+    assert config.uses_genai_transport is expected
+
+
+def test_get_client_routes_gemini_to_genai(mocker):
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    genai = mocker.patch.object(VertexAIEmbeddingConfig, "get_genai_client")
+    legacy = mocker.patch.object(VertexAIEmbeddingConfig, "get_legacy_client")
+
+    config.get_client()
+
+    genai.assert_called_once()
+    legacy.assert_not_called()
+
+
+def test_get_client_routes_legacy_model_to_text_embedding_model(mocker):
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="text-embedding-005")
+    genai = mocker.patch.object(VertexAIEmbeddingConfig, "get_genai_client")
+    legacy = mocker.patch.object(VertexAIEmbeddingConfig, "get_legacy_client")
+
+    config.get_client()
+
+    legacy.assert_called_once()
+    genai.assert_not_called()
+
+
+# --- genai embed calls -----------------------------------------------------------------------
+
+
+def _genai_client(mocker, values: list[list[float]]):
+    """A genai client whose embed_content returns one embedding per call, in order."""
+    client = mocker.MagicMock()
+
+    def respond(**kwargs):
+        response = mocker.MagicMock()
+        response.embeddings = [mocker.MagicMock(values=values[respond.calls])]
+        respond.calls += 1
+        return response
+
+    respond.calls = 0
+    client.models.embed_content.side_effect = respond
+    return client
+
+
+def test_genai_embed_batch_sends_one_request_per_text(mocker):
+    """embedContent takes exactly one content per request: a list of strings is coalesced into a
+    single multi-part Content and returns one vector for the whole batch. Fan out instead."""
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    client = _genai_client(mocker, [[0.1, 0.2], [0.3, 0.4]])
+
+    result = config.embed_batch(client=client, batch=["a", "b"])
+
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+    assert client.models.embed_content.call_count == 2
+    sent = [call.kwargs["contents"] for call in client.models.embed_content.call_args_list]
+    assert sent == ["a", "b"], "each text must be sent as its own single content"
+    first = client.models.embed_content.call_args_list[0].kwargs
+    assert first["model"] == "gemini-embedding-2"
+    # No dimensionality/task configured -> no config object is sent
+    assert first["config"] is None
+
+
+def test_genai_embed_batch_accepts_a_tuple_batch(mocker):
+    """batch_generator yields tuples, so the transport must not assume a list."""
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    client = _genai_client(mocker, [[0.1], [0.2]])
+
+    result = config.embed_batch(client=client, batch=("a", "b"))
+
+    assert result == [[0.1], [0.2]]
+
+
+def test_genai_embed_batch_raises_when_no_embedding_returned(mocker):
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    client = mocker.MagicMock()
+    response = mocker.MagicMock()
+    response.embeddings = []
+    client.models.embed_content.return_value = response
+
+    with pytest.raises(ProviderError, match="no embedding"):
+        config.embed_batch(client=client, batch=["a"])
+
+
+def test_genai_embed_batch_forwards_dimensionality_and_task(mocker):
+    config = VertexAIEmbeddingConfig(
+        api_key=CREDENTIALS,
+        model_name="gemini-embedding-2",
+        dimensionality=768,
+        task="RETRIEVAL_DOCUMENT",
+    )
+    client = _genai_client(mocker, [[0.1]])
+
+    config.embed_batch(client=client, batch=["a"])
+
+    sent = client.models.embed_content.call_args.kwargs["config"]
+    assert sent.output_dimensionality == 768
+    assert sent.task_type == "RETRIEVAL_DOCUMENT"
+
+
+def test_legacy_embed_batch_uses_text_embedding_model(mocker):
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="text-embedding-005")
+    client = mocker.MagicMock()
+    client.get_embeddings.return_value = [mocker.MagicMock(values=[0.7])]
+
+    result = config.embed_batch(client=client, batch=["a"])
+
+    assert result == [[0.7]]
+    client.get_embeddings.assert_called_once()
+    client.models.embed_content.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_genai_embed_batch_async_fans_out_preserving_order(mocker):
+    """Concurrent per-text requests must still come back aligned with the input order."""
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    client = mocker.MagicMock()
+    vectors = {"a": [0.1], "b": [0.2], "c": [0.3]}
+    sent = []
+
+    async def embed_content(**kwargs):
+        text = kwargs["contents"]
+        sent.append(text)
+        # Resolve out of input order so a mis-ordered gather would be caught.
+        await asyncio.sleep(0.01 if text == "a" else 0)
+        response = mocker.MagicMock()
+        response.embeddings = [mocker.MagicMock(values=vectors[text])]
+        return response
+
+    client.aio.models.embed_content = embed_content
+
+    result = await config.embed_batch_async(client=client, batch=("a", "b", "c"))
+
+    assert result == [[0.1], [0.2], [0.3]]
+    assert sorted(sent) == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_async_encoder_delegates_to_config(mocker):
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    encoder = AsyncVertexAIEmbeddingEncoder(config=config)
+    mocker.patch.object(VertexAIEmbeddingConfig, "get_client", return_value=mocker.MagicMock())
+    embed = mocker.patch.object(
+        VertexAIEmbeddingConfig,
+        "embed_batch_async",
+        return_value=[[0.1], [0.2]],
+    )
+
+    elements = await encoder.embed_documents(elements=[{"text": "a"}, {"text": "b"}])
+
+    embed.assert_awaited_once()
+    assert [e["embeddings"] for e in elements] == [[0.1], [0.2]]
+
+
+# --- region resolution -----------------------------------------------------------------------
+
+
+def test_region_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    assert config._resolve_location() == "us-east1"
+
+
+def test_explicit_region_wins_over_env(monkeypatch):
+    monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
+    config = VertexAIEmbeddingConfig(
+        api_key=CREDENTIALS, model_name="gemini-embedding-2", region="europe-west4"
+    )
+    assert config._resolve_location() == "europe-west4"
+
+
+def test_resource_path_region_wins_over_config_and_env(monkeypatch):
+    monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
+    config = VertexAIEmbeddingConfig(
+        api_key=CREDENTIALS,
+        model_name="projects/p/locations/europe-west1/endpoints/123",
+        region="us-central1",
+    )
+    assert config._resolve_location() == "europe-west1"
+
+
+def test_missing_region_raises_user_error(monkeypatch):
+    monkeypatch.delenv("VERTEXAI_REGION", raising=False)
+    config = VertexAIEmbeddingConfig(api_key=CREDENTIALS, model_name="gemini-embedding-2")
+    with pytest.raises(UserError, match="Vertex AI region is required"):
+        config._resolve_location()
+
+
+def test_genai_client_requires_project_id(monkeypatch):
+    monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
+    config = VertexAIEmbeddingConfig(
+        api_key={"type": "service_account"}, model_name="gemini-embedding-2"
+    )
+    with pytest.raises(UserError, match="project_id"):
+        config.get_genai_client()
+
+
+@pytest.mark.parametrize(
+    ("location", "expected_base_url"),
+    [
+        ("us", "https://aiplatform.us.rep.googleapis.com/"),
+        ("eu", "https://aiplatform.eu.rep.googleapis.com/"),
+        ("us-east1", None),
+    ],
+)
+def test_multi_region_base_url(location: str, expected_base_url):
+    assert _vertex_multi_region_base_url(location) == expected_base_url

--- a/test/unit/embedders/test_vertexai.py
+++ b/test/unit/embedders/test_vertexai.py
@@ -61,6 +61,8 @@ def test_embedder_config_forwards_gemini_settings():
 
 
 def test_embedder_config_forwards_zero_dimensionality():
+    """0 must survive the forwarding filter: it is a configured width, not "unset". A truthiness
+    filter here would drop it and silently fall back to the model's full width."""
     embedder = EmbedderConfig(
         embedding_provider="vertexai",
         embedding_api_key=CREDENTIALS,
@@ -83,3 +85,28 @@ def test_embedder_config_omits_unset_gemini_settings():
     assert embedder.config.region is None
     assert embedder.config.dimensionality is None
     assert embedder.config.task is None
+
+
+def test_embedder_config_leaves_region_env_fallback_intact(monkeypatch):
+    """The end-to-end consequence of not forwarding an unset region: $VERTEXAI_REGION still wins,
+    so a pipeline that never sets the region keeps reaching its configured region."""
+    monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
+    embedder = EmbedderConfig(
+        embedding_provider="vertexai",
+        embedding_api_key=CREDENTIALS,
+        embedding_model_name="gemini-embedding-2",
+    ).get_embedder()
+
+    assert embedder.config._resolve_location() == "us-east1"
+
+
+def test_embedder_config_region_overrides_env(monkeypatch):
+    monkeypatch.setenv("VERTEXAI_REGION", "us-east1")
+    embedder = EmbedderConfig(
+        embedding_provider="vertexai",
+        embedding_api_key=CREDENTIALS,
+        embedding_model_name="gemini-embedding-2",
+        embedding_vertexai_region="europe-west4",
+    ).get_embedder()
+
+    assert embedder.config._resolve_location() == "europe-west4"

--- a/test/unit/embedders/test_vertexai.py
+++ b/test/unit/embedders/test_vertexai.py
@@ -7,8 +7,11 @@ import pytest
 
 from test.unit.utils.data_generator import generate_random_dictionary
 from unstructured_ingest.embed.vertexai import VertexAIEmbeddingConfig, VertexAIEmbeddingEncoder
+from unstructured_ingest.processes.embedder import EmbedderConfig
 
 fake = faker.Faker()
+
+CREDENTIALS = json.dumps({"project_id": "test-project", "type": "service_account"})
 
 
 def generate_embedder_config_params() -> dict:
@@ -35,3 +38,48 @@ def test_embedder(embedder_config_params: dict):
     embedder_config = VertexAIEmbeddingConfig.model_validate(embedder_config_params)
     embedder = VertexAIEmbeddingEncoder(config=embedder_config)
     assert embedder
+
+
+# --- EmbedderConfig pass-through ---------------------------------------------------------------
+
+
+def test_embedder_config_forwards_gemini_settings():
+    """The Gemini-only settings must survive the generic EmbedderConfig path, which is how the
+    pipeline builds embedders."""
+    embedder = EmbedderConfig(
+        embedding_provider="vertexai",
+        embedding_api_key=CREDENTIALS,
+        embedding_model_name="gemini-embedding-2",
+        embedding_vertexai_region="europe-west4",
+        embedding_vertexai_dimensionality=768,
+        embedding_vertexai_task="RETRIEVAL_DOCUMENT",
+    ).get_embedder()
+
+    assert embedder.config.region == "europe-west4"
+    assert embedder.config.dimensionality == 768
+    assert embedder.config.task == "RETRIEVAL_DOCUMENT"
+
+
+def test_embedder_config_forwards_zero_dimensionality():
+    embedder = EmbedderConfig(
+        embedding_provider="vertexai",
+        embedding_api_key=CREDENTIALS,
+        embedding_model_name="gemini-embedding-2",
+        embedding_vertexai_dimensionality=0,
+    ).get_embedder()
+
+    assert embedder.config.dimensionality == 0
+
+
+def test_embedder_config_omits_unset_gemini_settings():
+    """Unset settings must not be forwarded as explicit values, so the config's own defaults —
+    including the VERTEXAI_REGION fallback — stay reachable."""
+    embedder = EmbedderConfig(
+        embedding_provider="vertexai",
+        embedding_api_key=CREDENTIALS,
+        embedding_model_name="gemini-embedding-2",
+    ).get_embedder()
+
+    assert embedder.config.region is None
+    assert embedder.config.dimensionality is None
+    assert embedder.config.task is None

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.8.0"  # pragma: no cover
+__version__ = "1.9.0"  # pragma: no cover

--- a/unstructured_ingest/embed/vertexai.py
+++ b/unstructured_ingest/embed/vertexai.py
@@ -1,6 +1,8 @@
 # type: ignore
+import asyncio
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Optional
@@ -13,7 +15,12 @@ from unstructured_ingest.embed.interfaces import (
     BaseEmbeddingEncoder,
     EmbeddingConfig,
 )
-from unstructured_ingest.error import UserAuthError, is_internal_error
+from unstructured_ingest.error import (
+    ProviderError,
+    UserAuthError,
+    UserError,
+    is_internal_error,
+)
 from unstructured_ingest.utils.dep_check import requires_dependencies
 
 if TYPE_CHECKING:
@@ -31,11 +38,87 @@ def conform_string_to_dict(value: Any) -> dict:
 ApiKeyType = Secret[Annotated[dict, BeforeValidator(conform_string_to_dict)]]
 
 
+# Gemini-family embedding models are NOT served through the PaLM-era
+# ``vertexai.language_models.TextEmbeddingModel`` predict interface. That class dispatches on the
+# publisher model's ``predict_schemata.instance_schema_uri`` and only accepts
+# ``.../text_embedding_1.0.0.yaml``, so ``TextEmbeddingModel.from_pretrained("gemini-embedding-2")``
+# raises ``ValueError: Unknown model publishers/google/models/gemini-embedding-2; {...}``. The
+# Gemini family is reached through google-genai's ``embed_content`` instead.
+#
+# Dispatch on the model-id prefix rather than probing the publisher model: it costs no extra
+# authenticated round trip, and new members of the family (``gemini-embedding-001``,
+# ``gemini-embedding-2``, ...) work without a release here.
+_GENAI_MODEL_PREFIXES: tuple[str, ...] = ("gemini-embedding",)
+
+# ``embedContent`` accepts exactly ONE content per request for these models — passing a list of
+# strings does NOT batch, it is coalesced into a single multi-part Content and returns a single
+# vector for the whole batch (an explicit ``list[Content]`` fails outright with "The embedContent
+# API for this model only supports one content at a time"). So a batch is fanned out as one request
+# per text. The async path runs them concurrently, bounded to keep a large ``batch_size`` from
+# turning into an equally large burst of requests against the provider's rate limit.
+_GENAI_MAX_CONCURRENT_REQUESTS = 8
+
+# Fine-tuned Vertex models are addressed by a full resource path that already names the region the
+# endpoint is served from, e.g. ``projects/<project>/locations/<location>/endpoints/<id>``. Those
+# endpoints live in a fixed location, so a single global ``VERTEXAI_REGION`` cannot reach more than
+# one of them in the same process. Plain model ids (``gemini-embedding-2``) do not match and keep
+# using the configured/global region.
+_VERTEX_RESOURCE_LOCATION_RE = re.compile(r"^projects/[^/]+/locations/(?P<location>[^/]+)/")
+
+# Vertex multi-region locations are not served by the ``<location>-aiplatform.googleapis.com``
+# regional host google-genai builds by default (that host is invalid for a multi-region) — they are
+# served by the regionalized "rep" host. Supplied explicitly so a model deployed to a multi-region
+# endpoint is reachable without depending on the installed SDK version building it.
+_VERTEX_MULTI_REGIONS = frozenset({"us", "eu"})
+
+
+def _vertex_location_from_resource_path(model_name: Optional[str]) -> Optional[str]:
+    """Return the ``locations/<loc>`` segment of a full Vertex resource-path model id, or ``None``
+    for a plain model id (which should fall back to the configured region)."""
+    if not isinstance(model_name, str):
+        return None
+    match = _VERTEX_RESOURCE_LOCATION_RE.match(model_name)
+    return match.group("location") if match else None
+
+
+def _vertex_multi_region_base_url(location: Optional[str]) -> Optional[str]:
+    """Return the regionalized "rep" base URL for a Vertex multi-region location, else ``None``."""
+    if location in _VERTEX_MULTI_REGIONS:
+        return f"https://aiplatform.{location}.rep.googleapis.com/"
+    return None
+
+
 class VertexAIEmbeddingConfig(EmbeddingConfig):
     api_key: ApiKeyType = Field(description="API key for Vertex AI")
     embedder_model_name: Optional[str] = Field(
         default="text-embedding-005", alias="model_name", description="Vertex AI model name"
     )
+    region: Optional[str] = Field(
+        default=None,
+        description=(
+            "Vertex AI region. Only used by Gemini-family models; falls back to the "
+            "VERTEXAI_REGION environment variable."
+        ),
+    )
+    dimensionality: Optional[int] = Field(
+        default=None,
+        description=(
+            "Output embedding dimension. Only used by Gemini-family models, which support "
+            "Matryoshka truncation; ignored by the legacy text-embedding models."
+        ),
+    )
+    task: Optional[str] = Field(
+        default=None,
+        description=(
+            "Embedding task type, e.g. RETRIEVAL_DOCUMENT. Only used by Gemini-family models."
+        ),
+    )
+
+    @property
+    def uses_genai_transport(self) -> bool:
+        """Whether this model must be driven through google-genai rather than TextEmbeddingModel."""
+        model_name = (self.embedder_model_name or "").lower()
+        return model_name.startswith(_GENAI_MODEL_PREFIXES)
 
     def wrap_error(self, e: Exception) -> Exception:
         if is_internal_error(e=e):
@@ -53,16 +136,123 @@ class VertexAIEmbeddingConfig(EmbeddingConfig):
             json.dump(self.api_key.get_secret_value(), credentials_file)
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(application_credentials_path)
 
-    @requires_dependencies(
-        ["vertexai"],
-        extras="vertexai",
-    )
-    def get_client(self) -> "TextEmbeddingModel":
+    def _resolve_location(self) -> str:
+        """Region for the genai client: the location baked into a full resource-path model id,
+        else the configured region, else ``$VERTEXAI_REGION``."""
+        location = (
+            _vertex_location_from_resource_path(self.embedder_model_name)
+            or self.region
+            or os.getenv("VERTEXAI_REGION")
+        )
+        if not location:
+            raise UserError(
+                f"A Vertex AI region is required for model '{self.embedder_model_name}'. Set the "
+                "region on the embedder settings or the VERTEXAI_REGION environment variable."
+            )
+        return location
+
+    @requires_dependencies(["google.genai"], extras="vertexai")
+    def get_genai_client(self):
+        """Creates a google-genai client in Vertex mode for Gemini-family embedding models."""
+        from google import genai
+        from google.oauth2 import service_account
+
+        credentials_json = self.api_key.get_secret_value()
+        project = credentials_json.get("project_id")
+        if not project:
+            raise UserError(
+                "Vertex AI credentials are missing 'project_id'; a service account JSON is "
+                "required for Gemini-family embedding models."
+            )
+        credentials = service_account.Credentials.from_service_account_info(
+            credentials_json, scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
+        location = self._resolve_location()
+        client_kwargs: dict[str, Any] = {}
+        multi_region_base_url = _vertex_multi_region_base_url(location)
+        if multi_region_base_url:
+            client_kwargs["http_options"] = genai.types.HttpOptions(base_url=multi_region_base_url)
+        return genai.Client(
+            vertexai=True,
+            credentials=credentials,
+            project=project,
+            location=location,
+            **client_kwargs,
+        )
+
+    @requires_dependencies(["vertexai"], extras="vertexai")
+    def get_legacy_client(self) -> "TextEmbeddingModel":
         """Creates a VertexAI python client to embed elements."""
         from vertexai.language_models import TextEmbeddingModel
 
         self.register_application_credentials()
         return TextEmbeddingModel.from_pretrained(self.embedder_model_name)
+
+    def get_client(self):
+        """Client for the transport this model is served through."""
+        if self.uses_genai_transport:
+            return self.get_genai_client()
+        return self.get_legacy_client()
+
+    def _genai_embed_config(self):
+        """``EmbedContentConfig`` for the configured dimensionality/task, or ``None``."""
+        from google.genai import types
+
+        kwargs: dict[str, Any] = {}
+        if self.dimensionality:
+            kwargs["output_dimensionality"] = self.dimensionality
+        if self.task:
+            kwargs["task_type"] = self.task
+        return types.EmbedContentConfig(**kwargs) if kwargs else None
+
+    @staticmethod
+    def _first_embedding(response: Any) -> list[float]:
+        """Values of the single embedding an ``embedContent`` request returns."""
+        embeddings = response.embeddings
+        if not embeddings:
+            raise ProviderError("Vertex AI embedContent returned no embedding for an input")
+        return embeddings[0].values
+
+    def _genai_embed_one(self, client: Any, text: str, config: Any) -> list[float]:
+        response = client.models.embed_content(
+            model=self.embedder_model_name, contents=text, config=config
+        )
+        return self._first_embedding(response)
+
+    # Batch embedding lives on the config, not the encoder, so that every caller — the sync
+    # encoder, the async encoder, and downstream callers that drive their own batch loop — shares
+    # one implementation and cannot drift on which transport a model needs. Dependencies are
+    # already gated by the matching ``get_*_client``, which must run before a client gets here.
+    def embed_batch(self, client: Any, batch: list[str]) -> list[list[float]]:
+        if self.uses_genai_transport:
+            config = self._genai_embed_config()
+            return [self._genai_embed_one(client, text, config) for text in batch]
+
+        from vertexai.language_models import TextEmbeddingInput
+
+        inputs = [TextEmbeddingInput(text=text) for text in batch]
+        response = client.get_embeddings(inputs)
+        return [e.values for e in response]
+
+    async def embed_batch_async(self, client: Any, batch: list[str]) -> list[list[float]]:
+        if self.uses_genai_transport:
+            config = self._genai_embed_config()
+            semaphore = asyncio.Semaphore(_GENAI_MAX_CONCURRENT_REQUESTS)
+
+            async def embed_one(text: str) -> list[float]:
+                async with semaphore:
+                    response = await client.aio.models.embed_content(
+                        model=self.embedder_model_name, contents=text, config=config
+                    )
+                return self._first_embedding(response)
+
+            return list(await asyncio.gather(*(embed_one(text) for text in batch)))
+
+        from vertexai.language_models import TextEmbeddingInput
+
+        inputs = [TextEmbeddingInput(text=text) for text in batch]
+        response = await client.get_embeddings_async(inputs)
+        return [e.values for e in response]
 
 
 @dataclass
@@ -72,19 +262,11 @@ class VertexAIEmbeddingEncoder(BaseEmbeddingEncoder):
     def wrap_error(self, e: Exception) -> Exception:
         return self.config.wrap_error(e=e)
 
-    def get_client(self) -> "TextEmbeddingModel":
+    def get_client(self) -> Any:
         return self.config.get_client()
 
-    @requires_dependencies(
-        ["vertexai"],
-        extras="embed-vertexai",
-    )
-    def embed_batch(self, client: "TextEmbeddingModel", batch: list[str]) -> list[list[float]]:
-        from vertexai.language_models import TextEmbeddingInput
-
-        inputs = [TextEmbeddingInput(text=text) for text in batch]
-        response = client.get_embeddings(inputs)
-        return [e.values for e in response]
+    def embed_batch(self, client: Any, batch: list[str]) -> list[list[float]]:
+        return self.config.embed_batch(client=client, batch=batch)
 
 
 @dataclass
@@ -94,16 +276,8 @@ class AsyncVertexAIEmbeddingEncoder(AsyncBaseEmbeddingEncoder):
     def wrap_error(self, e: Exception) -> Exception:
         return self.config.wrap_error(e=e)
 
-    def get_client(self) -> "TextEmbeddingModel":
+    def get_client(self) -> Any:
         return self.config.get_client()
 
-    @requires_dependencies(
-        ["vertexai"],
-        extras="embed-vertexai",
-    )
     async def embed_batch(self, client: Any, batch: list[str]) -> list[list[float]]:
-        from vertexai.language_models import TextEmbeddingInput
-
-        inputs = [TextEmbeddingInput(text=text) for text in batch]
-        response = await client.get_embeddings_async(inputs)
-        return [e.values for e in response]
+        return await self.config.embed_batch_async(client=client, batch=batch)

--- a/unstructured_ingest/embed/vertexai.py
+++ b/unstructured_ingest/embed/vertexai.py
@@ -81,6 +81,14 @@ _VERTEX_PUBLISHER_MODEL_RE = re.compile(
 # endpoint is reachable without depending on the installed SDK version building it.
 _VERTEX_MULTI_REGIONS = frozenset({"us", "eu"})
 
+# Region of last resort for the genai transport. Availability is per-model, not per-deployment: the
+# Gemini embedding family is served from ``global`` and 404s in ordinary regions like us-east1,
+# while the legacy text-embedding models are served from both. So a deployment-wide regional pin
+# cannot be correct for every model, and ``global`` is the only value that serves all of them.
+# NOTE: ``global`` is deliberately not in _VERTEX_MULTI_REGIONS — google-genai builds the correct
+# host for it on its own, and forcing the "rep" host here would break it.
+_VERTEX_DEFAULT_LOCATION = "global"
+
 
 def _vertex_location_from_resource_path(model_name: Optional[str]) -> Optional[str]:
     """Return the ``locations/<loc>`` segment of a full Vertex resource-path model id, or ``None``
@@ -117,7 +125,7 @@ class VertexAIEmbeddingConfig(EmbeddingConfig):
         default=None,
         description=(
             "Vertex AI region. Only used by Gemini-family models; falls back to the "
-            "VERTEXAI_REGION environment variable."
+            "VERTEXAI_REGION environment variable, then to 'global'."
         ),
     )
     dimensionality: Optional[int] = Field(
@@ -157,19 +165,14 @@ class VertexAIEmbeddingConfig(EmbeddingConfig):
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(application_credentials_path)
 
     def _resolve_location(self) -> str:
-        """Region for the genai client: the location baked into a full resource-path model id,
-        else the configured region, else ``$VERTEXAI_REGION``."""
-        location = (
+        """Region for the genai client: the location baked into a full resource-path model id, else
+        the configured region, else ``$VERTEXAI_REGION``, else ``global``."""
+        return (
             _vertex_location_from_resource_path(self.embedder_model_name)
             or self.region
             or os.getenv("VERTEXAI_REGION")
+            or _VERTEX_DEFAULT_LOCATION
         )
-        if not location:
-            raise UserError(
-                f"A Vertex AI region is required for model '{self.embedder_model_name}'. Set the "
-                "region on the embedder settings or the VERTEXAI_REGION environment variable."
-            )
-        return location
 
     @requires_dependencies(["google.genai"], extras="vertexai")
     def get_genai_client(self):

--- a/unstructured_ingest/embed/vertexai.py
+++ b/unstructured_ingest/embed/vertexai.py
@@ -199,7 +199,7 @@ class VertexAIEmbeddingConfig(EmbeddingConfig):
         from google.genai import types
 
         kwargs: dict[str, Any] = {}
-        if self.dimensionality:
+        if self.dimensionality is not None:
             kwargs["output_dimensionality"] = self.dimensionality
         if self.task:
             kwargs["task_type"] = self.task

--- a/unstructured_ingest/embed/vertexai.py
+++ b/unstructured_ingest/embed/vertexai.py
@@ -47,7 +47,8 @@ ApiKeyType = Secret[Annotated[dict, BeforeValidator(conform_string_to_dict)]]
 #
 # Dispatch on the model-id prefix rather than probing the publisher model: it costs no extra
 # authenticated round trip, and new members of the family (``gemini-embedding-001``,
-# ``gemini-embedding-2``, ...) work without a release here.
+# ``gemini-embedding-2``, ...) work without a release here. Matched against the bare model id, so
+# a publisher-style path naming a Gemini model routes here too — see _vertex_routing_model_id.
 _GENAI_MODEL_PREFIXES: tuple[str, ...] = ("gemini-embedding",)
 
 # ``embedContent`` accepts exactly ONE content per request for these models — passing a list of
@@ -58,12 +59,21 @@ _GENAI_MODEL_PREFIXES: tuple[str, ...] = ("gemini-embedding",)
 # turning into an equally large burst of requests against the provider's rate limit.
 _GENAI_MAX_CONCURRENT_REQUESTS = 8
 
-# Fine-tuned Vertex models are addressed by a full resource path that already names the region the
-# endpoint is served from, e.g. ``projects/<project>/locations/<location>/endpoints/<id>``. Those
-# endpoints live in a fixed location, so a single global ``VERTEXAI_REGION`` cannot reach more than
-# one of them in the same process. Plain model ids (``gemini-embedding-2``) do not match and keep
-# using the configured/global region.
+# Vertex models can also be addressed by a full resource path that already names the region they are
+# served from, e.g. ``projects/<project>/locations/<location>/publishers/google/models/<model>`` for
+# a publisher model, or ``projects/<project>/locations/<location>/endpoints/<id>`` for a fine-tuned
+# endpoint. Those live in a fixed location, so a single global ``VERTEXAI_REGION`` cannot reach more
+# than one of them in the same process — and the client must be built for the location named in the
+# path, or the request 404s. Plain model ids (``gemini-embedding-2``) do not match and keep using
+# the configured/global region.
 _VERTEX_RESOURCE_LOCATION_RE = re.compile(r"^projects/[^/]+/locations/(?P<location>[^/]+)/")
+
+# A publisher-style resource path names the model in its final segment, so transport routing can
+# still tell a Gemini model from a legacy one. A bare ``endpoints/<id>`` path names no model at all,
+# carries no signal about which family it serves, and therefore stays on the legacy transport.
+_VERTEX_PUBLISHER_MODEL_RE = re.compile(
+    r"^projects/[^/]+/locations/[^/]+/publishers/[^/]+/models/(?P<model>.+)$"
+)
 
 # Vertex multi-region locations are not served by the ``<location>-aiplatform.googleapis.com``
 # regional host google-genai builds by default (that host is invalid for a multi-region) — they are
@@ -79,6 +89,16 @@ def _vertex_location_from_resource_path(model_name: Optional[str]) -> Optional[s
         return None
     match = _VERTEX_RESOURCE_LOCATION_RE.match(model_name)
     return match.group("location") if match else None
+
+
+def _vertex_routing_model_id(model_name: Optional[str]) -> str:
+    """Return the bare model id to route on. Unwraps a publisher-style resource path
+    (``projects/../locations/../publishers/google/models/gemini-embedding-2`` -> that final
+    segment); any other value, including a bare ``endpoints/<id>`` path, is returned unchanged."""
+    if not isinstance(model_name, str):
+        return ""
+    match = _VERTEX_PUBLISHER_MODEL_RE.match(model_name)
+    return match.group("model") if match else model_name
 
 
 def _vertex_multi_region_base_url(location: Optional[str]) -> Optional[str]:
@@ -117,7 +137,7 @@ class VertexAIEmbeddingConfig(EmbeddingConfig):
     @property
     def uses_genai_transport(self) -> bool:
         """Whether this model must be driven through google-genai rather than TextEmbeddingModel."""
-        model_name = (self.embedder_model_name or "").lower()
+        model_name = _vertex_routing_model_id(self.embedder_model_name).lower()
         return model_name.startswith(_GENAI_MODEL_PREFIXES)
 
     def wrap_error(self, e: Exception) -> Exception:

--- a/unstructured_ingest/processes/embedder.py
+++ b/unstructured_ingest/processes/embedder.py
@@ -52,6 +52,21 @@ class EmbedderConfig(BaseModel):
     embedding_azure_api_version: Optional[str] = Field(
         description="Azure API version", default=None
     )
+    embedding_vertexai_region: Optional[str] = Field(
+        default=None,
+        description="Vertex AI region. Only used by Gemini-family models; falls back to the "
+        "VERTEXAI_REGION environment variable.",
+    )
+    embedding_vertexai_dimensionality: Optional[int] = Field(
+        default=None,
+        description="Output embedding dimension. Only used by Gemini-family Vertex AI models, "
+        "which support Matryoshka truncation.",
+    )
+    embedding_vertexai_task: Optional[str] = Field(
+        default=None,
+        description="Embedding task type, e.g. RETRIEVAL_DOCUMENT. "
+        "Only used by Gemini-family Vertex AI models.",
+    )
 
     def get_huggingface_embedder(self, embedding_kwargs: dict) -> "BaseEmbeddingEncoder":
         from unstructured_ingest.embed.huggingface import (
@@ -113,6 +128,18 @@ class EmbedderConfig(BaseModel):
             VertexAIEmbeddingConfig,
             VertexAIEmbeddingEncoder,
         )
+
+        # Only forward what was actually set; the config's own defaults (and the
+        # VERTEXAI_REGION fallback) must stay reachable, and dimensionality=0 is a
+        # value the provider gets to reject rather than one that means "unset".
+        gemini_kwargs = {
+            "region": self.embedding_vertexai_region,
+            "dimensionality": self.embedding_vertexai_dimensionality,
+            "task": self.embedding_vertexai_task,
+        }
+        embedding_kwargs = embedding_kwargs | {
+            key: value for key, value in gemini_kwargs.items() if value is not None
+        }
 
         return VertexAIEmbeddingEncoder(
             config=VertexAIEmbeddingConfig.model_validate(embedding_kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -7304,6 +7304,7 @@ vectara = [
     { name = "requests" },
 ]
 vertexai = [
+    { name = "google-genai" },
     { name = "vertexai" },
 ]
 voyageai = [
@@ -7342,6 +7343,7 @@ test = [
     { name = "docker" },
     { name = "faker" },
     { name = "fsspec" },
+    { name = "google-genai" },
     { name = "htmlbuilder" },
     { name = "httpx" },
     { name = "networkx" },
@@ -7407,6 +7409,7 @@ requires-dist = [
     { name = "fsspec", marker = "extra == 'sftp'" },
     { name = "gcsfs", marker = "extra == 'gcs'" },
     { name = "google-api-python-client", marker = "extra == 'google-drive'" },
+    { name = "google-genai", marker = "extra == 'vertexai'" },
     { name = "htmlbuilder", marker = "extra == 'notion'" },
     { name = "httpx", marker = "extra == 'ibm-watsonx-s3'" },
     { name = "httpx", marker = "extra == 'notion'" },
@@ -7523,6 +7526,7 @@ test = [
     { name = "docker" },
     { name = "faker" },
     { name = "fsspec" },
+    { name = "google-genai" },
     { name = "htmlbuilder" },
     { name = "httpx" },
     { name = "networkx" },


### PR DESCRIPTION
## Summary

Gemini-family Vertex AI embedding models (e.g. `gemini-embedding-2`, `gemini-embedding-001`) could not be used at all. `VertexAIEmbeddingConfig` only ever built a `vertexai.language_models.TextEmbeddingModel`, which dispatches on the publisher model's `predict_schemata.instance_schema_uri` and accepts only `.../text_embedding_1.0.0.yaml`. Gemini embedding models are served through `google-genai`'s `embed_content` instead, so they failed at client construction:

```
ValueError: Unknown model publishers/google/models/gemini-embedding-2;
{'gs://google-cloud-aiplatform/schema/predict/instance/text_embedding_1.0.0.yaml':
 <class 'vertexai.language_models.TextEmbeddingModel'>}
```

## Changes

- **Transport routing.** Models whose id starts with `gemini-embedding` get a `google-genai` client in Vertex mode. The four legacy `textembedding-gecko@*` / `text-embedding-00*` models keep the existing transport, byte-for-byte. Dispatch is on the model-id prefix rather than probing the publisher model, so it costs no extra authenticated round trip and new members of the family work without a release here.
- **Batch embedding moved onto the config** (`embed_batch` / `embed_batch_async`). The sync encoder, the async encoder, and any caller driving its own batch loop now share one transport decision and can't drift.
- **One request per text.** `embedContent` accepts exactly one content per request for these models. Passing a list of strings does *not* batch — it is silently coalesced into a single multi-part Content and returns one vector for the whole batch (an explicit `list[Content]` fails outright with *"The embedContent API for this model only supports one content at a time"*). Batches are fanned out as one request per text, concurrent and bounded at 8 on the async path so a large `batch_size` doesn't become an equally large burst.
- **New Gemini-only settings:** `region` (falling back to `$VERTEXAI_REGION`), `dimensionality` (Matryoshka output truncation), `task` (embedding task type). `task` is deliberately not wired into the legacy path, which would change existing embeddings.
- **Region resolution** prefers the location baked into a full `projects/.../locations/<loc>/...` resource-path model id over the configured/global region, and supplies the regionalized `aiplatform.<loc>.rep.googleapis.com` host for the `us`/`eu` multi-regions, which older `google-genai` does not build itself.
- Adds `google-genai` to the `vertexai` extra.

## Testing

22 new unit tests (43 total in `test/unit/embed/`): routing across 7 model ids, both client branches, one-request-per-text with per-call assertions, tuple batches (`batch_generator` yields tuples), async fan-out order preservation under out-of-order completion, `dimensionality`/`task` forwarding, empty-response handling, all four region precedence rules, and multi-region host derivation.

Verified live against Vertex AI with a service-account credential:

| check | result |
| --- | --- |
| routing (`gemini-embedding-2` → genai, `text-embedding-005` → legacy) | pass |
| `gemini-embedding-2` sync batch of 2 | 2 vectors, 3072 dims |
| `gemini-embedding-2` with `dimensionality=768` + `task` | 768 dims |
| `gemini-embedding-2` async encoder | 2 elements embedded, 3072 dims |
| `text-embedding-005` legacy path (regression) | 768 dims |

The live run is what surfaced the one-content-per-request behaviour and the tuple-batch failure; both are now covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

