### PR TITLE
chore(deps): bump claude-code-action to v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.GH_ANTHROPIC_API_KEY }}
           claude_args: |
-            --allowedTools "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+            --allowedTools "Bash(git:*),Read,Glob,Grep"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.GH_ANTHROPIC_API_KEY }}
           allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,5 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.GH_ANTHROPIC_API_KEY }}
-          allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+          claude_args: |
+            --allowedTools "Bash(git:*),View,GlobTool,GrepTool,BatchTool"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.10.4]
+
+### Fixes
+
+- **chore(ci): bump `anthropics/claude-code-action` to `v1`.** Moves the `@claude` workflow off the deprecated `@beta` pin and migrates the tool allowlist to the current Claude Code CLI tool names (`Read`/`Glob`/`Grep`).
+
 ## [1.10.3]
 
 ### Fixes

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.10.3"  # pragma: no cover
+__version__ = "1.10.4"  # pragma: no cover


### PR DESCRIPTION
Bumps `anthropics/claude-code-action` from `@beta` to `@v1`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

