### PR TITLE
fix(ibm-watsonx-s3): write Iceberg data files through FsspecFileIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+- **fix(ibm-watsonx-s3): write Iceberg data files through FsspecFileIO.** PyIceberg defaults `s3://` to `PyArrowFileIO` whenever pyarrow is installed. That initializes pyarrow's AWS C++ S3 client, whose vendored s2n process-aborts under FIPS libcrypto (`s2n_init() failed: FIPS mode is not supported for the libcrypto`) instead of failing the job. Catalog config now sets `py-io-impl` to `pyiceberg.io.fsspec.FsspecFileIO` so COS writes use s3fs/botocore (the same stack as the S3 destination). Adds `s3fs` to the `ibm-watsonx-s3` extra.
+
 - **fix: map Vertex AI `ResourceExhausted` to `QuotaError`.** `VertexAIEmbeddingConfig.wrap_error` only wrapped Google auth errors, so a quota/rate-exhaustion (`google.api_core.exceptions.ResourceExhausted`, HTTP 429) surfaced raw. Combined with the transient-skip test guard added below, that would have caused a quota exhaustion to be treated as a transient blip and skipped rather than failing. Vertex now maps `ResourceExhausted` to `QuotaError` (a user error), mirroring how OpenAI/OctoAI map `insufficient_quota`, so it fails loudly.
 
 ### Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## [1.11.2]
+## [1.11.3]
 
 ### Fixes
 
 - **fix(ibm-watsonx-s3): write Iceberg data files through FsspecFileIO.** PyIceberg defaults `s3://` to `PyArrowFileIO` whenever pyarrow is installed. That initializes pyarrow's AWS C++ S3 client, whose vendored s2n process-aborts under FIPS libcrypto (`s2n_init() failed: FIPS mode is not supported for the libcrypto`) instead of failing the job. Catalog config now sets `py-io-impl` to `pyiceberg.io.fsspec.FsspecFileIO` so COS writes use s3fs/botocore (the same stack as the S3 destination). Adds `s3fs` to the `ibm-watsonx-s3` extra.
+
+## [1.11.2]
+
+### Fixes
 
 - **fix: map Vertex AI `ResourceExhausted` to `QuotaError`.** `VertexAIEmbeddingConfig.wrap_error` only wrapped Google auth errors, so a quota/rate-exhaustion (`google.api_core.exceptions.ResourceExhausted`, HTTP 429) surfaced raw. Combined with the transient-skip test guard added below, that would have caused a quota exhaustion to be treated as a transient blip and skipped rather than failing. Vertex now maps `ResourceExhausted` to `QuotaError` (a user error), mirroring how OpenAI/OctoAI map `insufficient_quota`, so it fails loudly.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ github = ["pygithub>1.58.0", "requests", "tenacity"]
 gitlab = ["python-gitlab"]
 google-drive = ["google-api-python-client", "tenacity"]
 hubspot = ["hubspot-api-client", "urllib3"]
-ibm-watsonx-s3 = ["pyiceberg", "httpx", "pyarrow", "tenacity", "pandas"]
+ibm-watsonx-s3 = ["pyiceberg", "httpx", "pyarrow", "tenacity", "pandas", "s3fs"]
 jira = ["atlassian-python-api"]
 kafka = ["confluent-kafka"]
 kdbai = ["pandas", "kdbai-client>=1.4.0"]
