### PR TITLE
feat(PLU-534): enable incremental + emit ACL digest for Confluence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.10.4]
+
+### Enhancements
+
+- **feat(confluence): enable incremental + emit an ACL digest (PLU-534).** Confluence was in no incremental allowlist, so it reprocessed every page on every run. The indexer now emits the content version (page `version.number`) and a per-file `permissions_version` ACL digest at index time, so under incremental (`reprocess_all=false`, `reprocess_on_permission_change=true`) an unchanged page is skipped and an ACL-only change (page restriction / space permission) reprocesses it. The permission fetch/parse moved from the downloader into module-level functions the indexer calls (single implementation); the digest follows the None-vs-`[]` contract (an unavailable fetch leaves the ACL fields unset so the comparison is skipped; a genuinely empty ACL yields a real digest). The now-redundant download-time permission fetch is removed, and `ConfluenceDownloaderConfig.max_num_metadata_permissions` is deprecated in favor of the same field on `ConfluenceIndexerConfig`.
+
 ## [1.10.3]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **feat(confluence): enable incremental + emit an ACL digest (PLU-534).** Confluence was in no incremental allowlist, so it reprocessed every page on every run. The indexer now emits the content version (page `version.number`) and a per-file `permissions_version` ACL digest at index time, so under incremental (`reprocess_all=false`, `reprocess_on_permission_change=true`) an unchanged page is skipped and an ACL-only change (page restriction / space permission) reprocesses it. The permission fetch/parse moved from the downloader into module-level functions the indexer calls (single implementation); the digest follows the None-vs-`[]` contract (an unavailable fetch leaves the ACL fields unset so the comparison is skipped; a genuinely empty ACL yields a real digest). The now-redundant download-time permission fetch is removed, and `ConfluenceDownloaderConfig.max_num_metadata_permissions` is deprecated in favor of the same field on `ConfluenceIndexerConfig`.
 
+### Fixes
+
+- **fix(confluence): parse ACL `access-class` principals instead of crashing (PLU-625).** The permission parser assumed every principal was a `user` or `group` and raised `KeyError` on Confluence's built-in `access-class` principals (`ALL_LICENSED_USERS`, `ALL_PRODUCT_ADMINS`, …), which appear on essentially every space. The exception was swallowed, so `permissions_data` came back blank for every space — and, because the crash happened after page restrictions were already parsed, it discarded those too, so even explicitly-restricted pages emitted no ACL. Principals are now bucketed by type into `users` / `groups` / `access_classes` (unknown types skipped), so the parser no longer crashes, page restrictions survive, and access-class grants are captured in the digest.
+
 ## [1.10.3]
 
 ### Fixes

--- a/test/unit/connectors/test_confluence.py
+++ b/test/unit/connectors/test_confluence.py
@@ -544,7 +544,17 @@ def test_get_permissions_data_is_order_independent(connection_config):
     # same normalized result (and therefore the same digest).
     def run_with_user_order(user_results):
         mock_client = mock.MagicMock()
-        mock_client.get.return_value = {"results": [], "_links": {}}
+        # Non-empty space perm so parsing/normalization actually runs (an empty space
+        # response would make the test assert nothing about ordering).
+        mock_client.get.return_value = {
+            "results": [
+                {
+                    "operation": {"key": "read", "targetType": "space"},
+                    "principal": {"id": "space-user", "type": "user"},
+                }
+            ],
+            "_links": {},
+        }
         mock_client.get_all_restrictions_for_content.return_value = {
             "read": {
                 "restrictions": {
@@ -622,6 +632,25 @@ def test_indexer_permissions_unavailable_leaves_version_unset(connection_config)
     assert fd.metadata.version == "7"
     assert fd.metadata.permissions_data is None
     assert fd.metadata.permissions_version is None
+
+
+def test_indexer_emits_digest_for_empty_permissions(connection_config):
+    # Empty-but-present ACL ([]) is a real state (no grants), distinct from unavailable
+    # (None). It must still emit permissions_data == [] and a real digest so a later
+    # revocation-to-empty is detected rather than dropped as "unavailable".
+    indexer, docs = _indexer_with_docs(connection_config, [_DOC])
+    with (
+        mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[("ENG", 987)]),
+        mock.patch.object(indexer, "_get_docs_ids_within_one_space", return_value=docs),
+        mock.patch(f"{CONFLUENCE_MODULE}.get_permissions_data", return_value=[]),
+    ):
+        results = list(indexer.run())
+
+    assert len(results) == 1
+    fd = results[0]
+    assert fd.metadata.version == "7"
+    assert fd.metadata.permissions_data == []
+    assert fd.metadata.permissions_version == compute_permissions_version([])
 
 
 # --- PLU-625: access-class principals must not crash the permission parser ---------
@@ -706,3 +735,10 @@ def test_parse_skips_unknown_principal_type(connection_config):
     ]
     result = _run_get_permissions_data(connection_config, space_permissions, _NO_PAGE_RESTRICTION)
     assert result is not None
+    # the unknown principal is skipped, not silently bucketed under some role
+    assert all(
+        "weird" not in principal_ids
+        for role in result
+        for buckets in role.values()
+        for principal_ids in buckets.values()
+    )

--- a/test/unit/connectors/test_confluence.py
+++ b/test/unit/connectors/test_confluence.py
@@ -836,3 +836,63 @@ def test_indexer_clears_permissions_cache_at_run_start(connection_config):
     with mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[]):
         list(indexer.run())
     assert 987 not in indexer._permissions_cache
+
+
+def test_get_space_permissions_none_on_nonlist_results_initial(connection_config):
+    # A present-but-non-list `results` is malformed, same as a missing one -> None.
+    mock_client = mock.MagicMock()
+    mock_client.get.return_value = {"results": "oops", "_links": {}}
+    cache = OrderedDict()
+    patcher = _patched_client(connection_config, mock_client)
+    try:
+        result = _get_space_permissions(connection_config, 987, cache)
+    finally:
+        patcher.stop()
+
+    assert result is None
+    assert 987 not in cache
+
+
+def test_get_space_permissions_none_on_nonlist_results_cursor(connection_config):
+    page1 = {
+        "results": [_space_perm("u1")],
+        "_links": {"next": "/wiki/api/v2/spaces/987/permissions?cursor=abc"},
+    }
+    bad_cursor_page = {"results": {"unexpected": "shape"}, "_links": {}}
+    mock_client = mock.MagicMock()
+    mock_client.get.side_effect = [page1, bad_cursor_page]
+    cache = OrderedDict()
+    patcher = _patched_client(connection_config, mock_client)
+    try:
+        result = _get_space_permissions(connection_config, 987, cache)
+    finally:
+        patcher.stop()
+
+    assert result is None
+    assert 987 not in cache
+
+
+def test_get_space_permissions_empty_results_returns_and_caches(connection_config):
+    # A valid empty space ACL ([]) is distinct from unavailable (None): it is returned
+    # as [] and cached, so the caller emits a real (empty) digest.
+    mock_client = mock.MagicMock()
+    mock_client.get.return_value = {"results": [], "_links": {}}
+    cache = OrderedDict()
+    patcher = _patched_client(connection_config, mock_client)
+    try:
+        result = _get_space_permissions(connection_config, 987, cache)
+    finally:
+        patcher.stop()
+
+    assert result == []
+    assert cache[987] == []
+
+
+@pytest.mark.parametrize("bad_doc_response", [None, {}, [], "nope"])
+def test_get_permissions_data_none_on_malformed_doc_restrictions(
+    connection_config, bad_doc_response
+):
+    # awalker4 review: the per-doc restrictions fetch must also return None on a
+    # malformed response instead of parsing it into a fabricated unrestricted ACL.
+    result = _run_get_permissions_data(connection_config, [_space_perm("u1")], bad_doc_response)
+    assert result is None

