### PR TITLE
fix(test): exclude permissions_version from fixture comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.4]
+
+### Fixes
+
+- **fix(test): exclude `permissions_version` from fixture comparison.** PLU-511 added `permissions_version: Optional[str] = None` to `FileDataSourceMetadata`. Pydantic serializes `None` fields by default, so every connector's JSON output gained the key even when no ACL digest was computed, causing all ~221 snapshot fixtures to fail with `dictionary_item_added: permissions_version`. Rather than patching fixture files (which would break again on the next optional field), `permissions_version` is now excluded in both comparison utilities — `SourceValidationConfigs.exclude_fields` (connector integration tests) and `omit_ignored_fields` in `test_e2e/check-diff-expected-output.py` (E2E tests) — following the same pattern as `local_download_path` and `metadata.date_processed`. Hash-computation correctness is covered by the existing unit tests in `test/unit/utils/test_acl.py` and `test/unit/connectors/test_onedrive.py`.
+
 ## [1.11.3]
 
 ### Fixes

--- a/test/integration/connectors/utils/validation/source.py
+++ b/test/integration/connectors/utils/validation/source.py
@@ -85,7 +85,11 @@ class SourceValidationConfigs(ValidationConfig):
     predownload_file_data_check: Optional[FILEDATA_CHECKS_TYPE] = None
     postdownload_file_data_check: Optional[FILEDATA_CHECKS_TYPE] = None
     exclude_fields: list[str] = Field(
-        default_factory=lambda: ["local_download_path", "metadata.date_processed"]
+        default_factory=lambda: [
+            "local_download_path",
+            "metadata.date_processed",
+            "metadata.permissions_version",
+        ]
     )
     exclude_fields_extend: list[str] = Field(default_factory=list)
     fixture_scrubbers: list[FixtureScrubber] = Field(

--- a/test_e2e/check-diff-expected-output.py
+++ b/test_e2e/check-diff-expected-output.py
@@ -79,6 +79,10 @@ def omit_ignored_fields(data: dict) -> None:
     if metadata := data.get("metadata"):
         metadata.pop("text_as_html", None)
         metadata.pop("languages", None)
+        if data_source := metadata.get("data_source"):
+            # Connector-specific optional field; null value carries no information
+            # for connectors that don't compute ACL digests.
+            data_source.pop("permissions_version", None)
 
 
 def compare_files(expected_file: Path, current_file: Path) -> list[DeepDiff]:

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.3"  # pragma: no cover
+__version__ = "1.11.4"  # pragma: no cover


### PR DESCRIPTION
## What

Excludes `permissions_version` from the fixture comparison utilities so the all-green test suite is restored after PLU-511 (`cbd0fbd7`).

## Root cause

`permissions_version: Optional[str] = None` was added to `FileDataSourceMetadata` by PLU-511. Because Pydantic serializes `None` fields by default, every connector's serialized output now includes `"permissions_version": null` — even connectors that never compute an ACL digest. The ~221 integration and E2E fixture files were generated before this field existed, so `deepdiff` flags it as `dictionary_item_added` and every snapshot comparison fails.

## Fix

Added `permissions_version` to the exclusion lists in both comparison utilities:

- **`test/integration/connectors/utils/validation/source.py`** — added `"metadata.permissions_version"` to the default `exclude_fields` in `SourceValidationConfigs`. This is the same pattern already used for `local_download_path` and `metadata.date_processed`.
- **`test_e2e/check-diff-expected-output.py`** — added `data_source.pop("permissions_version", None)` to `omit_ignored_fields`, which normalises element-level metadata before comparison.

**Why not update the ~221 fixture files?** That would fix today's failures but not tomorrow's — the next optional field added to `FileDataSourceMetadata` would break the whole suite again. The exclusion approach is forward-compatible.

**Why not `model_config = ConfigDict(exclude_none=True)` on the model?** The existing fixtures already contain `"permissions_data": null` (the sibling field). Globally suppressing nulls from serialization would flip that mismatch direction and still require a bulk fixture rewrite.

**Coverage for the field itself** is not lost: `test/unit/utils/test_acl.py` and `test/unit/connectors/test_onedrive.py` validate hash determinism, order-independence, and empty-vs-None semantics directly.

## Jobs fixed

All six failing CI job types had the same root cause:
- `src_e2e_test`
- `sql_connectors_int_test`
- `blob_storage_connectors_int_test`
- `vector_db_connectors_int_test`
- `nosql_connectors_int_test`
- `uncategorized_connectors_int_test`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

