### PR TITLE
fix: skip elements with no embedding in qdrant, chroma and astradb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.9.3]
+
+### Fixes
+
+- **fix(qdrant, chroma, astradb): skip elements that have no embedding.** Elements with empty text are not embedded, and each of these destinations failed differently on them: Chroma rejected the entire batch, Astra DB raised an error asking the user to configure an embedding provider they already had, and Qdrant stored a point with no vector that search can never return. All three now drop those elements before upload, matching Milvus and Pinecone. Astra DB keeps them when it is configured to generate the vectors itself, and Weaviate is unchanged, since both treat a missing vector as a request to vectorize server-side.
+
 ## [1.9.2]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **fix(qdrant, chroma, astradb): skip elements that have no embedding.** Elements with empty text are not embedded, and each of these destinations failed differently on them: Chroma rejected the entire batch, Astra DB raised an error asking the user to configure an embedding provider they already had, and Qdrant stored a point with no vector that search can never return. All three now drop those elements before upload, matching Milvus and Pinecone. Astra DB keeps them when it is configured to generate the vectors itself, and Weaviate is unchanged, since both treat a missing vector as a request to vectorize server-side.
+- **fix(qdrant, chroma, astradb): skip elements the embedder left without an embedding.** Elements with empty text are not embedded, and each of these destinations failed differently on them: Chroma rejected the entire batch, Astra DB raised an error asking the user to configure an embedding provider they already had, and Qdrant stored a point with no vector that search can never return. All three now drop those elements during staging. An element that has text but no embedding is kept, since that means no embedder ran at all and each destination's existing error should still surface rather than a workflow silently uploading nothing. Astra DB drops nothing when configured to generate the vectors itself, and Weaviate is unchanged, since both treat a missing vector as a request to vectorize server-side.
 
 ## [1.9.2]
 

--- a/test/unit/processes/connectors/test_vector_destination_skips_unembedded.py
+++ b/test/unit/processes/connectors/test_vector_destination_skips_unembedded.py
@@ -1,0 +1,101 @@
+"""Vector destinations must not stage elements that have no embedding.
+
+Elements with empty text are skipped by the embedder and arrive at the stager without
+an "embeddings" key. Qdrant, Chroma and Astra DB each map that key onto a vector field
+and cannot use the element without it, so they drop it before upload.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
+from unstructured_ingest.processes.connectors.astradb import (
+    AstraDBUploadStager,
+    AstraDBUploadStagerConfig,
+)
+from unstructured_ingest.processes.connectors.chroma import (
+    ChromaUploadStager,
+    ChromaUploadStagerConfig,
+)
+from unstructured_ingest.processes.connectors.qdrant.cloud import (
+    CloudQdrantUploadStager,
+    CloudQdrantUploadStagerConfig,
+)
+from unstructured_ingest.utils import ndjson
+
+EMBEDDED = {
+    "element_id": "embedded",
+    "type": "NarrativeText",
+    "text": "hello world",
+    "embeddings": [0.1, 0.2, 0.3, 0.4],
+    "metadata": {"filename": "doc.pdf", "page_number": 1},
+}
+UNEMBEDDED = {
+    "element_id": "unembedded",
+    "type": "UncategorizedText",
+    "text": "",
+    "metadata": {"filename": "doc.pdf", "page_number": 2},
+}
+
+
+def _stagers():
+    return [
+        pytest.param(CloudQdrantUploadStager(CloudQdrantUploadStagerConfig()), id="qdrant"),
+        pytest.param(ChromaUploadStager(ChromaUploadStagerConfig()), id="chroma"),
+        pytest.param(AstraDBUploadStager(AstraDBUploadStagerConfig()), id="astradb"),
+    ]
+
+
+@pytest.fixture
+def file_data():
+    return FileData(
+        connector_type="test",
+        identifier="test_record_id",
+        source_identifiers=SourceIdentifiers(filename="doc.pdf", fullpath="doc.pdf"),
+    )
+
+
+@pytest.mark.parametrize("stager", _stagers())
+def test_includes_element_with_embeddings(stager):
+    assert stager.should_include(element_dict=dict(EMBEDDED)) is True
+
+
+@pytest.mark.parametrize("stager", _stagers())
+def test_excludes_element_without_embeddings(stager):
+    assert stager.should_include(element_dict=dict(UNEMBEDDED)) is False
+
+
+@pytest.mark.parametrize("stager", _stagers())
+@pytest.mark.parametrize("suffix", [".json", ".ndjson"])
+def test_run_drops_unembedded_elements(stager, suffix, file_data, tmp_path: Path):
+    input_file = tmp_path / f"elements{suffix}"
+    elements = [dict(EMBEDDED), dict(UNEMBEDDED)]
+    if suffix == ".json":
+        input_file.write_text(json.dumps(elements))
+    else:
+        with input_file.open("w") as f:
+            ndjson.dump(elements, f)
+
+    output_path = stager.run(
+        elements_filepath=input_file,
+        file_data=file_data,
+        output_dir=tmp_path / "staged",
+        output_filename=f"elements{suffix}",
+    )
+
+    if suffix == ".json":
+        staged = json.loads(output_path.read_text())
+    else:
+        with output_path.open() as f:
+            staged = ndjson.load(f)
+    assert len(staged) == 1
+
+
+def test_astradb_keeps_unembedded_when_astra_generates_vectors():
+    """Astra vectorizes from the content itself, so the element is still usable."""
+    stager = AstraDBUploadStager(
+        upload_stager_config=AstraDBUploadStagerConfig(astra_generated_embeddings=True)
+    )
+    assert stager.should_include(element_dict=dict(UNEMBEDDED)) is True

--- a/test/unit/processes/connectors/test_vector_destination_skips_unembedded.py
+++ b/test/unit/processes/connectors/test_vector_destination_skips_unembedded.py
@@ -1,8 +1,12 @@
-"""Vector destinations must not stage elements that have no embedding.
+"""Vector destinations must not stage elements the embedder intentionally skipped.
 
-Elements with empty text are skipped by the embedder and arrive at the stager without
-an "embeddings" key. Qdrant, Chroma and Astra DB each map that key onto a vector field
-and cannot use the element without it, so they drop it before upload.
+The embedder embeds only elements with text, so an element with empty text arrives at
+the stager with no "embeddings" key and nothing to index. Qdrant, Chroma and Astra DB
+each map that key onto a vector field, so they drop those elements.
+
+An element that has text but no embedding is a different case: it means no embedder ran
+at all. Those are kept, so each destination's existing failure still surfaces instead of
+a workflow silently uploading nothing.
 """
 
 import json