--- a/test/unit/connectors/test_confluence.py
+++ b/test/unit/connectors/test_confluence.py
@@ -168,12 +168,8 @@ def test_indexer_oauth_file_data_uses_cloud_identity():
     assert file_data.identifier == "456"
     assert file_data.source_identifiers.fullpath == "cloud-123/ENG/456.html"
     assert file_data.metadata.url == "https://example.atlassian.net/wiki/pages/456"
-    assert file_data.metadata.date_created == str(
-        parser.parse("2026-05-28T10:00:00Z").timestamp()
-    )
-    assert file_data.metadata.date_modified == str(
-        parser.parse("2026-05-28T11:00:00Z").timestamp()
-    )
+    assert file_data.metadata.date_created == str(parser.parse("2026-05-28T10:00:00Z").timestamp())
+    assert file_data.metadata.date_modified == str(parser.parse("2026-05-28T11:00:00Z").timestamp())
     assert file_data.metadata.version == "7"
     assert file_data.metadata.record_locator["cloud_id"] == "cloud-123"
     assert file_data.additional_metadata["site_url"] == "https://example.atlassian.net/wiki"
@@ -381,10 +377,7 @@ def test_precheck_with_spaces_uses_v2_spaces(monkeypatch, connection_config):
         result = indexer.precheck()
         calls = [
             mock.call("api/v2/spaces", params={"limit": 1}),
-            *[
-                mock.call("api/v2/spaces", params={"limit": 1, "keys": [space]})
-                for space in spaces
-            ],
+            *[mock.call("api/v2/spaces", params={"limit": 1, "keys": [space]}) for space in spaces],
         ]
         mock_client.get.assert_has_calls(calls, any_order=False)
         assert result is True
@@ -484,6 +477,7 @@ def test_downloader_error_redacts_secret(tmp_path, connection_config):
     # The page identifier and the sanitized summary survive for troubleshooting.
     assert "123" in message
     assert "Exception" in message
+
 
 # --- PLU-534: ACL digest (permissions_version) ---------------------------------
 
@@ -599,9 +593,11 @@ def test_indexer_emits_permissions_version(connection_config):
         {"update": {"users": [], "groups": []}},
         {"delete": {"users": [], "groups": []}},
     ]
-    with mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[("ENG", 987)]), \
-        mock.patch.object(indexer, "_get_docs_ids_within_one_space", return_value=docs), \
-        mock.patch(f"{CONFLUENCE_MODULE}.get_permissions_data", return_value=permissions_data):
+    with (
+        mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[("ENG", 987)]),
+        mock.patch.object(indexer, "_get_docs_ids_within_one_space", return_value=docs),
+        mock.patch(f"{CONFLUENCE_MODULE}.get_permissions_data", return_value=permissions_data),
+    ):
         results = list(indexer.run())
 
     assert len(results) == 1
@@ -613,9 +609,11 @@ def test_indexer_emits_permissions_version(connection_config):
 
 def test_indexer_permissions_unavailable_leaves_version_unset(connection_config):
     indexer, docs = _indexer_with_docs(connection_config, [_DOC])
-    with mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[("ENG", 987)]), \
-        mock.patch.object(indexer, "_get_docs_ids_within_one_space", return_value=docs), \
-        mock.patch(f"{CONFLUENCE_MODULE}.get_permissions_data", return_value=None):
+    with (
+        mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[("ENG", 987)]),
+        mock.patch.object(indexer, "_get_docs_ids_within_one_space", return_value=docs),
+        mock.patch(f"{CONFLUENCE_MODULE}.get_permissions_data", return_value=None),
+    ):
         results = list(indexer.run())
 
     assert len(results) == 1
@@ -624,3 +622,87 @@ def test_indexer_permissions_unavailable_leaves_version_unset(connection_config)
     assert fd.metadata.version == "7"
     assert fd.metadata.permissions_data is None
     assert fd.metadata.permissions_version is None
+
+
+# --- PLU-625: access-class principals must not crash the permission parser ---------
+
+
+def _run_get_permissions_data(connection_config, space_permissions, doc_restrictions):
+    mock_client = mock.MagicMock()
+    mock_client.get.return_value = {"results": space_permissions, "_links": {}}
+    mock_client.get_all_restrictions_for_content.return_value = doc_restrictions
+    with mock.patch.object(type(connection_config), "get_client", mock.MagicMock()):
+        type(connection_config).get_client.return_value.__enter__.return_value = mock_client
+        return get_permissions_data(
+            connection_config=connection_config,
+            doc_id="123",
+            space_id=987,
+            cache=OrderedDict(),
+            max_num_metadata_permissions=250,
+        )
+
+
+_NO_PAGE_RESTRICTION = {
+    "read": {"restrictions": {"user": {"results": []}, "group": {"results": []}}},
+    "update": {"restrictions": {"user": {"results": []}, "group": {"results": []}}},
+}
+
+
+def test_parse_handles_access_class_space_permissions(connection_config):
+    # ALL_PRODUCT_ADMINS is an access-class principal present on essentially every space.
+    # Before PLU-625 this raised KeyError (access-classs bucket) -> swallowed -> None.
+    space_permissions = [
+        {
+            "operation": {"key": "administer", "targetType": "space"},
+            "principal": {"id": "ALL_PRODUCT_ADMINS", "type": "access-class"},
+        },
+        {
+            "operation": {"key": "delete", "targetType": "page"},
+            "principal": {"id": "ALL_PRODUCT_ADMINS", "type": "access-class"},
+        },
+    ]
+    result = _run_get_permissions_data(connection_config, space_permissions, _NO_PAGE_RESTRICTION)
+
+    assert result is not None  # would be None (KeyError swallowed) before the fix
+    read = next(entry["read"] for entry in result if "read" in entry)
+    # access-class captured in its own bucket, alongside users/groups
+    assert set(read.keys()) == {"users", "groups", "access_classes"}
+    assert "ALL_PRODUCT_ADMINS" in read["access_classes"]
+    delete = next(entry["delete"] for entry in result if "delete" in entry)
+    assert "ALL_PRODUCT_ADMINS" in delete["access_classes"]
+
+
+def test_page_restriction_survives_access_class_space_permissions(connection_config):
+    # The regression: a page IS restricted to a named user, but the space also carries
+    # an access-class delete/page perm whose branch condition evaluated the missing
+    # bucket -> KeyError -> the whole parse threw and discarded the page restriction too.
+    space_permissions = [
+        {
+            "operation": {"key": "delete", "targetType": "page"},
+            "principal": {"id": "ALL_PRODUCT_ADMINS", "type": "access-class"},
+        },
+    ]
+    doc_restrictions = {
+        "read": {
+            "restrictions": {"user": {"results": [{"accountId": "u1"}]}, "group": {"results": []}}
+        },
+        "update": {"restrictions": {"user": {"results": []}, "group": {"results": []}}},
+    }
+    result = _run_get_permissions_data(connection_config, space_permissions, doc_restrictions)
+
+    assert result is not None  # previously None
+    read = next(entry["read"] for entry in result if "read" in entry)
+    # the explicit page restriction is preserved (it was being discarded by the crash)
+    assert "u1" in read["users"]
+
+
+def test_parse_skips_unknown_principal_type(connection_config):
+    # A principal type we don't model should be skipped, not crash.
+    space_permissions = [
+        {
+            "operation": {"key": "administer", "targetType": "space"},
+            "principal": {"id": "weird", "type": "some-future-type"},
+        },
+    ]
+    result = _run_get_permissions_data(connection_config, space_permissions, _NO_PAGE_RESTRICTION)
+    assert result is not None

