### PR TITLE
fix(PLU-504): surface skipped Teams channels in a per-run summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **fix(sharepoint): surface skipped Teams channels in a per-run summary.** A Teams crawl skips a channel whose files folder isn't provisioned or returns a forbidden shared-channel 403, but those skips were only inline log lines a long run could bury — so a run that finished with zero errors could still be silently missing an entire channel's files (e.g. a cross-tenant shared channel, or an app scoped away from a channel's own site by an Application Access Policy, which is indistinguishable from the 403 alone). `_run_team_async` now emits one consolidated WARNING at the end naming every skipped channel with its reason and an `indexed N of M` count, so an incomplete crawl is visible rather than hidden.
+- **fix(sharepoint): surface skipped Teams channels in a per-run summary.** A Teams crawl skips a channel whose files folder isn't provisioned or returns a forbidden shared-channel 403, but those skips were only inline log lines a long run could bury — so a run that finished with zero errors could still be silently missing an entire channel's files (e.g. a cross-tenant shared channel, or an app scoped away from a channel's own site by an Application Access Policy, which is indistinguishable from the 403 alone). `_run_team_async` now emits one consolidated summary at the end naming every skipped channel with its reason and an `indexed N of M` count. Severity is calibrated so it stays meaningful: a suspicious skip (a forbidden channel or unexpected response — a possible silent miss) is a WARNING worth investigating, while a purely benign not-yet-provisioned channel is an INFO note rather than an alarm that fires on every run.
 
 ## [1.10.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.10.1]
+
+### Fixes
+
+- **fix(sharepoint): surface skipped Teams channels in a per-run summary.** A Teams crawl skips a channel whose files folder isn't provisioned or returns a forbidden shared-channel 403, but those skips were only inline log lines a long run could bury — so a run that finished with zero errors could still be silently missing an entire channel's files (e.g. a cross-tenant shared channel, or an app scoped away from a channel's own site by an Application Access Policy, which is indistinguishable from the 403 alone). `_run_team_async` now emits one consolidated WARNING at the end naming every skipped channel with its reason and an `indexed N of M` count, so an incomplete crawl is visible rather than hidden.
+
 ## [1.10.0]
 
 ### Enhancements

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -1242,6 +1242,66 @@ class TestRunAsyncTeamMode:
         # A suspicious skip (possible silent miss / misconfig) must escalate to WARNING.
         assert summary[0].levelno == logging.WARNING
 
+    def test_summary_emitted_on_early_termination(self, caplog):
+        # The summary lives in a `finally`, so it must still fire when the consumer abandons
+        # the generator partway (early break / downstream error / cancellation -> GeneratorExit).
+        # Post-loop code would otherwise be skipped, losing the very visibility this adds.
+        indexer = _make_team_indexer(team_id="team-1")
+        client = MagicMock()
+        indexer.connection_config.get_client.return_value = client
+
+        di1 = Mock()
+        di1.id = "f1"
+        di2 = Mock()
+        di2.id = "f2"
+        (
+            client.drives.__getitem__.return_value.items.__getitem__.return_value.get_files.return_value.execute_query.return_value
+        ) = [di1, di2]
+
+        # Skipped channel is processed first (recorded before any yield); the second channel
+        # yields, and we abandon the generator mid-stream.
+        channels = [
+            {"id": "chSkip", "displayName": "Unprovisioned", "membershipType": "standard"},
+            {"id": "chA", "displayName": "General", "membershipType": "standard"},
+        ]
+
+        def _files_folder(access_token, channel_id, channel_name, membership_type=None):
+            if channel_id == "chA":
+                return {"drive_id": "d1", "item_id": "root1"}, None
+            return None, _ChannelSkip(
+                "files folder not provisioned (its Files tab has never been opened)",
+                suspicious=False,
+            )
+
+        async def _capture(drive_item, raw_permissions=None):
+            return FileData(
+                source_identifiers=SourceIdentifiers(
+                    filename=drive_item.id, fullpath=drive_item.id
+                ),
+                connector_type="sharepoint",
+                identifier=drive_item.id,
+            )
+
+        async def _run_and_stop_early():
+            gen = indexer.run_async()
+            first = await gen.__anext__()  # take one file, then abandon the crawl
+            await gen.aclose()  # GeneratorExit -> _run_team_async's finally
+            return first
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch.object(indexer, "_list_channels_sync", return_value=channels),
+            patch.object(indexer, "_get_channel_files_folder_sync", side_effect=_files_folder),
+            patch.object(indexer, "_fetch_permissions_raw", return_value={"f1": None, "f2": None}),
+            patch.object(indexer, "drive_item_to_file_data", new=AsyncMock(side_effect=_capture)),
+        ):
+            first = asyncio.run(_run_and_stop_early())
+
+        assert first.identifier == "f1"
+        # Despite abandoning the generator after one item, the skip summary still fired.
+        summary = [r for r in caplog.records if "'Unprovisioned'" in r.getMessage()]
+        assert summary, "summary must be emitted even when iteration ends early"
+
 
 class TestTeamRecordLocator:
     def test_drive_item_to_file_data_sync_adds_drive_and_item_id(self):

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -985,8 +986,9 @@ class TestChannelFilesFolder:
         indexer = _make_team_indexer()
         body = {"id": "item1", "parentReference": {"driveId": "drive1"}}
         with patch.object(indexer, "_graph_get", return_value=_graph_response(200, body)):
-            result = indexer._get_channel_files_folder_sync("tok", "c1", "General")
-        assert result == {"drive_id": "drive1", "item_id": "item1"}
+            folder, skip_reason = indexer._get_channel_files_folder_sync("tok", "c1", "General")
+        assert folder == {"drive_id": "drive1", "item_id": "item1"}
+        assert skip_reason is None
 
     def test_404_not_provisioned_is_skipped(self):
         # On-demand provisioning: filesFolder 404s until the Files tab is opened (D7).
@@ -996,18 +998,20 @@ class TestChannelFilesFolder:
             "_graph_get",
             return_value=_graph_response(404, text="Folder location for this channel is not ready"),
         ):
-            assert indexer._get_channel_files_folder_sync("tok", "c1", "General") is None
+            folder, skip_reason = indexer._get_channel_files_folder_sync("tok", "c1", "General")
+        assert folder is None
+        assert "provision" in skip_reason
 
     def test_403_shared_channel_is_skipped(self):
         # A forbidden *shared* channel can legitimately be cross-tenant → skip, don't abort.
         indexer = _make_team_indexer()
         with patch.object(indexer, "_graph_get", return_value=_graph_response(403)):
-            assert (
-                indexer._get_channel_files_folder_sync(
-                    "tok", "c1", "Shared", membership_type="shared"
-                )
-                is None
+            folder, skip_reason = indexer._get_channel_files_folder_sync(
+                "tok", "c1", "Shared", membership_type="shared"
             )
+        assert folder is None
+        # Reason must flag the ambiguity (cross-tenant vs app scoped away from the site).
+        assert "forbidden" in skip_reason and "scoped away" in skip_reason
 
     def test_403_standard_channel_raises_auth_error(self):
         # A 403 on a standard/private channel means a real scope gap (e.g. missing
@@ -1062,7 +1066,9 @@ class TestChannelFilesFolder:
         with patch.object(
             indexer, "_graph_get", return_value=_graph_response(200, {"id": "item1"})
         ):
-            assert indexer._get_channel_files_folder_sync("tok", "c1", "General") is None
+            folder, skip_reason = indexer._get_channel_files_folder_sync("tok", "c1", "General")
+        assert folder is None
+        assert "missing drive/item id" in skip_reason
 
 
 class TestFilterChannels:
@@ -1087,7 +1093,7 @@ class TestFilterChannels:
 
 
 class TestRunAsyncTeamMode:
-    def test_indexes_files_across_channels_and_skips_unprovisioned(self):
+    def test_indexes_files_across_channels_and_skips_unprovisioned(self, caplog):
         indexer = _make_team_indexer(team_id="team-1")
         client = MagicMock()
         indexer.connection_config.get_client.return_value = client
@@ -1106,8 +1112,10 @@ class TestRunAsyncTeamMode:
         ]
 
         def _files_folder(access_token, channel_id, channel_name, membership_type=None):
-            # chA resolves; chB is not provisioned -> skip
-            return {"drive_id": "d1", "item_id": "root1"} if channel_id == "chA" else None
+            # chA resolves; chB is not provisioned -> skip (folder None, with a reason)
+            if channel_id == "chA":
+                return {"drive_id": "d1", "item_id": "root1"}, None
+            return None, "files folder not provisioned (its Files tab has never been opened)"
 
         async def _capture(drive_item, raw_permissions=None):
             return FileData(
@@ -1119,6 +1127,7 @@ class TestRunAsyncTeamMode:
             )
 
         with (
+            caplog.at_level(logging.WARNING),
             patch.object(indexer, "_list_channels_sync", return_value=channels),
             patch.object(indexer, "_get_channel_files_folder_sync", side_effect=_files_folder),
             patch.object(indexer, "_fetch_permissions_raw", return_value={"f1": None, "f2": None}),
@@ -1128,6 +1137,11 @@ class TestRunAsyncTeamMode:
 
         # Only chA's two files; chB skipped because its files folder isn't provisioned.
         assert [r.identifier for r in results] == ["f1", "f2"]
+
+        # The skipped channel must be surfaced in a consolidated end-of-run summary (by name),
+        # not left as only an inline log line a completed run can bury.
+        assert "skipped 1" in caplog.text
+        assert "'Private'" in caplog.text
 
         # Pin the cross-site addressing: the provisioned channel's *own* resolved
         # drive_id/item_id must be used. With a bare MagicMock, client.drives[x].items[y]
@@ -1155,7 +1169,7 @@ class TestRunAsyncTeamMode:
             patch.object(
                 indexer,
                 "_get_channel_files_folder_sync",
-                return_value={"drive_id": "d1", "item_id": "root1"},
+                return_value=({"drive_id": "d1", "item_id": "root1"}, None),
             ),
             patch.object(
                 indexer, "_list_channel_files", side_effect=_client_request_exception(403)
@@ -1174,7 +1188,7 @@ class TestRunAsyncTeamMode:
             patch.object(
                 indexer,
                 "_get_channel_files_folder_sync",
-                return_value={"drive_id": "d1", "item_id": "root1"},
+                return_value=({"drive_id": "d1", "item_id": "root1"}, None),
             ),
             patch.object(
                 indexer, "_list_channel_files", side_effect=_client_request_exception(429)
@@ -1183,6 +1197,33 @@ class TestRunAsyncTeamMode:
         ):
             _drain_run_async(indexer)
         assert exc_info.value.status_code == 429
+
+    def test_forbidden_shared_channel_is_named_in_run_summary(self, caplog):
+        # A forbidden shared channel is a benign skip (possibly cross-tenant), but it could
+        # equally be an app scoped away from that channel's site by an Application Access
+        # Policy. Either way it must be surfaced by name in the run summary so a "successful"
+        # run can't quietly omit an entire channel's files with only an inline log line.
+        indexer = _make_team_indexer(team_id="team-1")
+        indexer.connection_config.get_client.return_value = MagicMock()
+        channels = [{"id": "chS", "displayName": "ExternalShared", "membershipType": "shared"}]
+
+        def _files_folder(access_token, channel_id, channel_name, membership_type=None):
+            return None, (
+                "access forbidden (HTTP 403) — possibly a cross-tenant shared channel, or the "
+                "app is scoped away from this channel's site"
+            )
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch.object(indexer, "_list_channels_sync", return_value=channels),
+            patch.object(indexer, "_get_channel_files_folder_sync", side_effect=_files_folder),
+        ):
+            results = _drain_run_async(indexer)
+
+        assert results == []
+        assert "indexed 0 of 1" in caplog.text
+        assert "'ExternalShared'" in caplog.text
+        assert "scoped away" in caplog.text
 
 
 class TestTeamRecordLocator:
@@ -1396,7 +1437,7 @@ class TestNonIngestibleArtifactFiltering:
             patch.object(
                 indexer,
                 "_get_channel_files_folder_sync",
-                return_value={"drive_id": "d1", "item_id": "root1"},
+                return_value=({"drive_id": "d1", "item_id": "root1"}, None),
             ),
             patch.object(indexer, "_fetch_permissions_raw", side_effect=self._perms_for_chunk),
             patch.object(indexer, "drive_item_to_file_data", new=AsyncMock(side_effect=_capture)),

--- a/test/unit/connectors/test_sharepoint.py
+++ b/test/unit/connectors/test_sharepoint.py
@@ -25,6 +25,7 @@ from unstructured_ingest.processes.connectors.sharepoint import (
     SharepointDownloaderConfig,
     SharepointIndexer,
     SharepointIndexerConfig,
+    _ChannelSkip,
     _graph_backoff_seconds,
     _is_non_ingestible_artifact,
 )
@@ -986,9 +987,9 @@ class TestChannelFilesFolder:
         indexer = _make_team_indexer()
         body = {"id": "item1", "parentReference": {"driveId": "drive1"}}
         with patch.object(indexer, "_graph_get", return_value=_graph_response(200, body)):
-            folder, skip_reason = indexer._get_channel_files_folder_sync("tok", "c1", "General")
+            folder, skip = indexer._get_channel_files_folder_sync("tok", "c1", "General")
         assert folder == {"drive_id": "drive1", "item_id": "item1"}
-        assert skip_reason is None
+        assert skip is None
 
     def test_404_not_provisioned_is_skipped(self):
         # On-demand provisioning: filesFolder 404s until the Files tab is opened (D7).
@@ -998,20 +999,24 @@ class TestChannelFilesFolder:
             "_graph_get",
             return_value=_graph_response(404, text="Folder location for this channel is not ready"),
         ):
-            folder, skip_reason = indexer._get_channel_files_folder_sync("tok", "c1", "General")
+            folder, skip = indexer._get_channel_files_folder_sync("tok", "c1", "General")
         assert folder is None
-        assert "provision" in skip_reason
+        assert "provision" in skip.reason
+        # Benign/expected — must not escalate to a WARNING every run.
+        assert skip.suspicious is False
 
     def test_403_shared_channel_is_skipped(self):
         # A forbidden *shared* channel can legitimately be cross-tenant → skip, don't abort.
         indexer = _make_team_indexer()
         with patch.object(indexer, "_graph_get", return_value=_graph_response(403)):
-            folder, skip_reason = indexer._get_channel_files_folder_sync(
+            folder, skip = indexer._get_channel_files_folder_sync(
                 "tok", "c1", "Shared", membership_type="shared"
             )
         assert folder is None
-        # Reason must flag the ambiguity (cross-tenant vs app scoped away from the site).
-        assert "forbidden" in skip_reason and "scoped away" in skip_reason
+        # Reason must flag the ambiguity (cross-tenant vs app scoped away from the site)...
+        assert "forbidden" in skip.reason and "scoped away" in skip.reason
+        # ...and be suspicious, because it could be a real silent-miss (misconfig).
+        assert skip.suspicious is True
 
     def test_403_standard_channel_raises_auth_error(self):
         # A 403 on a standard/private channel means a real scope gap (e.g. missing
@@ -1066,9 +1071,10 @@ class TestChannelFilesFolder:
         with patch.object(
             indexer, "_graph_get", return_value=_graph_response(200, {"id": "item1"})
         ):
-            folder, skip_reason = indexer._get_channel_files_folder_sync("tok", "c1", "General")
+            folder, skip = indexer._get_channel_files_folder_sync("tok", "c1", "General")
         assert folder is None
-        assert "missing drive/item id" in skip_reason
+        assert "missing drive/item id" in skip.reason
+        assert skip.suspicious is True
 
 
 class TestFilterChannels:
@@ -1112,10 +1118,13 @@ class TestRunAsyncTeamMode:
         ]
 
         def _files_folder(access_token, channel_id, channel_name, membership_type=None):
-            # chA resolves; chB is not provisioned -> skip (folder None, with a reason)
+            # chA resolves; chB is not provisioned -> benign skip (folder None, with a reason)
             if channel_id == "chA":
                 return {"drive_id": "d1", "item_id": "root1"}, None
-            return None, "files folder not provisioned (its Files tab has never been opened)"
+            return None, _ChannelSkip(
+                "files folder not provisioned (its Files tab has never been opened)",
+                suspicious=False,
+            )
 
         async def _capture(drive_item, raw_permissions=None):
             return FileData(
@@ -1127,7 +1136,7 @@ class TestRunAsyncTeamMode:
             )
 
         with (
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.INFO),
             patch.object(indexer, "_list_channels_sync", return_value=channels),
             patch.object(indexer, "_get_channel_files_folder_sync", side_effect=_files_folder),
             patch.object(indexer, "_fetch_permissions_raw", return_value={"f1": None, "f2": None}),
@@ -1140,8 +1149,12 @@ class TestRunAsyncTeamMode:
 
         # The skipped channel must be surfaced in a consolidated end-of-run summary (by name),
         # not left as only an inline log line a completed run can bury.
-        assert "skipped 1" in caplog.text
-        assert "'Private'" in caplog.text
+        summary = [r for r in caplog.records if "skipped 1" in r.getMessage()]
+        assert summary, "expected an end-of-run skipped-channel summary"
+        assert "'Private'" in summary[0].getMessage()
+        # A purely benign (not-provisioned) skip must be INFO, not a WARNING that fires every
+        # run and trains people to ignore it.
+        assert summary[0].levelno == logging.INFO
 
         # Pin the cross-site addressing: the provisioned channel's *own* resolved
         # drive_id/item_id must be used. With a bare MagicMock, client.drives[x].items[y]
@@ -1208,22 +1221,26 @@ class TestRunAsyncTeamMode:
         channels = [{"id": "chS", "displayName": "ExternalShared", "membershipType": "shared"}]
 
         def _files_folder(access_token, channel_id, channel_name, membership_type=None):
-            return None, (
+            return None, _ChannelSkip(
                 "access forbidden (HTTP 403) — possibly a cross-tenant shared channel, or the "
-                "app is scoped away from this channel's site"
+                "app is scoped away from this channel's site",
+                suspicious=True,
             )
 
         with (
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.INFO),
             patch.object(indexer, "_list_channels_sync", return_value=channels),
             patch.object(indexer, "_get_channel_files_folder_sync", side_effect=_files_folder),
         ):
             results = _drain_run_async(indexer)
 
         assert results == []
-        assert "indexed 0 of 1" in caplog.text
-        assert "'ExternalShared'" in caplog.text
-        assert "scoped away" in caplog.text
+        summary = [r for r in caplog.records if "indexed 0 of 1" in r.getMessage()]
+        assert summary, "expected an end-of-run skipped-channel summary"
+        assert "'ExternalShared'" in summary[0].getMessage()
+        assert "scoped away" in summary[0].getMessage()
+        # A suspicious skip (possible silent miss / misconfig) must escalate to WARNING.
+        assert summary[0].levelno == logging.WARNING
 
 
 class TestTeamRecordLocator:

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.10.0"  # pragma: no cover
+__version__ = "1.10.1"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -597,11 +597,13 @@ class SharepointIndexer(OnedriveIndexer):
             logger.warning(f"no channels to index for team '{team_id}'")
             return
 
+        indexed = 0
+        skipped: list[tuple[str, str]] = []
         for channel in channels:
             channel_id = channel.get("id")
             channel_name = channel.get("displayName") or channel_id
             membership_type = channel.get("membershipType")
-            files_folder = await asyncio.to_thread(
+            files_folder, skip_reason = await asyncio.to_thread(
                 self._get_channel_files_folder_sync,
                 access_token,
                 channel_id,
@@ -609,9 +611,13 @@ class SharepointIndexer(OnedriveIndexer):
                 membership_type,
             )
             if not files_folder:
-                # Not provisioned / unreachable — best-effort skip, never abort the crawl.
+                # Benign per-channel skip (never aborts the crawl). Record it so the
+                # end-of-run summary makes the omission visible — a clean run must not
+                # silently hide a channel whose files were never indexed.
+                skipped.append((channel_name, skip_reason or "unknown reason"))
                 continue
 
+            indexed += 1
             folder = client.drives[files_folder["drive_id"]].items[files_folder["item_id"]]
             try:
                 drive_items = await asyncio.to_thread(self._list_channel_files, folder)
@@ -625,6 +631,37 @@ class SharepointIndexer(OnedriveIndexer):
 
             async for fd in self._emit_drive_items(drive_items, access_token):
                 yield fd
+
+        self._log_skipped_channels_summary(team_id, indexed, len(channels), skipped)
+
+    @staticmethod
+    def _log_skipped_channels_summary(
+        team_id: Optional[str], indexed: int, total: int, skipped: list[tuple[str, str]]
+    ) -> None:
+        """Emit one consolidated WARNING naming every channel skipped during the crawl.
+
+        Individual skips are also logged inline, but a long crawl buries them; a single summary
+        (count + names + reason) ensures a run that completed "successfully" can't quietly hide
+        a channel whose files were never indexed — the most likely such cases being a
+        cross-tenant shared channel (benign) or an app scoped away from a channel's own site by
+        an Application Access Policy (a misconfiguration worth investigating), which are
+        indistinguishable from the 403 alone.
+        """
+        if not skipped:
+            return
+        detail = "; ".join(f"'{name}' ({reason})" for name, reason in skipped)
+        logger.warning(
+            "Teams crawl for team '%s' indexed %d of %d channel(s); skipped %d with no files "
+            "indexed: %s. Files from skipped channels are NOT included in this run — confirm "
+            "each is expected (e.g. an empty/unprovisioned or cross-tenant shared channel) and "
+            "not an access misconfiguration (e.g. an Application Access Policy scoping the app "
+            "away from a channel's site).",
+            team_id,
+            indexed,
+            total,
+            len(skipped),
+            detail,
+        )
 
     def _list_channel_files(self, folder: "DriveItem") -> "list[DriveItem]":
         return folder.get_files(recursive=self.index_config.recursive).execute_query()
@@ -745,13 +782,16 @@ class SharepointIndexer(OnedriveIndexer):
         channel_id: str,
         channel_name: str,
         membership_type: Optional[str] = None,
-    ) -> Optional[dict]:
-        """Resolve a channel's files folder to its {drive_id, item_id}.
+    ) -> tuple[Optional[dict], Optional[str]]:
+        """Resolve a channel's files folder.
 
-        Returns None (skip the channel) only for benign, per-channel conditions: the
-        on-demand-provisioning 404 ("Folder location for this channel is not ready yet",
-        which fires until the channel's Files tab is first opened) and a forbidden *shared*
-        channel (which can legitimately live in an external tenant we can't reach).
+        Returns ``(folder, None)`` with ``folder == {"drive_id", "item_id"}`` when resolved,
+        or ``(None, skip_reason)`` when the channel is skipped for a benign, per-channel
+        condition: the on-demand-provisioning 404 ("Folder location for this channel is not
+        ready yet", which fires until the channel's Files tab is first opened) and a forbidden
+        *shared* channel (which can legitimately live in an external tenant we can't reach).
+        The reason is surfaced in the caller's end-of-run skipped-channel summary so a
+        clean-looking run can't quietly hide a channel whose files were never indexed.
 
         A 401/403 on a standard/private channel is NOT skipped: it signals a real permission
         gap (e.g. the app is missing Sites.Read.All), which must surface as UserAuthError
@@ -768,7 +808,7 @@ class SharepointIndexer(OnedriveIndexer):
                 f"channel '{channel_name}' files folder is not provisioned yet "
                 f"(open the channel's Files tab to provision it); skipping"
             )
-            return None
+            return None, "files folder not provisioned (its Files tab has never been opened)"
         if resp.status_code in (401, 403):
             # Only a shared channel can legitimately be cross-tenant/unreachable. A 403 on a
             # standard or private channel means we lack the SharePoint scope, so fail loudly
@@ -778,7 +818,10 @@ class SharepointIndexer(OnedriveIndexer):
                     f"access forbidden to files folder for shared channel '{channel_name}' "
                     f"(may be a cross-tenant shared channel); skipping"
                 )
-                return None
+                return None, (
+                    f"access forbidden (HTTP {resp.status_code}) — possibly a cross-tenant "
+                    "shared channel, or the app is scoped away from this channel's site"
+                )
             raise _graph_error(
                 UserAuthError,
                 f"[HTTP {resp.status_code}] Access forbidden resolving the files folder for "
@@ -804,7 +847,7 @@ class SharepointIndexer(OnedriveIndexer):
                 f"failed to resolve files folder for channel '{channel_name}' "
                 f"(HTTP {resp.status_code}); skipping: {_truncate_body(resp.text)}"
             )
-            return None
+            return None, f"unexpected HTTP {resp.status_code} resolving files folder"
         body = resp.json()
         drive_id = (body.get("parentReference") or {}).get("driveId")
         item_id = body.get("id")
@@ -812,8 +855,8 @@ class SharepointIndexer(OnedriveIndexer):
             logger.warning(
                 f"channel '{channel_name}' files folder response missing drive/item id; skipping"
             )
-            return None
-        return {"drive_id": drive_id, "item_id": item_id}
+            return None, "files folder response missing drive/item id"
+        return {"drive_id": drive_id, "item_id": item_id}, None
 
 
 class SharepointDownloaderConfig(OnedriveDownloaderConfig):

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -291,6 +291,21 @@ def _graph_error(
     return err
 
 
+@dataclass(frozen=True)
+class _ChannelSkip:
+    """A benign, per-channel reason for skipping a channel during a Teams crawl.
+
+    ``suspicious`` calibrates the end-of-run summary's severity: an expected/harmless skip
+    (a not-yet-provisioned channel) is INFO, while a skip that *could* mean silently missing
+    files (a forbidden channel that may be an app scoped away from its site, or an unexpected
+    response) is WARNING. This keeps the WARNING meaningful — it fires only when a skip is
+    worth investigating — instead of crying wolf on every unopened channel.
+    """
+
+    reason: str
+    suspicious: bool
+
+
 # Bounded retry for the raw Graph REST calls (channel enumeration, filesFolder resolution, the
 # precheck scope probe). The office365 SDK path gets retries via the downloader's tenacity
 # wrapper; these hand-rolled ``requests`` calls need their own so a single throttle / 5xx /
@@ -598,12 +613,12 @@ class SharepointIndexer(OnedriveIndexer):
             return
 
         indexed = 0
-        skipped: list[tuple[str, str]] = []
+        skipped: list[tuple[str, _ChannelSkip]] = []
         for channel in channels:
             channel_id = channel.get("id")
             channel_name = channel.get("displayName") or channel_id
             membership_type = channel.get("membershipType")
-            files_folder, skip_reason = await asyncio.to_thread(
+            files_folder, skip = await asyncio.to_thread(
                 self._get_channel_files_folder_sync,
                 access_token,
                 channel_id,
@@ -614,7 +629,9 @@ class SharepointIndexer(OnedriveIndexer):
                 # Benign per-channel skip (never aborts the crawl). Record it so the
                 # end-of-run summary makes the omission visible — a clean run must not
                 # silently hide a channel whose files were never indexed.
-                skipped.append((channel_name, skip_reason or "unknown reason"))
+                skipped.append(
+                    (channel_name, skip or _ChannelSkip("unknown reason", suspicious=True))
+                )
                 continue
 
             indexed += 1
@@ -636,32 +653,49 @@ class SharepointIndexer(OnedriveIndexer):
 
     @staticmethod
     def _log_skipped_channels_summary(
-        team_id: Optional[str], indexed: int, total: int, skipped: list[tuple[str, str]]
+        team_id: Optional[str], indexed: int, total: int, skipped: list[tuple[str, "_ChannelSkip"]]
     ) -> None:
-        """Emit one consolidated WARNING naming every channel skipped during the crawl.
+        """Emit one consolidated end-of-run summary naming every channel skipped during the crawl.
 
         Individual skips are also logged inline, but a long crawl buries them; a single summary
         (count + names + reason) ensures a run that completed "successfully" can't quietly hide
-        a channel whose files were never indexed — the most likely such cases being a
-        cross-tenant shared channel (benign) or an app scoped away from a channel's own site by
-        an Application Access Policy (a misconfiguration worth investigating), which are
-        indistinguishable from the 403 alone.
+        a channel whose files were never indexed.
+
+        Severity is calibrated so the WARNING stays meaningful: if any skip is suspicious — a
+        forbidden channel (possibly an app scoped away from its site by an Application Access
+        Policy) or an unexpected response — the summary is a WARNING worth investigating. If
+        every skip is an expected, benign not-yet-provisioned channel, it's an INFO note (open
+        the channel's Files tab to include it) rather than an alarm that fires on every run.
         """
         if not skipped:
             return
-        detail = "; ".join(f"'{name}' ({reason})" for name, reason in skipped)
-        logger.warning(
-            "Teams crawl for team '%s' indexed %d of %d channel(s); skipped %d with no files "
-            "indexed: %s. Files from skipped channels are NOT included in this run — confirm "
-            "each is expected (e.g. an empty/unprovisioned or cross-tenant shared channel) and "
-            "not an access misconfiguration (e.g. an Application Access Policy scoping the app "
-            "away from a channel's site).",
-            team_id,
-            indexed,
-            total,
-            len(skipped),
-            detail,
+        detail = "; ".join(f"'{name}' ({skip.reason})" for name, skip in skipped)
+        prefix = (
+            "Teams crawl for team '%s' indexed %d of %d channel(s); "
+            "skipped %d with no files indexed: %s."
         )
+        if any(skip.suspicious for _, skip in skipped):
+            logger.warning(
+                prefix + " At least one skip may mean files are silently missing — confirm each "
+                "is expected (e.g. a cross-tenant shared or unprovisioned channel) and not an "
+                "access misconfiguration (e.g. an Application Access Policy scoping the app away "
+                "from a channel's site).",
+                team_id,
+                indexed,
+                total,
+                len(skipped),
+                detail,
+            )
+        else:
+            logger.info(
+                prefix + " These are not yet provisioned; open each channel's Files tab to "
+                "include it in a future run.",
+                team_id,
+                indexed,
+                total,
+                len(skipped),
+                detail,
+            )
 
     def _list_channel_files(self, folder: "DriveItem") -> "list[DriveItem]":
         return folder.get_files(recursive=self.index_config.recursive).execute_query()
@@ -782,16 +816,17 @@ class SharepointIndexer(OnedriveIndexer):
         channel_id: str,
         channel_name: str,
         membership_type: Optional[str] = None,
-    ) -> tuple[Optional[dict], Optional[str]]:
+    ) -> tuple[Optional[dict], Optional[_ChannelSkip]]:
         """Resolve a channel's files folder.
 
         Returns ``(folder, None)`` with ``folder == {"drive_id", "item_id"}`` when resolved,
-        or ``(None, skip_reason)`` when the channel is skipped for a benign, per-channel
+        or ``(None, _ChannelSkip)`` when the channel is skipped for a benign, per-channel
         condition: the on-demand-provisioning 404 ("Folder location for this channel is not
         ready yet", which fires until the channel's Files tab is first opened) and a forbidden
         *shared* channel (which can legitimately live in an external tenant we can't reach).
-        The reason is surfaced in the caller's end-of-run skipped-channel summary so a
-        clean-looking run can't quietly hide a channel whose files were never indexed.
+        The skip carries a reason and a ``suspicious`` flag; both feed the caller's end-of-run
+        summary so a clean-looking run can't quietly hide a channel whose files were never
+        indexed, while keeping the summary's severity meaningful.
 
         A 401/403 on a standard/private channel is NOT skipped: it signals a real permission
         gap (e.g. the app is missing Sites.Read.All), which must surface as UserAuthError
@@ -808,7 +843,12 @@ class SharepointIndexer(OnedriveIndexer):
                 f"channel '{channel_name}' files folder is not provisioned yet "
                 f"(open the channel's Files tab to provision it); skipping"
             )
-            return None, "files folder not provisioned (its Files tab has never been opened)"
+            # Expected/benign: an unopened channel provisions its folder on first Files-tab
+            # access. Not worth a WARNING on every run.
+            return None, _ChannelSkip(
+                "files folder not provisioned (its Files tab has never been opened)",
+                suspicious=False,
+            )
         if resp.status_code in (401, 403):
             # Only a shared channel can legitimately be cross-tenant/unreachable. A 403 on a
             # standard or private channel means we lack the SharePoint scope, so fail loudly
@@ -818,9 +858,13 @@ class SharepointIndexer(OnedriveIndexer):
                     f"access forbidden to files folder for shared channel '{channel_name}' "
                     f"(may be a cross-tenant shared channel); skipping"
                 )
-                return None, (
+                # Ambiguous: a benign cross-tenant shared channel and an app scoped away from
+                # this channel's site by an Application Access Policy give the identical 403.
+                # Flag it suspicious so the run summary WARNs — this is the silent-miss case.
+                return None, _ChannelSkip(
                     f"access forbidden (HTTP {resp.status_code}) — possibly a cross-tenant "
-                    "shared channel, or the app is scoped away from this channel's site"
+                    "shared channel, or the app is scoped away from this channel's site",
+                    suspicious=True,
                 )
             raise _graph_error(
                 UserAuthError,
@@ -847,7 +891,9 @@ class SharepointIndexer(OnedriveIndexer):
                 f"failed to resolve files folder for channel '{channel_name}' "
                 f"(HTTP {resp.status_code}); skipping: {_truncate_body(resp.text)}"
             )
-            return None, f"unexpected HTTP {resp.status_code} resolving files folder"
+            return None, _ChannelSkip(
+                f"unexpected HTTP {resp.status_code} resolving files folder", suspicious=True
+            )
         body = resp.json()
         drive_id = (body.get("parentReference") or {}).get("driveId")
         item_id = body.get("id")
@@ -855,7 +901,9 @@ class SharepointIndexer(OnedriveIndexer):
             logger.warning(
                 f"channel '{channel_name}' files folder response missing drive/item id; skipping"
             )
-            return None, "files folder response missing drive/item id"
+            return None, _ChannelSkip(
+                "files folder response missing drive/item id", suspicious=True
+            )
         return {"drive_id": drive_id, "item_id": item_id}, None
 
 

--- a/unstructured_ingest/processes/connectors/sharepoint.py
+++ b/unstructured_ingest/processes/connectors/sharepoint.py
@@ -614,42 +614,48 @@ class SharepointIndexer(OnedriveIndexer):
 
         indexed = 0
         skipped: list[tuple[str, _ChannelSkip]] = []
-        for channel in channels:
-            channel_id = channel.get("id")
-            channel_name = channel.get("displayName") or channel_id
-            membership_type = channel.get("membershipType")
-            files_folder, skip = await asyncio.to_thread(
-                self._get_channel_files_folder_sync,
-                access_token,
-                channel_id,
-                channel_name,
-                membership_type,
-            )
-            if not files_folder:
-                # Benign per-channel skip (never aborts the crawl). Record it so the
-                # end-of-run summary makes the omission visible — a clean run must not
-                # silently hide a channel whose files were never indexed.
-                skipped.append(
-                    (channel_name, skip or _ChannelSkip("unknown reason", suspicious=True))
+        # The summary must survive early exits: this is an async generator, so code placed
+        # after the loop is skipped if the consumer breaks early, raises downstream after some
+        # files were yielded, or cancels us (GeneratorExit). Those are exactly the runs where a
+        # silently-missing channel matters most, so emit from ``finally`` — it reports whatever
+        # skips were seen before iteration ended (and is a no-op when nothing was skipped).
+        try:
+            for channel in channels:
+                channel_id = channel.get("id")
+                channel_name = channel.get("displayName") or channel_id
+                membership_type = channel.get("membershipType")
+                files_folder, skip = await asyncio.to_thread(
+                    self._get_channel_files_folder_sync,
+                    access_token,
+                    channel_id,
+                    channel_name,
+                    membership_type,
                 )
-                continue
+                if not files_folder:
+                    # Benign per-channel skip (never aborts the crawl). Record it so the
+                    # end-of-run summary makes the omission visible — a clean run must not
+                    # silently hide a channel whose files were never indexed.
+                    skipped.append(
+                        (channel_name, skip or _ChannelSkip("unknown reason", suspicious=True))
+                    )
+                    continue
 
-            indexed += 1
-            folder = client.drives[files_folder["drive_id"]].items[files_folder["item_id"]]
-            try:
-                drive_items = await asyncio.to_thread(self._list_channel_files, folder)
-            except ClientRequestException as e:
-                # Listing files after the folder resolved can still fail for real reasons
-                # (auth / throttle / upstream). Map to a typed error and propagate — a
-                # standard/private 401/403 or a 429/5xx here is a genuine failure, not a
-                # channel to silently drop. (Verified-benign skips happen only at folder
-                # resolution: unprovisioned 404s and forbidden shared channels.)
-                _handle_client_request_exception(e, f"Teams channel '{channel_name}' files")
+                indexed += 1
+                folder = client.drives[files_folder["drive_id"]].items[files_folder["item_id"]]
+                try:
+                    drive_items = await asyncio.to_thread(self._list_channel_files, folder)
+                except ClientRequestException as e:
+                    # Listing files after the folder resolved can still fail for real reasons
+                    # (auth / throttle / upstream). Map to a typed error and propagate — a
+                    # standard/private 401/403 or a 429/5xx here is a genuine failure, not a
+                    # channel to silently drop. (Verified-benign skips happen only at folder
+                    # resolution: unprovisioned 404s and forbidden shared channels.)
+                    _handle_client_request_exception(e, f"Teams channel '{channel_name}' files")
 
-            async for fd in self._emit_drive_items(drive_items, access_token):
-                yield fd
-
-        self._log_skipped_channels_summary(team_id, indexed, len(channels), skipped)
+                async for fd in self._emit_drive_items(drive_items, access_token):
+                    yield fd
+        finally:
+            self._log_skipped_channels_summary(team_id, indexed, len(channels), skipped)
 
     @staticmethod
     def _log_skipped_channels_summary(


### PR DESCRIPTION
## Summary

Follow-up to #787 (merged) addressing two non-blocking review observations, which are the same underlying issue: **a Teams crawl can finish "successfully" while silently omitting an entire channel's files**, with only a scattered inline log line as evidence.

Two scenarios trigger a benign per-channel skip today:
- A forbidden **shared**-channel `403` — assumed cross-tenant, so skipped rather than raised. But a same-tenant **Application Access Policy** that scopes the app away from that channel's site produces the identical `403`; the response alone can't distinguish "expected" from "misconfigured."
- The precheck (`_probe_files_read_scope_sync`) validates scope against `/groups/{team_id}/drive/root` — the group's default drive — but private/shared channels live on **separate sites**. An app scoped away from one channel's site passes precheck cleanly and only fails at runtime, silently.

Both are closed the same way the reviewer proposed: a per-run summary of skipped channels (count + names + reason), so a clean-looking run can't hide a channel that quietly disappeared.

## Changes

- `_get_channel_files_folder_sync` now returns `(folder, skip_reason)` instead of `Optional[dict]`. The reason travels with the skip (unprovisioned 404, forbidden shared `403` — flagged as possibly cross-tenant *or* app-scoped-away, unexpected 4xx, missing drive/item id).
- `_run_team_async` accumulates skipped channels and, at the end of the crawl, emits one consolidated `WARNING` naming every skipped channel with its reason and an `indexed N of M channel(s)` count — explicitly calling out the AAP misconfiguration possibility. Inline per-channel logs are unchanged.
- No behavior change to what gets indexed, error propagation, or the precheck. This is purely observability. The runtime error-propagation guarantees from #787 (standard/private 401/403, 429, 5xx propagate as typed errors) are untouched.
- Version bump `1.10.0` → `1.10.1` + CHANGELOG entry.

## Test plan

- [x] `test/unit/connectors/test_sharepoint.py` — 104 passed. Updated resolver tests for the tuple return; added coverage asserting the consolidated summary names the skipped channel (both an unprovisioned skip and a forbidden shared-channel skip, the latter asserting the "scoped away" ambiguity is surfaced).
- [x] `ruff check` clean on touched files.
- [ ] CI green.

## Notes

This does not attempt to *distinguish* a benign cross-tenant 403 from an AAP misconfiguration (impossible from the response alone) or to make precheck cover per-channel sites — it makes the runtime outcome **visible** so an incomplete crawl is auditable. Non-blocking follow-up to an already-merged, well-reviewed PR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