@@ -38,13 +42,33 @@ UNEMBEDDED = {
     "text": "",
     "metadata": {"filename": "doc.pdf", "page_number": 2},
 }
+# text present, no embedding: what every element looks like when no embedder ran
+NO_EMBEDDER = {
+    "element_id": "no_embedder",
+    "type": "NarrativeText",
+    "text": "hello world",
+    "metadata": {"filename": "doc.pdf", "page_number": 3},
+}
 
 
 def _stagers():
+    """(stager, staged_text) per destination, so a test can identify which element survived."""
     return [
-        pytest.param(CloudQdrantUploadStager(CloudQdrantUploadStagerConfig()), id="qdrant"),
-        pytest.param(ChromaUploadStager(ChromaUploadStagerConfig()), id="chroma"),
-        pytest.param(AstraDBUploadStager(AstraDBUploadStagerConfig()), id="astradb"),
+        pytest.param(
+            CloudQdrantUploadStager(CloudQdrantUploadStagerConfig()),
+            lambda row: row["payload"]["text"],
+            id="qdrant",
+        ),
+        pytest.param(
+            ChromaUploadStager(ChromaUploadStagerConfig()),
+            lambda row: row["document"],
+            id="chroma",
+        ),
+        pytest.param(
+            AstraDBUploadStager(AstraDBUploadStagerConfig()),
+            lambda row: row["content"],
+            id="astradb",
+        ),
     ]
 
 
@@ -57,45 +81,84 @@ def file_data():
     )
 
 