@@ -161,6 +161,7 @@ test = [
     "google-genai",
     "pyiceberg",
     "pyarrow",
+    "s3fs",
     "networkx",
     "htmlBuilder",
     "office365-rest-python-client",

--- a/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
+++ b/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -18,6 +19,7 @@ from unstructured_ingest.error import (
 )
 from unstructured_ingest.processes.connectors.ibm_watsonx import IBM_WATSONX_S3_CONNECTOR_TYPE
 from unstructured_ingest.processes.connectors.ibm_watsonx.ibm_watsonx_s3 import (
+    DEFAULT_PY_IO_IMPL,
     IbmWatsonxAccessConfig,
     IbmWatsonxConnectionConfig,
     IbmWatsonxUploader,
@@ -213,6 +215,7 @@ def test_ibm_watsonx_connection_config_get_catalog_config_no_account_id(
     mocker.patch.object(IbmWatsonxConnectionConfig, "bearer_token", new="test_bearer_token")
     config = connection_config.get_catalog_config()
     assert "header.AccountId" not in config
+    assert config["py-io-impl"] == DEFAULT_PY_IO_IMPL
 
 
 def test_ibm_watsonx_connection_config_get_catalog_config_account_scoped(
@@ -224,6 +227,7 @@ def test_ibm_watsonx_connection_config_get_catalog_config_account_scoped(
     config = account_scoped_connection_config.get_catalog_config()
     assert config["header.AccountId"] == "test_account_id"
     assert config["uri"] == "https://test_iceberg_endpoint/api/v1/iceberg"
+    assert config["py-io-impl"] == DEFAULT_PY_IO_IMPL
 
 
 def test_ibm_watsonx_connection_config_object_storage_url(
@@ -323,8 +327,31 @@ def test_ibm_watsonx_connection_config_get_catalog_success(
             "s3.secret-access-key": "test_secret_access_key",
             "s3.region": "test_region",
             "header.X-Iceberg-Access-Delegation": None,
+            "py-io-impl": DEFAULT_PY_IO_IMPL,
         }
     )
+
+
+def test_catalog_config_constructs_fsspec_file_io_backed_by_s3fs(
+    mocker: MockerFixture, connection_config: IbmWatsonxConnectionConfig
+):
+    # Setting py-io-impl is not enough: PyIceberg still prefers PyArrowFileIO for s3://
+    # unless that property actually constructs FsspecFileIO. Construct FileIO the same
+    # way the catalog does and assert the s3 scheme is s3fs, not pyarrow.
+    from pyiceberg.io import load_file_io
+    from pyiceberg.io.fsspec import FsspecFileIO
+    from s3fs import S3FileSystem
+
+    mocker.patch.object(IbmWatsonxConnectionConfig, "bearer_token", new="test_bearer_token")
+    config = connection_config.get_catalog_config()
+    file_io = load_file_io(properties=config, location="s3://test-bucket/warehouse")
+
+    assert isinstance(file_io, FsspecFileIO)
+    assert type(file_io).__module__ == "pyiceberg.io.fsspec"
+    s3_fs = file_io.get_fs("s3")
+    assert isinstance(s3_fs, S3FileSystem)
+    assert type(s3_fs).__module__.startswith("s3fs")
+    assert "pyarrow" not in type(s3_fs).__module__
 
 
 def test_ibm_watsonx_connection_config_get_catalog_account_scoped_success(
@@ -353,6 +380,7 @@ def test_ibm_watsonx_connection_config_get_catalog_account_scoped_success(
             "s3.region": "test_region",
             "header.X-Iceberg-Access-Delegation": None,
             "header.AccountId": "test_account_id",
+            "py-io-impl": DEFAULT_PY_IO_IMPL,
         }
     )
 
@@ -853,9 +881,7 @@ def test_ibm_watsonx_upload_data_table_commit_failed_redacts_secret(
             max_retries=2,
         ),
     )
-    mock_transaction.append.side_effect = CommitFailedException(
-        f"commit conflict token={_SECRET}"
-    )
+    mock_transaction.append.side_effect = CommitFailedException(f"commit conflict token={_SECRET}")
 
     with pytest.raises(ProviderError) as excinfo:
         fast_uploader.upload_data_table(mock_table, mock_data_table, file_data)

--- a/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
+++ b/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from pathlib import Path
 from unittest.mock import MagicMock

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.2"  # pragma: no cover
+__version__ = "1.11.3"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
+++ b/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
@@ -49,6 +49,11 @@ DEFAULT_ICEBERG_URI_PATH = "/mds/iceberg"
 # instance-scoped /mds/iceberg path in favor of this one.
 ACCOUNT_SCOPED_ICEBERG_URI_PATH = "/api/v1/iceberg"
 DEFAULT_ICEBERG_CATALOG_TYPE = "rest"
+# PyIceberg prefers PyArrowFileIO for s3:// whenever pyarrow is installed.
+# PyArrow's AWS C++ S3 client then runs s2n_init(), which process-aborts under
+# FIPS libcrypto (not a catchable exception). FsspecFileIO uses s3fs/botocore,
+# the same stack as the S3 destination.
+DEFAULT_PY_IO_IMPL = "pyiceberg.io.fsspec.FsspecFileIO"
 
 
 class IbmWatsonxAccessConfig(AccessConfig):
@@ -173,6 +178,7 @@ class IbmWatsonxConnectionConfig(ConnectionConfig):
             # configuration doesn't allow vending credentials. We need to set it to `None`
             # in order to use user-provided S3 credentials.
             "header.X-Iceberg-Access-Delegation": None,
+            "py-io-impl": DEFAULT_PY_IO_IMPL,
         }
         # Account-scoped (SaaS) MDS requires the account ID as a request header.
         # It must be the `AccountId` header; the query-parameter form is rejected.
@@ -180,7 +186,7 @@ class IbmWatsonxConnectionConfig(ConnectionConfig):
             config["header.AccountId"] = self.account_id
         return config
 
-    @requires_dependencies(["pyiceberg"], extras="ibm-watsonx-s3")
+    @requires_dependencies(["pyiceberg", "s3fs"], extras="ibm-watsonx-s3")
     @contextmanager
     def get_catalog(
         self, max_retries: Optional[int] = None

--- a/uv.lock
+++ b/uv.lock
@@ -7149,6 +7149,7 @@ ibm-watsonx-s3 = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pyiceberg" },
+    { name = "s3fs" },
     { name = "tenacity" },
 ]
 image = [
@@ -7362,6 +7363,7 @@ test = [
     { name = "pytest-tagging" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "s3fs" },
     { name = "slack-sdk", extra = ["optional"] },
     { name = "universal-pathlib" },
     { name = "vertexai" },
@@ -7471,6 +7473,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'onedrive'" },
     { name = "requests", marker = "extra == 'sharepoint'" },
     { name = "requests", marker = "extra == 'vectara'" },
+    { name = "s3fs", marker = "extra == 'ibm-watsonx-s3'" },
     { name = "s3fs", marker = "extra == 's3'" },
     { name = "sentence-transformers", marker = "extra == 'huggingface'" },
     { name = "simple-salesforce", marker = "extra == 'salesforce'" },
@@ -7546,6 +7549,7 @@ test = [
     { name = "pytest-tagging" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "s3fs" },
     { name = "slack-sdk", extras = ["optional"] },
     { name = "universal-pathlib" },
     { name = "vertexai" },


### PR DESCRIPTION
## Summary
- Pin Iceberg catalog `py-io-impl` to `pyiceberg.io.fsspec.FsspecFileIO` so COS writes go through s3fs/botocore instead of pyarrow’s S3 client.
- PyArrowFileIO initializes vendored s2n, which process-aborts under Chainguard FIPS libcrypto (`s2n_init`). This is the blocker for moving the uploader image to `python-fips`.
- Iceberg REST, delete-then-append by `record_id`, and `pa.Table.from_pandas` are unchanged. Adds `s3fs` to the `ibm-watsonx-s3` extra.

## Test plan
- [x] Unit: `test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py` (catalog config + `load_file_io` returns FsspecFileIO backed by s3fs)
- [x] Live Mac pipeline against `iceberg_data.e2e_test_schema.e2e_test_table`
- [x] FIPS env (`cgr.dev/unstructured.io/python-fips:3.12-dev`, linux/amd64): pyarrow `S3FileSystem()` still SIGABRT; FsspecFileIO + live `uploader.run` (and re-run) exit 0


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