--- a/test/unit/connectors/test_confluence.py
+++ b/test/unit/connectors/test_confluence.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from unittest import mock
 
 import pytest
@@ -16,7 +17,9 @@ from unstructured_ingest.processes.connectors.confluence import (
     ConfluenceDownloaderConfig,
     ConfluenceIndexer,
     ConfluenceIndexerConfig,
+    get_permissions_data,
 )
+from unstructured_ingest.utils.acl import compute_permissions_version
 
 
 @pytest.fixture
@@ -336,9 +339,10 @@ def test_downloader_uses_v2_page_api(tmp_path, connection_config):
 
     with mock.patch.object(type(connection_config), "get_client", mock.MagicMock()):
         type(connection_config).get_client.return_value.__enter__.return_value = mock_client
-        with mock.patch.object(downloader, "_get_permissions_for_space", return_value=None):
-            response = downloader.run(file_data)
+        response = downloader.run(file_data)
 
+    # PLU-534: the downloader no longer fetches permissions (resolved at index time),
+    # so the only client.get is the v2 page fetch.
     mock_client.get.assert_called_once_with(
         "api/v2/pages/123",
         params={"body-format": "view", "include-version": "true"},
@@ -480,3 +484,143 @@ def test_downloader_error_redacts_secret(tmp_path, connection_config):
     # The page identifier and the sanitized summary survive for troubleshooting.
     assert "123" in message
     assert "Exception" in message
+
+# --- PLU-534: ACL digest (permissions_version) ---------------------------------
+
+CONFLUENCE_MODULE = "unstructured_ingest.processes.connectors.confluence"
+
+
+def test_get_permissions_data_none_when_space_fetch_unavailable(connection_config):
+    # A failed space-permission fetch is "unavailable", not "empty": return None so
+    # the caller leaves the ACL fields unset rather than fabricating an empty ACL.
+    mock_client = mock.MagicMock()
+    mock_client.get.side_effect = Exception("boom")
+
+    with mock.patch.object(type(connection_config), "get_client", mock.MagicMock()):
+        type(connection_config).get_client.return_value.__enter__.return_value = mock_client
+        result = get_permissions_data(
+            connection_config=connection_config,
+            doc_id="123",
+            space_id=987,
+            cache=OrderedDict(),
+            max_num_metadata_permissions=250,
+        )
+
+    assert result is None
+
+
+def test_get_permissions_data_returns_normalized_permissions(connection_config):
+    space_permissions = [
+        {
+            "operation": {"key": "read", "targetType": "space"},
+            "principal": {"id": "u-space", "type": "user"},
+        },
+    ]
+    mock_client = mock.MagicMock()
+    mock_client.get.return_value = {"results": space_permissions, "_links": {}}
+    mock_client.get_all_restrictions_for_content.return_value = {
+        "read": {
+            "restrictions": {
+                "user": {"results": [{"accountId": "u1"}]},
+                "group": {"results": []},
+            }
+        },
+        "update": {"restrictions": {"user": {"results": []}, "group": {"results": []}}},
+    }
+
+    with mock.patch.object(type(connection_config), "get_client", mock.MagicMock()):
+        type(connection_config).get_client.return_value.__enter__.return_value = mock_client
+        result = get_permissions_data(
+            connection_config=connection_config,
+            doc_id="123",
+            space_id=987,
+            cache=OrderedDict(),
+            max_num_metadata_permissions=250,
+        )
+
+    assert result is not None
+    assert [next(iter(entry)) for entry in result] == ["read", "update", "delete"]
+    read = next(entry["read"] for entry in result if "read" in entry)
+    # page-level read restriction is captured
+    assert "u1" in read["users"]
+
+
+def test_get_permissions_data_is_order_independent(connection_config):
+    # Determinism: the same permissions in a different API order must produce the
+    # same normalized result (and therefore the same digest).
+    def run_with_user_order(user_results):
+        mock_client = mock.MagicMock()
+        mock_client.get.return_value = {"results": [], "_links": {}}
+        mock_client.get_all_restrictions_for_content.return_value = {
+            "read": {
+                "restrictions": {
+                    "user": {"results": user_results},
+                    "group": {"results": []},
+                }
+            },
+        }
+        with mock.patch.object(type(connection_config), "get_client", mock.MagicMock()):
+            type(connection_config).get_client.return_value.__enter__.return_value = mock_client
+            return get_permissions_data(
+                connection_config=connection_config,
+                doc_id="123",
+                space_id=987,
+                cache=OrderedDict(),
+                max_num_metadata_permissions=250,
+            )
+
+    a = run_with_user_order([{"accountId": "u1"}, {"accountId": "u2"}])
+    b = run_with_user_order([{"accountId": "u2"}, {"accountId": "u1"}])
+    assert a == b
+    assert compute_permissions_version(a) == compute_permissions_version(b)
+
+
+def _indexer_with_docs(connection_config, docs):
+    indexer = ConfluenceIndexer(
+        connection_config=connection_config,
+        index_config=ConfluenceIndexerConfig(spaces=["ENG"]),
+    )
+    return indexer, docs
+
+
+_DOC = {
+    "space_id": 987,
+    "doc_id": "123",
+    "date_created": None,
+    "date_modified": None,
+    "version_number": 7,
+}
+
+
+def test_indexer_emits_permissions_version(connection_config):
+    indexer, docs = _indexer_with_docs(connection_config, [_DOC])
+    permissions_data = [
+        {"read": {"users": ["u1"], "groups": ["g1"]}},
+        {"update": {"users": [], "groups": []}},
+        {"delete": {"users": [], "groups": []}},
+    ]
+    with mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[("ENG", 987)]), \
+        mock.patch.object(indexer, "_get_docs_ids_within_one_space", return_value=docs), \
+        mock.patch(f"{CONFLUENCE_MODULE}.get_permissions_data", return_value=permissions_data):
+        results = list(indexer.run())
+
+    assert len(results) == 1
+    fd = results[0]
+    assert fd.metadata.version == "7"
+    assert fd.metadata.permissions_data == permissions_data
+    assert fd.metadata.permissions_version == compute_permissions_version(permissions_data)
+
+
+def test_indexer_permissions_unavailable_leaves_version_unset(connection_config):
+    indexer, docs = _indexer_with_docs(connection_config, [_DOC])
+    with mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[("ENG", 987)]), \
+        mock.patch.object(indexer, "_get_docs_ids_within_one_space", return_value=docs), \
+        mock.patch(f"{CONFLUENCE_MODULE}.get_permissions_data", return_value=None):
+        results = list(indexer.run())
+
+    assert len(results) == 1
+    fd = results[0]
+    # content version still emitted; ACL fields left unset so the compare is skipped
+    assert fd.metadata.version == "7"
+    assert fd.metadata.permissions_data is None
+    assert fd.metadata.permissions_version is None

--- a/test/unit/connectors/test_confluence.py
+++ b/test/unit/connectors/test_confluence.py
@@ -17,6 +17,8 @@ from unstructured_ingest.processes.connectors.confluence import (
     ConfluenceDownloaderConfig,
     ConfluenceIndexer,
     ConfluenceIndexerConfig,
+    _get_space_permissions,
+    _next_page_path,
     get_permissions_data,
 )
 from unstructured_ingest.utils.acl import compute_permissions_version
@@ -742,3 +744,95 @@ def test_parse_skips_unknown_principal_type(connection_config):
         for buckets in role.values()
         for principal_ids in buckets.values()
     )