-@pytest.mark.parametrize("stager", _stagers())
-def test_includes_element_with_embeddings(stager):
-    assert stager.should_include(element_dict=dict(EMBEDDED)) is True
-
-
-@pytest.mark.parametrize("stager", _stagers())
-def test_excludes_element_without_embeddings(stager):
-    assert stager.should_include(element_dict=dict(UNEMBEDDED)) is False
-
-
-@pytest.mark.parametrize("stager", _stagers())
-@pytest.mark.parametrize("suffix", [".json", ".ndjson"])
-def test_run_drops_unembedded_elements(stager, suffix, file_data, tmp_path: Path):
-    input_file = tmp_path / f"elements{suffix}"
-    elements = [dict(EMBEDDED), dict(UNEMBEDDED)]
-    if suffix == ".json":
+def _write(input_file: Path, elements: list[dict]) -> None:
+    if input_file.suffix == ".json":
         input_file.write_text(json.dumps(elements))
     else:
         with input_file.open("w") as f:
             ndjson.dump(elements, f)
 
+
+def _read(output_path: Path) -> list[dict]:
+    if output_path.suffix == ".json":
+        return json.loads(output_path.read_text())
+    with output_path.open() as f:
+        return ndjson.load(f)
+
+
+def _stage(stager, elements, file_data, tmp_path: Path, suffix: str) -> list[dict]:
+    input_file = tmp_path / f"elements{suffix}"
+    _write(input_file, elements)
     output_path = stager.run(
         elements_filepath=input_file,
         file_data=file_data,
         output_dir=tmp_path / "staged",
         output_filename=f"elements{suffix}",
     )
+    return _read(output_path)
 
-    if suffix == ".json":
-        staged = json.loads(output_path.read_text())
-    else:
-        with output_path.open() as f:
-            staged = ndjson.load(f)
+
+@pytest.mark.parametrize("stager,staged_text", _stagers())
+def test_includes_element_with_embeddings(stager, staged_text):
+    assert stager.should_include(element_dict=dict(EMBEDDED)) is True
+
+
+@pytest.mark.parametrize("stager,staged_text", _stagers())
+def test_excludes_element_with_no_text_and_no_embeddings(stager, staged_text):
+    assert stager.should_include(element_dict=dict(UNEMBEDDED)) is False
+
+
+@pytest.mark.parametrize("stager,staged_text", _stagers())
+def test_includes_element_with_text_but_no_embeddings(stager, staged_text):
+    """No embedder ran; the destination's own error must still surface."""
+    assert stager.should_include(element_dict=dict(NO_EMBEDDER)) is True
+
+
+@pytest.mark.parametrize("stager,staged_text", _stagers())
+@pytest.mark.parametrize("suffix", [".json", ".ndjson"])
+def test_run_drops_only_the_unembedded_element(stager, staged_text, suffix, file_data, tmp_path):
+    staged = _stage(stager, [dict(EMBEDDED), dict(UNEMBEDDED)], file_data, tmp_path, suffix)
+
     assert len(staged) == 1
+    assert staged_text(staged[0]) == EMBEDDED["text"]
 
 
-def test_astradb_keeps_unembedded_when_astra_generates_vectors():
-    """Astra vectorizes from the content itself, so the element is still usable."""
+@pytest.mark.parametrize("suffix", [".json", ".ndjson"])
+def test_run_keeps_unembedded_when_astra_generates_vectors(suffix, file_data, tmp_path):
+    """Astra vectorizes from the content, so nothing is dropped in that mode.
+
+    Elements carry no embeddings at all here, since supplying both is rejected.
+    """
     stager = AstraDBUploadStager(
         upload_stager_config=AstraDBUploadStagerConfig(astra_generated_embeddings=True)
     )
-    assert stager.should_include(element_dict=dict(UNEMBEDDED)) is True
+    staged = _stage(stager, [dict(NO_EMBEDDER), dict(UNEMBEDDED)], file_data, tmp_path, suffix)
+
+    assert len(staged) == 2
+    assert [row["$vectorize"] for row in staged] == [NO_EMBEDDER["text"], UNEMBEDDED["text"]]
+
+
+def test_astradb_still_raises_when_no_embedder_ran(file_data, tmp_path):
+    """The 'No vectors provided' configuration error must not be filtered away."""
+    stager = AstraDBUploadStager(upload_stager_config=AstraDBUploadStagerConfig())
+
+    with pytest.raises(ValueError, match="No vectors provided"):
+        _stage(stager, [dict(NO_EMBEDDER)], file_data, tmp_path, ".json")
+
+
+def test_astradb_empty_embeddings_still_raises(file_data, tmp_path):
+    """An empty vector is an invalid value, not an element to drop silently."""
+    stager = AstraDBUploadStager(upload_stager_config=AstraDBUploadStagerConfig())
+
+    with pytest.raises(ValueError, match="No vectors provided"):
+        _stage(stager, [dict(EMBEDDED, embeddings=[])], file_data, tmp_path, ".json")

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.9.2"  # pragma: no cover
+__version__ = "1.9.3"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/astradb.py
+++ b/unstructured_ingest/processes/connectors/astradb.py
@@ -344,12 +344,14 @@ class AstraDBUploadStager(UploadStager):
             metadata.pop("orig_elements", None)
 
     def should_include(self, element_dict: dict) -> bool:
-        # Elements with empty text are skipped by the embedder and arrive without an
-        # "embeddings" key. When Astra generates the vectors it works from the content
-        # instead, so only drop the element when we are the ones supplying the vector.
+        # The embedder skips elements with empty text, so those arrive without an
+        # "embeddings" key and have nothing to index. When Astra generates the vectors
+        # it works from the content instead, so nothing is dropped in that mode.
         if self.upload_stager_config.astra_generated_embeddings:
             return True
-        return "embeddings" in element_dict
+        # An element that has text but no embedding means no embedder ran, which is a
+        # configuration error conform_dict reports. Keep it so that error still surfaces.
+        return bool(element_dict.get("text")) or "embeddings" in element_dict
 
     def conform_dict(self, element_dict: dict, file_data: FileData) -> dict:
         self.truncate_dict_elements(element_dict)

--- a/unstructured_ingest/processes/connectors/astradb.py
+++ b/unstructured_ingest/processes/connectors/astradb.py
@@ -343,6 +343,14 @@ class AstraDBUploadStager(UploadStager):
             metadata["original_elements"] = format_and_truncate_orig_elements(element_dict)
             metadata.pop("orig_elements", None)
 
+    def should_include(self, element_dict: dict) -> bool:
+        # Elements with empty text are skipped by the embedder and arrive without an
+        # "embeddings" key. When Astra generates the vectors it works from the content
+        # instead, so only drop the element when we are the ones supplying the vector.
+        if self.upload_stager_config.astra_generated_embeddings:
+            return True
+        return "embeddings" in element_dict
+
     def conform_dict(self, element_dict: dict, file_data: FileData) -> dict:
         self.truncate_dict_elements(element_dict)
         if self.upload_stager_config.flatten_metadata:

--- a/unstructured_ingest/processes/connectors/chroma.py
+++ b/unstructured_ingest/processes/connectors/chroma.py
@@ -109,10 +109,12 @@ class ChromaUploadStager(UploadStager):
         return parser.parse(date_string)
 
     def should_include(self, element_dict: dict) -> bool:
-        # Elements with empty text are skipped by the embedder and arrive without an
+        # The embedder skips elements with empty text, so those arrive without an
         # "embeddings" key. The uploader passes one embedding per id, so a missing one
-        # becomes a null entry and Chroma rejects the whole batch.
-        return "embeddings" in element_dict
+        # becomes a null entry and Chroma rejects the whole batch. An element that has
+        # text but no embedding means no embedder ran, which is a misconfiguration that
+        # should keep failing loudly rather than be dropped silently.
+        return bool(element_dict.get("text")) or "embeddings" in element_dict
 
     def conform_dict(self, element_dict: dict, file_data: FileData) -> dict:
         """

--- a/unstructured_ingest/processes/connectors/chroma.py
+++ b/unstructured_ingest/processes/connectors/chroma.py
@@ -108,6 +108,12 @@ class ChromaUploadStager(UploadStager):
             logger.debug(f"date {date_string} string not a timestamp: {e}")
         return parser.parse(date_string)
 
+    def should_include(self, element_dict: dict) -> bool:
+        # Elements with empty text are skipped by the embedder and arrive without an
+        # "embeddings" key. The uploader passes one embedding per id, so a missing one
+        # becomes a null entry and Chroma rejects the whole batch.
+        return "embeddings" in element_dict
+
     def conform_dict(self, element_dict: dict, file_data: FileData) -> dict:
         """
         Prepares dictionary in the format that Chroma requires

--- a/unstructured_ingest/processes/connectors/qdrant/qdrant.py
+++ b/unstructured_ingest/processes/connectors/qdrant/qdrant.py
@@ -77,6 +77,12 @@ class QdrantUploadStager(UploadStager, ABC):
         default_factory=lambda: QdrantUploadStagerConfig()
     )
 
