### PR TITLE
fix(pinecone): make vector_length optional on create_destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.8.1]
+
+### Fixes
+
+- **fix(pinecone): make `vector_length` optional on `PineconeUploader.create_destination`.** The parameter was a required positional with no default, so any caller that could not determine the embedding dimension upfront crashed with `TypeError: create_destination() missing 1 required positional argument: 'vector_length'` before the method body ran. This happened even when the target index already existed and no dimension was needed, since the failure occurred at call binding. Pinecone was the only connector implementing `create_destination` with a required `vector_length`: Weaviate and AstraDB already default it to `None`, and Databricks and Teradata do not accept it. Pinecone now matches, so auto-create is a no-op when the index exists and the dimension is unknown.
+
 ## [1.8.0]
 
 ### Enhancements

--- a/test/unit/processes/connectors/test_pinecone.py
+++ b/test/unit/processes/connectors/test_pinecone.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
@@ -100,3 +102,15 @@ def test_map_pinecone_api_error_preserves_cause():
         raise wrapped from api_error
     except ProviderError as caught:
         assert caught.__cause__ is api_error
+
+
+def test_create_destination_callable_without_vector_length():
+    """Callers that cannot resolve the embedding dimension upfront still need to invoke
+    create_destination, which is a no-op when the index already exists. A required
+    vector_length raised TypeError at call binding, before that check could run."""
+    signature = inspect.signature(PineconeUploader.create_destination)
+
+    bound = signature.bind(None)
+
+    assert "vector_length" not in bound.arguments
+    assert signature.parameters["vector_length"].default is None

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.8.0"  # pragma: no cover
+__version__ = "1.8.1"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/pinecone.py
+++ b/unstructured_ingest/processes/connectors/pinecone.py
@@ -251,7 +251,7 @@ class PineconeUploader(VectorDBUploader):
 
     def create_destination(
         self,
-        vector_length: int,
+        vector_length: Optional[int] = None,
         destination_name: str = "unstructuredautocreated",
         destination_type: Literal["pod", "serverless"] = "serverless",
         serverless_cloud: str = "aws",


### PR DESCRIPTION
## What

`PineconeUploader.create_destination` declares `vector_length` as a required positional argument with no default. Any caller that cannot resolve the embedding dimension ahead of time fails with:

```
TypeError: create_destination() missing 1 required positional argument: 'vector_length'
```

## Why it matters

The embedding dimension is not always knowable before the upload step runs. It is unavailable whenever the embedding model is not one the platform can look up, for example a self-hosted OpenAI-compatible embedding endpoint, and also whenever a workflow has no embedder node at all. In those cases every record in the upload fails.

The failure is also broader than it needs to be. It happens at call binding, before the method body executes. `create_destination` already short-circuits on an existing index and returns without ever reading `vector_length`, so users whose index is already provisioned, who need no dimension whatsoever, still cannot get past the call.

## The change

Pinecone was the only connector implementing `create_destination` with a required `vector_length`. Weaviate and AstraDB already default it to `None`, and Databricks and Teradata do not accept the parameter at all. This brings Pinecone in line with that convention, so auto-create degrades to a no-op when the index exists and the dimension is unknown, which is the behaviour every other destination already has.

Adds a unit test asserting the method is callable without a dimension.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