+
+
+# --- space-permission pagination, malformed pages, and per-run cache (PLU-534 review) ---
+
+
+def _space_perm(principal_id, key="read"):
+    return {
+        "operation": {"key": key, "targetType": "space"},
+        "principal": {"id": principal_id, "type": "user"},
+    }
+
+
+def _patched_client(connection_config, mock_client):
+    patcher = mock.patch.object(type(connection_config), "get_client", mock.MagicMock())
+    patcher.start()
+    type(connection_config).get_client.return_value.__enter__.return_value = mock_client
+    return patcher
+
+
+def test_next_page_path_normalizes_wiki_prefix_and_query():
+    resp = {"_links": {"next": "/wiki/api/v2/spaces/987/permissions?cursor=abc"}}
+    assert _next_page_path(resp) == "api/v2/spaces/987/permissions?cursor=abc"
+    assert _next_page_path({"_links": {}}) is None
+    assert _next_page_path({}) is None
+
+
+def test_get_space_permissions_paginates_and_normalizes_cursor(connection_config):
+    page1 = {
+        "results": [_space_perm("u1")],
+        "_links": {"next": "/wiki/api/v2/spaces/987/permissions?cursor=abc"},
+    }
+    page2 = {"results": [_space_perm("u2")], "_links": {}}
+    mock_client = mock.MagicMock()
+    mock_client.get.side_effect = [page1, page2]
+    patcher = _patched_client(connection_config, mock_client)
+    try:
+        result = _get_space_permissions(connection_config, 987, OrderedDict())
+    finally:
+        patcher.stop()
+
+    # every _links.next page is accumulated, not just the first
+    assert [p["principal"]["id"] for p in result] == ["u1", "u2"]
+    # the cursor URL is normalized (/wiki/ stripped, query kept) before the next GET
+    assert mock_client.get.call_args_list[1].args[0] == "api/v2/spaces/987/permissions?cursor=abc"
+
+
+def test_get_space_permissions_none_on_malformed_initial_page(connection_config):
+    # A 200 whose body omits `results` must not fabricate an empty ACL.
+    mock_client = mock.MagicMock()
+    mock_client.get.return_value = {"_links": {}}
+    cache = OrderedDict()
+    patcher = _patched_client(connection_config, mock_client)
+    try:
+        result = _get_space_permissions(connection_config, 987, cache)
+    finally:
+        patcher.stop()
+
+    assert result is None
+    assert 987 not in cache  # failures are never cached
+
+
+def test_get_space_permissions_none_on_malformed_cursor_page(connection_config):
+    # A malformed later page discards the partial result rather than returning a
+    # truncated ACL that would look like a revocation of the missing pages.
+    page1 = {
+        "results": [_space_perm("u1")],
+        "_links": {"next": "/wiki/api/v2/spaces/987/permissions?cursor=abc"},
+    }
+    bad_cursor_page = {"_links": {}}
+    mock_client = mock.MagicMock()
+    mock_client.get.side_effect = [page1, bad_cursor_page]
+    cache = OrderedDict()
+    patcher = _patched_client(connection_config, mock_client)
+    try:
+        result = _get_space_permissions(connection_config, 987, cache)
+    finally:
+        patcher.stop()
+
+    assert result is None
+    assert 987 not in cache
+
+
+def test_indexer_clears_permissions_cache_at_run_start(connection_config):
+    # A reused indexer instance must not serve a prior run's space ACL.
+    indexer = ConfluenceIndexer(
+        connection_config=connection_config,
+        index_config=ConfluenceIndexerConfig(spaces=["ENG"]),
+    )
+    indexer._permissions_cache[987] = [_space_perm("stale-user")]
+    with mock.patch.object(indexer, "_get_space_ids_and_keys", return_value=[]):
+        list(indexer.run())
+    assert 987 not in indexer._permissions_cache

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.10.3"  # pragma: no cover
+__version__ = "1.10.4"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -57,19 +57,36 @@ def _iso8601_to_epoch_str(iso_date: Optional[str]) -> Optional[str]:
     return str(parser.parse(iso_date).timestamp())
 
 
