### PR TITLE
fix(release): unblock PyPI publish and allow manual release runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   release:
     types:
       - published
+  # Manual re-run, e.g. when a publish failed after the release was cut.
+  # GitHub restricts workflow_dispatch to users with write access to this repo,
+  # which is granted solely through the Unstructured-IO engineering/infra/admins
+  # teams — there are no outside collaborators.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish (e.g. 1.9.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -19,8 +29,16 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # On a release event this is the published tag; on a manual run it is the
+      # tag typed into the form. Dispatch runs the workflow file from the ref it
+      # was launched on (normally main), so the tag must be checked out
+      # explicitly rather than relying on the default ref.
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -35,7 +53,7 @@ jobs:
 
       - name: Validate version matches release tag
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ env.RELEASE_TAG }}
         run: |
           PKG_VERSION=$(uv run --no-sync python -c "from unstructured_ingest.__version__ import __version__; print(__version__)")
           if [[ "$TAG" != "$PKG_VERSION" && "$TAG" != "v$PKG_VERSION" ]]; then
@@ -48,7 +66,7 @@ jobs:
         run: uv build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
       # Best-effort: attempt Azure upload even if PyPI fails, but only if build succeeded.
       - name: Create .pypirc for Azure Artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.9.1]
+
+### Fixes
+
+- **fix(release): unblock the PyPI publish.** `hatchling 1.32.0` bumped emitted `Metadata-Version` to `2.5`, which the publish action's pinned `packaging` 25.0 rejected. Caps `hatchling<1.32` and bumps `pypa/gh-action-pypi-publish` to v1.14.2. Also adds a `workflow_dispatch` trigger so a failed publish can be retried without cutting a new version.
+
 ## [1.9.0]
 
 ### Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,11 @@ test = [
 unstructured-ingest = "unstructured_ingest.main:main"
 
 [build-system]
-requires = ["hatchling"]
+# Upper bound guards against a backend release silently changing the emitted
+# Metadata-Version: hatchling 1.32.0 moved to 2.5, which older packaging/twine
+# (and other downstream metadata readers) reject. Stay on 2.4 until that has
+# had time to propagate.
+requires = ["hatchling>=1.27,<1.32"]
 build-backend = "hatchling.build"
 
 [tool.uv]

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.9.0"  # pragma: no cover
+__version__ = "1.9.1"  # pragma: no cover


### PR DESCRIPTION
## Problem

The [1.9.0 PyPI release](https://github.com/Unstructured-IO/unstructured-ingest/actions/runs/31535787006/job/93926442433) failed at the publish step:

```
Checking dist/unstructured_ingest-1.9.0-py3-none-any.whl: ERROR
  InvalidDistribution: Invalid distribution metadata:
  '2.5' is not a valid metadata version
```

`hatchling 1.32.0` was published to PyPI on 2026-08-11 and bumped its emitted `Metadata-Version` from `2.4` to `2.5`. Our `build-system.requires` was an unbounded `["hatchling"]`, so `uv build` on the runner resolved 1.32.0 and produced 2.5 metadata. Confirmed locally: current `main` builds at 2.5; hatchling 1.31.0 and 1.30.0 both emit 2.4.

The artifact itself was fine — PyPI accepts 2.5 (hatchling 1.32.0's own wheel is published with it). The failure was a stale action pin:

| pin | packaging | twine | accepts 2.5? |
|---|---|---|---|
| `ed0c539…` = v1.13.0 (Sep 2025), what we had | 25.0 | 6.1.0 | ❌ |
| v1.14.2 (Jul 2026) | 26.2 | 7.0.0 | ✅ |

`packaging` added `2.5` to `_VALID_METADATA_VERSIONS` in 26.2. The Azure Artifacts step succeeded because it shells out to the modern `twine` from our `release` dependency group rather than the action's bundled copy.

`unstructured-ingest 1.9.0` is **not** on PyPI (404) — only Azure got it.

## Changes

**1. Cap the build backend** — `requires = ["hatchling>=1.27,<1.32"]`. Keeps emitted metadata at 2.4, which also protects downstream consumers whose pip/resolver metadata readers predate 2.5. The `>=1.27` floor is the version that introduced the PEP 639 `License-Expression` field our metadata already uses.

**2. Bump the publish action** to v1.14.2 (`dc37677`), so lifting the cap later doesn't reintroduce the failure. The two fixes are deliberately redundant.

**3. Add a `workflow_dispatch` trigger** with a required `tag` input, so a failed publish can be retried without cutting a new version.

No guard job: GitHub already restricts manual dispatch to users with **write** access, and on this repo that is granted solely through the `engineering` / `infra` / `admins` org teams — 88 push-capable collaborators, **0 outside collaborators**. An org-membership check would re-verify what GitHub enforces before the run starts, at the cost of a `read:org` PAT to maintain. Worth noting the tradeoff: if an outside collaborator with push is ever added, the gate widens silently in org settings rather than visibly in this file.

Dispatch runs the workflow file from the ref it is launched on, so checkout now takes an explicit `ref` — without it a manual run from `main` would build whatever version `main` holds instead of the tag entered. The existing version-match validation reads the same resolved tag, so typing a mismatched tag fails the run rather than mispublishing.

## Verification

- Wheel and sdist rebuild at `Metadata-Version: 2.4`
- `twine check` passes on both artifacts under packaging 25.0 / twine 6.1.0 (the old action's stack) **and** 26.2 / 7.0.0 (the new one)
- `actionlint` clean, including context availability for `inputs` in job-level `env`
- `uv lock --check` unaffected — `build-system.requires` is not recorded in `uv.lock`, so no relock

## Follow-up after merge

Version is bumped to **1.9.1** — `check-version` rejects reusing 1.9.0 since it already has a commit on `main`, so this ships as a new release rather than a re-run of the failed tag. 1.9.0 remains absent from PyPI (it only reached Azure Artifacts); nothing consumes it from PyPI today, so there is no gap to backfill.

The new `workflow_dispatch` trigger is therefore not needed for this fix, but is available for the next time a publish fails after a tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
