### PR TITLE
chore(none): reduce merge-conflict churn on bookkeeping files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+CHANGELOG.md merge=union
+uv.lock merge=uv-lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.11.7]
+
+### Chores
+
+- **chore: reduce merge-conflict churn on bookkeeping files.** `CHANGELOG.md` now merges with the
+  `union` driver and `uv.lock` with the `uv-lock` driver, so two branches that each add an entry or
+  re-lock no longer produce a hand-resolved conflict.
+
 ## [1.11.6]
 
 ### Fixes

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.6"  # pragma: no cover
+__version__ = "1.11.7"  # pragma: no cover


### PR DESCRIPTION
Adds a `.gitattributes` so bookkeeping files stop generating spurious merge conflicts:

- `CHANGELOG.md merge=union` — keeps both sides' appended entries instead of conflicting on the version header. A built-in git driver (no per-clone setup), and GitHub honors it for mergeability, so a CHANGELOG whose only "conflict" is two appended entries no longer shows as conflicting.
- `uv.lock merge=uv-lock` — routes lockfile conflicts to a driver that regenerates the lock for contributors who have it configured (`dotfiles/bin/setup-uv-merge-driver.sh`); a harmless no-op for clones without it (git falls back to the default).

Mirrors the same change already made for platform-plugins and platform-api. Motivation: PRs like #781 kept re-conflicting on CHANGELOG.md against every main advance even though both sides only appended entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