+# Confluence principals fall into three kinds. "access-class" covers the built-in
+# categories (ALL_LICENSED_USERS, ALL_PRODUCT_ADMINS, anonymous, ...) that appear on
+# essentially every space; earlier code assumed only user/group and raised KeyError on
+# these, which was swallowed and produced blank permissions_data (PLU-625). Unknown
+# principal types are skipped rather than crashing the whole parse.
+_PRINCIPAL_TYPE_TO_BUCKET = {
+    "user": "users",
+    "group": "groups",
+    "access-class": "access_classes",
+}
+
+
+def _empty_permission_buckets() -> dict[str, set]:
+    return {"users": set(), "groups": set(), "access_classes": set()}
+
+
 def _parse_permissions(
     doc_permissions: dict,
     space_permissions: list,
     max_num_metadata_permissions: int,
 ) -> dict[str, dict]:
     """
-    Parses document and space permissions to determine final user/group roles.
+    Parses document and space permissions to determine final user/group/access-class roles.
 
     :param doc_permissions: dict containing document-level restrictions
     - doc_permissions type in Confluence: ContentRestrictionArray
     :param space_permissions: list of space-level permission assignments
     - space_permissions type in Confluence: list of SpacePermissionAssignment
-    :return: dict with operation as keys and each maps to dict with "users" and "groups"
+    :return: dict with operation as keys, each mapping to dict with "users", "groups",
+      and "access_classes"
 
     Get document permissions. If they exist, they will override space level permissions.
     Otherwise, apply relevant space permissions (read, administer, delete)
@@ -93,24 +110,29 @@ def _parse_permissions(
     )
 
     permissions_by_role = {
-        "read": {"users": set(), "groups": set()},
-        "update": {"users": set(), "groups": set()},
-        "delete": {"users": set(), "groups": set()},
+        "read": _empty_permission_buckets(),
+        "update": _empty_permission_buckets(),
+        "delete": _empty_permission_buckets(),
     }
 
     total_permissions = 0
 
     for action, permissions in doc_permissions.items():
+        if action not in permissions_by_role:
+            continue
         restrictions_dict = permissions.get("restrictions", {})
 
         for entity_type, entity_data in restrictions_dict.items():
-            for entity in entity_data.get("results"):
+            bucket = _PRINCIPAL_TYPE_TO_BUCKET.get(entity_type)
+            if bucket is None:
+                continue
+            for entity in entity_data.get("results") or []:
                 entity_id = entity["accountId"] if entity_type == "user" else entity["id"]
-                permissions_by_role[action][f"{entity_type}s"].add(entity_id)
+                permissions_by_role[action][bucket].add(entity_id)
                 total_permissions += 1
                 # edit permission implies view permission
                 if action == "update":
-                    permissions_by_role["read"][f"{entity_type}s"].add(entity_id)
+                    permissions_by_role["read"][bucket].add(entity_id)
                     # total_permissions += 1
                     # ^ omitting to not double count an entity.
                     # may result in a higher total count than max_num_metadata_permissions
@@ -121,6 +143,11 @@ def _parse_permissions(
             space_target_type = space_perm["operation"]["targetType"]
             space_entity_id = space_perm["principal"]["id"]
             space_entity_type = space_perm["principal"]["type"]
+            bucket = _PRINCIPAL_TYPE_TO_BUCKET.get(space_entity_type)
+            if bucket is None:
+                # Unknown principal type (not user/group/access-class); skip rather than
+                # crash the whole parse (PLU-625).
+                continue
 
             # Apply space-level view permissions if no page restrictions exist
             if (
@@ -128,16 +155,16 @@ def _parse_permissions(
                 and space_operation == "read"
                 and not page_view_restricted
             ):
-                permissions_by_role["read"][f"{space_entity_type}s"].add(space_entity_id)
+                permissions_by_role["read"][bucket].add(space_entity_id)
                 total_permissions += 1
 
             # Administer permission includes view + edit. Apply if not page restricted
             elif space_target_type == "space" and space_operation == "administer":
                 if not page_view_restricted:
-                    permissions_by_role["read"][f"{space_entity_type}s"].add(space_entity_id)
+                    permissions_by_role["read"][bucket].add(space_entity_id)
                     total_permissions += 1
                     if not page_edit_restricted:
-                        permissions_by_role["update"][f"{space_entity_type}s"].add(space_entity_id)
+                        permissions_by_role["update"][bucket].add(space_entity_id)
                         # total_permissions += 1
                         # ^ omitting to not double count an entity.
                         # may result in a higher total count than max_num_metadata_permissions
@@ -146,9 +173,9 @@ def _parse_permissions(
             elif (
                 space_target_type == "page"
                 and space_operation == "delete"
-                and space_entity_id in permissions_by_role["read"][f"{space_entity_type}s"]
+                and space_entity_id in permissions_by_role["read"][bucket]
             ):
-                permissions_by_role["delete"][f"{space_entity_type}s"].add(space_entity_id)
+                permissions_by_role["delete"][bucket].add(space_entity_id)
                 total_permissions += 1
 
     # turn sets into sorted lists for consistency and json serialization

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -35,6 +35,7 @@ from unstructured_ingest.logger import logger
 from unstructured_ingest.processes.connector_registry import (
     SourceRegistryEntry,
 )
+from unstructured_ingest.utils.acl import compute_permissions_version
 from unstructured_ingest.utils.dep_check import requires_dependencies
 from unstructured_ingest.utils.html import HtmlMixin
 from unstructured_ingest.utils.string_and_date_utils import fix_unescaped_unicode
@@ -54,6 +55,192 @@ def _iso8601_to_epoch_str(iso_date: Optional[str]) -> Optional[str]:
     if iso_date is None:
         return None
     return str(parser.parse(iso_date).timestamp())
+
+
+def _parse_permissions(
+    doc_permissions: dict,
+    space_permissions: list,
+    max_num_metadata_permissions: int,
+) -> dict[str, dict]:
+    """
+    Parses document and space permissions to determine final user/group roles.
+
+    :param doc_permissions: dict containing document-level restrictions
+    - doc_permissions type in Confluence: ContentRestrictionArray
+    :param space_permissions: list of space-level permission assignments
+    - space_permissions type in Confluence: list of SpacePermissionAssignment
+    :return: dict with operation as keys and each maps to dict with "users" and "groups"
+
+    Get document permissions. If they exist, they will override space level permissions.
+    Otherwise, apply relevant space permissions (read, administer, delete)
+    """
+
+    # Separate flags to track if view or edit is restricted at the page level
+    page_view_restricted = bool(
+        doc_permissions.get("read", {}).get("restrictions", {}).get("user", {}).get("results")
+        or doc_permissions.get("read", {})
+        .get("restrictions", {})
+        .get("group", {})
+        .get("results")
+    )
+
+    page_edit_restricted = bool(
+        doc_permissions.get("update", {}).get("restrictions", {}).get("user", {}).get("results")
+        or doc_permissions.get("update", {})
+        .get("restrictions", {})
+        .get("group", {})
+        .get("results")
+    )
+
+    permissions_by_role = {
+        "read": {"users": set(), "groups": set()},
+        "update": {"users": set(), "groups": set()},
+        "delete": {"users": set(), "groups": set()},
+    }
+
+    total_permissions = 0
+
+    for action, permissions in doc_permissions.items():
+        restrictions_dict = permissions.get("restrictions", {})
+
+        for entity_type, entity_data in restrictions_dict.items():
+            for entity in entity_data.get("results"):
+                entity_id = entity["accountId"] if entity_type == "user" else entity["id"]
+                permissions_by_role[action][f"{entity_type}s"].add(entity_id)
+                total_permissions += 1
+                # edit permission implies view permission
+                if action == "update":
+                    permissions_by_role["read"][f"{entity_type}s"].add(entity_id)
+                    # total_permissions += 1
+                    # ^ omitting to not double count an entity.
+                    # may result in a higher total count than max_num_metadata_permissions
+
+    for space_perm in space_permissions:
+        if total_permissions < max_num_metadata_permissions:
+            space_operation = space_perm["operation"]["key"]
+            space_target_type = space_perm["operation"]["targetType"]
+            space_entity_id = space_perm["principal"]["id"]
+            space_entity_type = space_perm["principal"]["type"]
+
+            # Apply space-level view permissions if no page restrictions exist
+            if (
+                space_target_type == "space"
+                and space_operation == "read"
+                and not page_view_restricted
+            ):
+                permissions_by_role["read"][f"{space_entity_type}s"].add(space_entity_id)
+                total_permissions += 1
+
+            # Administer permission includes view + edit. Apply if not page restricted
+            elif space_target_type == "space" and space_operation == "administer":
+                if not page_view_restricted:
+                    permissions_by_role["read"][f"{space_entity_type}s"].add(space_entity_id)
+                    total_permissions += 1
+                    if not page_edit_restricted:
+                        permissions_by_role["update"][f"{space_entity_type}s"].add(space_entity_id)
+                        # total_permissions += 1
+                        # ^ omitting to not double count an entity.
+                        # may result in a higher total count than max_num_metadata_permissions
+
+            # Add the "delete page" space permissions if there are other page permissions
+            elif (
+                space_target_type == "page"
+                and space_operation == "delete"
+                and space_entity_id in permissions_by_role["read"][f"{space_entity_type}s"]
+            ):
+                permissions_by_role["delete"][f"{space_entity_type}s"].add(space_entity_id)
+                total_permissions += 1
+
+    # turn sets into sorted lists for consistency and json serialization
+    for role_dict in permissions_by_role.values():
+        for key in role_dict:
+            role_dict[key] = sorted(role_dict[key])
+
+    return permissions_by_role
+
+
+def _get_space_permissions(
+    connection_config: "ConfluenceConnectionConfig",
+    space_id: int,
+    cache: OrderedDict,
+    cache_max_size: int = 5,
+) -> Optional[List[dict]]:
+    """Fetch space-level permissions, LRU-cached in ``cache``.
+
+    Returns None when the fetch is unavailable this run (e.g. an API error) so
+    callers leave the ACL fields unset rather than fabricating an empty ACL.
+    """
+    if space_id in cache:
+        cache.move_to_end(space_id)  # mark recent use
+        logger.debug(f"Retrieved cached permissions for space {space_id}")
+        return cache[space_id]
+    with connection_config.get_client() as client:
+        try:
+            # TODO limit the total number of results being called.
+            # not yet implemented because this client call doesn't allow for filtering for
+            # certain operations, so adding a limit here would result in too little data.
+            space_permissions = []
+            space_permissions_result = client.get(f"/api/v2/spaces/{space_id}/permissions")
+            space_permissions.extend(space_permissions_result["results"])
+            if space_permissions_result["_links"].get("next"):  # pagination
+                while space_permissions_result.get("next"):
+                    space_permissions_result = client.get(space_permissions_result["next"])
+                    space_permissions.extend(space_permissions_result["results"])
+
+            if len(cache) >= cache_max_size:
+                cache.popitem(last=False)  # LRU/FIFO eviction
+            cache[space_id] = space_permissions
+
+            logger.debug(f"Retrieved permissions for space {space_id}")
+            return space_permissions
+        except Exception as e:
+            logger.debug(f"Could not retrieve permissions for space {space_id}: {e}")
+            return None
+
+
+def _get_doc_permissions_data(
+    connection_config: "ConfluenceConnectionConfig",
+    doc_id: str,
+    space_permissions: list,
+    max_num_metadata_permissions: int,
+) -> Optional[list[dict]]:
+    with connection_config.get_client() as client:
+        try:
+            doc_permissions = client.get_all_restrictions_for_content(content_id=doc_id)
+            parsed_permissions_dict = _parse_permissions(
+                doc_permissions, space_permissions, max_num_metadata_permissions
+            )
+            parsed_permissions_dict = [{k: v} for k, v in parsed_permissions_dict.items()]
+        except Exception as e:
+            # skip writing any permission metadata
+            logger.debug(f"Could not retrieve permissions for doc {doc_id}: {e}")
+            return None
+
+    logger.debug(f"normalized permissions generated: {parsed_permissions_dict}")
+    return parsed_permissions_dict
+
+
+def get_permissions_data(
+    connection_config: "ConfluenceConnectionConfig",
+    doc_id: str,
+    space_id: int,
+    cache: OrderedDict,
+    max_num_metadata_permissions: int,
+) -> Optional[list[dict]]:
+    """Resolve a document's effective permissions (space + page-level restrictions).
+
+    Returns None when permissions are unavailable this run (space fetch failed or the
+    per-doc fetch errored) so callers leave ``permissions_data``/``permissions_version``
+    unset and the orchestration skips the ACL comparison. Otherwise returns the
+    normalized permissions, which flow into both ``permissions_data`` and the
+    ``permissions_version`` digest.
+    """
+    space_perm = _get_space_permissions(connection_config, space_id, cache)
+    if not space_perm:
+        return None
+    return _get_doc_permissions_data(
+        connection_config, doc_id, space_perm, max_num_metadata_permissions
+    )
 
 
 class ConfluenceAccessConfig(AccessConfig):
@@ -167,6 +354,9 @@ class ConfluenceIndexerConfig(IndexerConfig):
         100, description="Maximum number of documents to fetch from each space"
     )
     spaces: Optional[List[str]] = Field(None, description="List of specific space keys to index")
+    max_num_metadata_permissions: int = Field(
+        250, description="Approximate maximum number of permissions included in metadata"
+    )
 
 
 @dataclass
@@ -174,6 +364,10 @@ class ConfluenceIndexer(Indexer):
     connection_config: ConfluenceConnectionConfig
     index_config: ConfluenceIndexerConfig
     connector_type: str = CONNECTOR_TYPE
+    # Space-level permissions are LRU-cached across the pages of a single index run
+    # (PLU-534): the ACL digest is computed here so an ACL-only change reprocesses
+    # under incremental.
+    _permissions_cache: OrderedDict = field(default_factory=OrderedDict)
 
     @staticmethod
     def _get_next_page_path(response: dict) -> Optional[str]:
@@ -385,6 +579,21 @@ class ConfluenceIndexer(Indexer):
                         ),
                     },
                 )
+                # ACL digest (PLU-534): resolve permissions at index so an ACL-only
+                # change reprocesses under incremental. None means the fetch was
+                # unavailable this run — leave the ACL fields unset so the orchestration
+                # skips the ACL compare (an empty-but-available ACL still yields a digest).
+                permissions_data = get_permissions_data(
+                    connection_config=self.connection_config,
+                    doc_id=doc_id,
+                    space_id=space_id,
+                    cache=self._permissions_cache,
+                    max_num_metadata_permissions=self.index_config.max_num_metadata_permissions,
+                )
+                if permissions_data is not None:
+                    metadata.permissions_data = permissions_data
+                    metadata.permissions_version = compute_permissions_version(permissions_data)
+
                 additional_metadata = {
                     "space_key": space_key,
                     "space_id": space_id,  # diff from record_locator space_id (which is space_key)
@@ -424,8 +633,11 @@ class ConfluenceIndexer(Indexer):
 
 
 class ConfluenceDownloaderConfig(HtmlMixin, DownloaderConfig):
+    # DEPRECATED (PLU-534): permissions are now resolved at index time, so this cap is
+    # read from ConfluenceIndexerConfig instead and this field is unused. Kept to avoid
+    # breaking existing serialized configs; remove once the FE moves it to the index step.
     max_num_metadata_permissions: int = Field(
-        250, description="Approximate maximum number of permissions included in metadata"
+        250, description="Deprecated; superseded by ConfluenceIndexerConfig.max_num_metadata_permissions",
     )
 
     @requires_dependencies(["bs4"])
@@ -451,8 +663,6 @@ class ConfluenceDownloader(Downloader):
     connection_config: ConfluenceConnectionConfig
     download_config: ConfluenceDownloaderConfig = field(default_factory=ConfluenceDownloaderConfig)
     connector_type: str = CONNECTOR_TYPE
-    _permissions_cache: dict = field(default_factory=OrderedDict)
-    _permissions_cache_max_size: int = 5
 
     def download_embedded_files(
         self, session, html: str, current_file_data: FileData
@@ -476,151 +686,6 @@ class ConfluenceDownloader(Downloader):
             html=html,
             session=session,
         )
-
-    def parse_permissions(self, doc_permissions: dict, space_permissions: list) -> dict[str, dict]:
-        """
-        Parses document and space permissions to determine final user/group roles.
-
-        :param doc_permissions: dict containing document-level restrictions
-        - doc_permissions type in Confluence: ContentRestrictionArray
-        :param space_permissions: list of space-level permission assignments
-        - space_permissions type in Confluence: list of SpacePermissionAssignment
-        :return: dict with operation as keys and each maps to dict with "users" and "groups"
-
-        Get document permissions. If they exist, they will override space level permissions.
-        Otherwise, apply relevant space permissions (read, administer, delete)
-        """
-
-        # Separate flags to track if view or edit is restricted at the page level
-        page_view_restricted = bool(
-            doc_permissions.get("read", {}).get("restrictions", {}).get("user", {}).get("results")
-            or doc_permissions.get("read", {})
-            .get("restrictions", {})
-            .get("group", {})
-            .get("results")
-        )
-
-        page_edit_restricted = bool(
-            doc_permissions.get("update", {}).get("restrictions", {}).get("user", {}).get("results")
-            or doc_permissions.get("update", {})
-            .get("restrictions", {})
-            .get("group", {})
-            .get("results")
-        )
-
-        permissions_by_role = {
-            "read": {"users": set(), "groups": set()},
-            "update": {"users": set(), "groups": set()},
-            "delete": {"users": set(), "groups": set()},
-        }
-
-        total_permissions = 0
-
-        for action, permissions in doc_permissions.items():
-            restrictions_dict = permissions.get("restrictions", {})
-
-            for entity_type, entity_data in restrictions_dict.items():
-                for entity in entity_data.get("results"):
-                    entity_id = entity["accountId"] if entity_type == "user" else entity["id"]
-                    permissions_by_role[action][f"{entity_type}s"].add(entity_id)
-                    total_permissions += 1
-                    # edit permission implies view permission
-                    if action == "update":
-                        permissions_by_role["read"][f"{entity_type}s"].add(entity_id)
-                        # total_permissions += 1
-                        # ^ omitting to not double count an entity.
-                        # may result in a higher total count than max_num_metadata_permissions
-
-        for space_perm in space_permissions:
-            if total_permissions < self.download_config.max_num_metadata_permissions:
-                space_operation = space_perm["operation"]["key"]
-                space_target_type = space_perm["operation"]["targetType"]
-                space_entity_id = space_perm["principal"]["id"]
-                space_entity_type = space_perm["principal"]["type"]
-
-                # Apply space-level view permissions if no page restrictions exist
-                if (
-                    space_target_type == "space"
-                    and space_operation == "read"
-                    and not page_view_restricted
-                ):
-                    permissions_by_role["read"][f"{space_entity_type}s"].add(space_entity_id)
-                    total_permissions += 1
-
-                # Administer permission includes view + edit. Apply if not page restricted
-                elif space_target_type == "space" and space_operation == "administer":
-                    if not page_view_restricted:
-                        permissions_by_role["read"][f"{space_entity_type}s"].add(space_entity_id)
-                        total_permissions += 1
-                        if not page_edit_restricted:
-                            permissions_by_role["update"][f"{space_entity_type}s"].add(
-                                space_entity_id
-                            )
-                            # total_permissions += 1
-                            # ^ omitting to not double count an entity.
-                            # may result in a higher total count than max_num_metadata_permissions
-
-                # Add the "delete page" space permissions if there are other page permissions
-                elif (
-                    space_target_type == "page"
-                    and space_operation == "delete"
-                    and space_entity_id in permissions_by_role["read"][f"{space_entity_type}s"]
-                ):
-                    permissions_by_role["delete"][f"{space_entity_type}s"].add(space_entity_id)
-                    total_permissions += 1
-
-        # turn sets into sorted lists for consistency and json serialization
-        for role_dict in permissions_by_role.values():
-            for key in role_dict:
-                role_dict[key] = sorted(role_dict[key])
-
-        return permissions_by_role
-
-    def _get_permissions_for_space(self, space_id: int) -> Optional[List[dict]]:
-        if space_id in self._permissions_cache:
-            self._permissions_cache.move_to_end(space_id)  # mark recent use
-            logger.debug(f"Retrieved cached permissions for space {space_id}")
-            return self._permissions_cache[space_id]
-        else:
-            with self.connection_config.get_client() as client:
-                try:
-                    # TODO limit the total number of results being called.
-                    # not yet implemented because this client call doesn't allow for filtering for
-                    # certain operations, so adding a limit here would result in too little data.
-                    space_permissions = []
-                    space_permissions_result = client.get(f"/api/v2/spaces/{space_id}/permissions")
-                    space_permissions.extend(space_permissions_result["results"])
-                    if space_permissions_result["_links"].get("next"):  # pagination
-                        while space_permissions_result.get("next"):
-                            space_permissions_result = client.get(space_permissions_result["next"])
-                            space_permissions.extend(space_permissions_result["results"])
-
-                    if len(self._permissions_cache) >= self._permissions_cache_max_size:
-                        self._permissions_cache.popitem(last=False)  # LRU/FIFO eviction
-                    self._permissions_cache[space_id] = space_permissions
-
-                    logger.debug(f"Retrieved permissions for space {space_id}")
-                    return space_permissions
-                except Exception as e:
-                    logger.debug(f"Could not retrieve permissions for space {space_id}: {e}")
-                    return None
-
-    def _parse_permissions_for_doc(
-        self, doc_id: str, space_permissions: list
-    ) -> Optional[list[dict]]:
-        with self.connection_config.get_client() as client:
-            try:
-                doc_permissions = client.get_all_restrictions_for_content(content_id=doc_id)
-                parsed_permissions_dict = self.parse_permissions(doc_permissions, space_permissions)
-                parsed_permissions_dict = [{k: v} for k, v in parsed_permissions_dict.items()]
-
-            except Exception as e:
-                # skip writing any permission metadata
-                logger.debug(f"Could not retrieve permissions for doc {doc_id}: {e}")
-                return None
-
-        logger.debug(f"normalized permissions generated: {parsed_permissions_dict}")
-        return parsed_permissions_dict
 
     def run(self, file_data: FileData, **kwargs) -> download_responses:
         from bs4 import BeautifulSoup
@@ -662,13 +727,8 @@ class ConfluenceDownloader(Downloader):
             soup = BeautifulSoup(content, "html.parser")
             f.write(soup.prettify())
 
-        # Get document permissions and update metadata
-        space_id = file_data.additional_metadata["space_id"]
-        space_perm = self._get_permissions_for_space(space_id)  # must be the id, NOT the space key
-        if space_perm:
-            combined_doc_permissions = self._parse_permissions_for_doc(doc_id, space_perm)
-            if combined_doc_permissions:
-                file_data.metadata.permissions_data = combined_doc_permissions
+        # permissions_data / permissions_version are resolved at index time (PLU-534)
+        # and carried on file_data, so the downloader no longer fetches permissions.
 
         # Update file_data with metadata
         file_data.metadata.date_created = _iso8601_to_epoch_str(page["createdAt"])

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -633,12 +633,11 @@ class ConfluenceIndexer(Indexer):
 
 
 class ConfluenceDownloaderConfig(HtmlMixin, DownloaderConfig):
-    # DEPRECATED (PLU-534): permissions are now resolved at index time, so this cap is
-    # read from ConfluenceIndexerConfig instead and this field is unused. Kept to avoid
-    # breaking existing serialized configs; remove once the FE moves it to the index step.
+    # Unused by the downloader since PLU-534 (permissions are resolved at index time),
+    # but kept identical to ConfluenceIndexerConfig.max_num_metadata_permissions so the
+    # shared CLI option stays consistent and existing serialized configs keep working.
     max_num_metadata_permissions: int = Field(
-        250,
-        description="Deprecated; use ConfluenceIndexerConfig.max_num_metadata_permissions",
+        250, description="Approximate maximum number of permissions included in metadata"
     )
 
     @requires_dependencies(["bs4"])

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -95,18 +95,12 @@ def _parse_permissions(
     # Separate flags to track if view or edit is restricted at the page level
     page_view_restricted = bool(
         doc_permissions.get("read", {}).get("restrictions", {}).get("user", {}).get("results")
-        or doc_permissions.get("read", {})
-        .get("restrictions", {})
-        .get("group", {})
-        .get("results")
+        or doc_permissions.get("read", {}).get("restrictions", {}).get("group", {}).get("results")
     )
 
     page_edit_restricted = bool(
         doc_permissions.get("update", {}).get("restrictions", {}).get("user", {}).get("results")
-        or doc_permissions.get("update", {})
-        .get("restrictions", {})
-        .get("group", {})
-        .get("results")
+        or doc_permissions.get("update", {}).get("restrictions", {}).get("group", {}).get("results")
     )
 
     permissions_by_role = {
@@ -186,6 +180,28 @@ def _parse_permissions(
     return permissions_by_role
 
 
+def _next_page_path(response: dict) -> Optional[str]:
+    """Return the relative path for a Confluence v2 ``_links.next`` cursor page, or None.
+
+    Strips the ``/wiki/`` context path and preserves the query so the result can be
+    passed straight back to ``client.get``. Shared by the space-permissions fetch and
+    the indexer's page listing so both paginate identically.
+    """
+    next_link = response.get("_links", {}).get("next")
+    if not next_link:
+        return None
+
+    parsed_next_link = urlparse(next_link)
+    next_path = parsed_next_link.path or next_link
+    if "/wiki/" in next_path:
+        next_path = next_path.split("/wiki/", maxsplit=1)[1]
+    else:
+        next_path = next_path.lstrip("/")
+    if parsed_next_link.query:
+        next_path = f"{next_path}?{parsed_next_link.query}"
+    return next_path
+
+
 def _get_space_permissions(
     connection_config: "ConfluenceConnectionConfig",
     space_id: int,
@@ -208,11 +224,12 @@ def _get_space_permissions(
             # certain operations, so adding a limit here would result in too little data.
             space_permissions = []
             space_permissions_result = client.get(f"/api/v2/spaces/{space_id}/permissions")
-            space_permissions.extend(space_permissions_result["results"])
-            if space_permissions_result["_links"].get("next"):  # pagination
-                while space_permissions_result.get("next"):
-                    space_permissions_result = client.get(space_permissions_result["next"])
-                    space_permissions.extend(space_permissions_result["results"])
+            space_permissions.extend(space_permissions_result.get("results", []))
+            next_path = _next_page_path(space_permissions_result)
+            while next_path:  # follow every _links.next cursor page
+                space_permissions_result = client.get(next_path)
+                space_permissions.extend(space_permissions_result.get("results", []))
+                next_path = _next_page_path(space_permissions_result)
 
             if len(cache) >= cache_max_size:
                 cache.popitem(last=False)  # LRU/FIFO eviction
@@ -263,7 +280,10 @@ def get_permissions_data(
     ``permissions_version`` digest.
     """
     space_perm = _get_space_permissions(connection_config, space_id, cache)