+    def should_include(self, element_dict: dict) -> bool:
+        # Elements with empty text are skipped by the embedder and arrive without an
+        # "embeddings" key. Qdrant accepts such a point with an empty vector rather
+        # than rejecting it, leaving a point that no vector search can ever return.
+        return "embeddings" in element_dict
+
     def conform_dict(self, element_dict: dict, file_data: FileData) -> dict:
         """Prepares dictionary in the format that Chroma requires"""
         data = element_dict.copy()

--- a/unstructured_ingest/processes/connectors/qdrant/qdrant.py
+++ b/unstructured_ingest/processes/connectors/qdrant/qdrant.py
@@ -78,10 +78,12 @@ class QdrantUploadStager(UploadStager, ABC):
     )
 
     def should_include(self, element_dict: dict) -> bool:
-        # Elements with empty text are skipped by the embedder and arrive without an
-        # "embeddings" key. Qdrant accepts such a point with an empty vector rather
-        # than rejecting it, leaving a point that no vector search can ever return.
-        return "embeddings" in element_dict
+        # The embedder skips elements with empty text, so those arrive without an
+        # "embeddings" key and would be upserted with an empty vector. Qdrant accepts
+        # such a point rather than rejecting it, leaving a point no search can return.
+        # An element that has text but no embedding means no embedder ran, which is a
+        # misconfiguration rather than an element to drop silently.
+        return bool(element_dict.get("text")) or "embeddings" in element_dict
 
     def conform_dict(self, element_dict: dict, file_data: FileData) -> dict:
         """Prepares dictionary in the format that Chroma requires"""


### PR DESCRIPTION
## What & why

Elements with empty text are never embedded — `embed_documents` embeds only elements with truthy text, so the rest arrive at the upload stager with no `embeddings` key. Three destinations map that key onto a vector field, and each mishandled its absence differently:

- **Chroma** — the uploader passes one embedding per id, so a missing one becomes a null entry and Chroma rejects the entire batch with `ValueError: Expected a 1-dimensional array, got a 0-dimensional array nan in upsert`.
- **Astra DB** — the stager raises `No vectors provided. Please enable an Unstructured embedding provider or configure Astra to generate embeddings`, which points the user at embedding configuration they already have.
- **Qdrant** — the point is upserted with an empty vector. Qdrant *accepts* it rather than rejecting it, storing a point that no vector search can ever return.

All three now override the `should_include` hook on `UploadStager`, matching Milvus and Pinecone.

## Linked ticket

PLU-431

## Scope

Narrower than it could be, deliberately. Pinecone already filters these elements. LanceDB stores the resulting null vector without complaint and KDB.AI indexes on a declared vector column, but neither has a reported failure behind it, and both would add surface area to a layer we are migrating away from.

Two exclusions are behavioural rather than incidental: Astra DB keeps unembedded elements when `astra_generated_embeddings` is set, and Weaviate is untouched, because both read a missing vector as a request to vectorize server-side. Filtering there would silently discard data for anyone relying on a server-side vectorizer.

## Verification

- **Qdrant, end to end against a real server** (stager + uploader, unnamed single-vector collection): before, 2 points stored and vector search returned 1 of 2; after, 1 point stored and 1 of 1. The empty vector is accepted on 1.7.4, 1.12.0 and 1.19.0, so this is a silent-data issue rather than a rejected write.
- **Chroma** rejection reproduced in-process against `chromadb` with the exact list shape the uploader builds.
- **Astra DB** raise reproduced by running the stager over a text-less element.
- New unit tests cover the predicate and both the `.json` and `.ndjson` run paths for all three, plus the Astra-generates-vectors case.
- Full unit suite: **1305 passed**.

## Follow-ups (separate PRs)

- Write errors interpolate only `str(e)`, which is empty for transport-level exceptions such as `httpx` timeouts and `ResponseHandlingException`. A failure recorded as `Qdrant error:` with no detail is unactionable; preserving the exception type would fix that, and the same pattern appears across several connectors.
- The Qdrant uploader sets no client timeout, so httpx's 5-second default applies, and it issues every batch for a record concurrently with `wait=True`. That combination wants a timeout, a retry, and a bound on concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