-    if not space_perm:
+    # None means the space fetch was unavailable this run -> leave ACL fields unset.
+    # An empty list is a valid state (no space-level grants) and must still resolve
+    # page-level restrictions and emit a digest, so guard on None, not falsiness.
+    if space_perm is None:
         return None
     return _get_doc_permissions_data(
         connection_config, doc_id, space_perm, max_num_metadata_permissions
@@ -398,19 +418,7 @@ class ConfluenceIndexer(Indexer):
 
     @staticmethod
     def _get_next_page_path(response: dict) -> Optional[str]:
-        next_link = response.get("_links", {}).get("next")
-        if not next_link:
-            return None
-
-        parsed_next_link = urlparse(next_link)
-        next_path = parsed_next_link.path or next_link
-        if "/wiki/" in next_path:
-            next_path = next_path.split("/wiki/", maxsplit=1)[1]
-        else:
-            next_path = next_path.lstrip("/")
-        if parsed_next_link.query:
-            next_path = f"{next_path}?{parsed_next_link.query}"
-        return next_path
+        return _next_page_path(response)
 
     def _paginate_v2_results(
         self,
@@ -581,6 +589,10 @@ class ConfluenceIndexer(Indexer):
     def run(self) -> Generator[FileData, None, None]:
         from time import time
 
+        # The space-permissions LRU cache is scoped to a single index run; clear it
+        # here so a reused indexer instance cannot serve a stale ACL from a prior run
+        # and emit an unchanged digest after permissions changed.
+        self._permissions_cache.clear()
         space_ids_and_keys = self._get_space_ids_and_keys()
         for space_key, space_id in space_ids_and_keys:
             doc_ids = self._get_docs_ids_within_one_space(space_id)

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -637,7 +637,8 @@ class ConfluenceDownloaderConfig(HtmlMixin, DownloaderConfig):
     # read from ConfluenceIndexerConfig instead and this field is unused. Kept to avoid
     # breaking existing serialized configs; remove once the FE moves it to the index step.
     max_num_metadata_permissions: int = Field(
-        250, description="Deprecated; superseded by ConfluenceIndexerConfig.max_num_metadata_permissions",
+        250,
+        description="Deprecated; use ConfluenceIndexerConfig.max_num_metadata_permissions",
     )
 
     @requires_dependencies(["bs4"])

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -224,12 +224,24 @@ def _get_space_permissions(
             # certain operations, so adding a limit here would result in too little data.
             space_permissions = []
             space_permissions_result = client.get(f"/api/v2/spaces/{space_id}/permissions")
-            space_permissions.extend(space_permissions_result.get("results", []))
-            next_path = _next_page_path(space_permissions_result)
-            while next_path:  # follow every _links.next cursor page
-                space_permissions_result = client.get(next_path)
-                space_permissions.extend(space_permissions_result.get("results", []))
+            page_results = space_permissions_result.get("results")
+            while True:  # follow every _links.next cursor page
+                if not isinstance(page_results, list):
+                    # A 200 whose body omits `results` is a failure masquerading as
+                    # success. Treat the whole fetch as unavailable (return None, not
+                    # cached) rather than fabricating an empty ACL, which the indexer
+                    # would emit as a digest and record as a permission revocation.
+                    logger.warning(
+                        f"Malformed space-permissions response for space {space_id}; "
+                        "treating permissions as unavailable this run"
+                    )
+                    return None
+                space_permissions.extend(page_results)
                 next_path = _next_page_path(space_permissions_result)
+                if not next_path:
+                    break
+                space_permissions_result = client.get(next_path)
+                page_results = space_permissions_result.get("results")
 
             if len(cache) >= cache_max_size:
                 cache.popitem(last=False)  # LRU/FIFO eviction

--- a/unstructured_ingest/processes/connectors/confluence.py
+++ b/unstructured_ingest/processes/connectors/confluence.py
@@ -263,6 +263,18 @@ def _get_doc_permissions_data(
     with connection_config.get_client() as client:
         try:
             doc_permissions = client.get_all_restrictions_for_content(content_id=doc_id)
+            # The byOperation restrictions endpoint always returns the operation keys
+            # (read/update) for a real page, even when unrestricted. A non-dict or empty
+            # response is a failure masquerading as success; treat it as unavailable
+            # (None) rather than parsing it into a fabricated "unrestricted" ACL, which
+            # would emit a digest and could read as a permission change. Mirrors the
+            # malformed-response guard in _get_space_permissions.
+            if not isinstance(doc_permissions, dict) or not doc_permissions:
+                logger.warning(
+                    f"Malformed content-restrictions response for doc {doc_id}; "
+                    "treating permissions as unavailable this run"
+                )
+                return None
             parsed_permissions_dict = _parse_permissions(
                 doc_permissions, space_permissions, max_num_metadata_permissions
             )


### PR DESCRIPTION
## What
Confluence was in no incremental allowlist, so it reprocessed everything every run. This enables incremental for Confluence (index-emitting) **and**, in the same pass, emits the per-file ACL digest so an ACL-only change (page restriction / space permission) reprocesses under incremental (`reprocess_all=false`, `reprocess_on_permission_change=true`).

Linear: [PLU-534](https://linear.app/unstructured/issue/PLU-534). Reference impl: SharePoint (PLU-531, shipped + validated E2E on staging). Prior spike: FS-1037.

## Approach — index-emitting
- The indexer already emits `metadata.version` (page `version.number`) from the v2 `/pages` list, so content-incremental was mostly a registration gap.
- Permissions are index-fetchable (space perms + per-doc restrictions need only `space_id` + `doc_id`, both available at index), so both the content version and the ACL digest are emitted at index and the skip decision uses both. This keeps the download-skip for unchanged pages (vs. download-emitting, which would fetch every page every run).

## Changes
- Extracted the permission fetch/parse into **module-level functions** (were `ConfluenceDownloader` methods) so the indexer can call them — single implementation, no duplication.
- `ConfluenceIndexer` resolves permissions per page and sets `metadata.permissions_data` + `metadata.permissions_version = compute_permissions_version(...)`, honoring the **None-vs-`[]` contract** (fetch unavailable → leave unset so orchestration skips the ACL compare; empty → real digest).
- Removed the now-redundant download-time permission fetch (FileData carries `permissions_data` from index).
- Deprecated `ConfluenceDownloaderConfig.max_num_metadata_permissions` (cap moved to `ConfluenceIndexerConfig`); kept in place to avoid breaking serialized configs — FE move is a follow-up.

## Tests
`test/unit/connectors/test_confluence.py` — module-fn None / populated / **order-independence** (determinism); indexer emits vs. omits the digest; fixed the existing downloader test (no longer fetches perms). 26 pass locally.

## Companion PR
platform-etl-orchestration registers Confluence as index-emitting: _petl PR link added below._

## Validation gate (not done yet)
SND E2E is required before merge (per the ticket's 7-step section): baseline → no-change rerun (0 files) → content edit (1 file) → **ACL-only change with content unchanged reprocesses** (page-restriction + space-permission, each) → flag-off does not → perf probe on a large space. Image build kicked off separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

