### PR TITLE
fix(test): exclude drive_id/item_id from SharePoint fixture comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.5]
+
+### Fixes
+
+- **fix(test): exclude `drive_id`/`item_id` from SharePoint fixture comparison.** PLU-504 added `drive_id` and `item_id` to the SharePoint `record_locator` for Teams file download support. These are Graph API IDs that are environment-specific and can't be baked into static fixtures, breaking 6 SharePoint source integration tests. Both fields are now added to `SHAREPOINT_SOURCE_EXCLUDE_FIELDS` in `test/integration/connectors/test_sharepoint.py`.
+
 ## [1.11.4]
 
 ### Fixes

--- a/test/integration/connectors/test_sharepoint.py
+++ b/test/integration/connectors/test_sharepoint.py
@@ -39,6 +39,11 @@ SHAREPOINT_SOURCE_EXCLUDE_FIELDS = [
     "additional_metadata.@microsoft.graph.downloadUrl",
     # live tenant ACL snapshot (object ids); drifts when site sharing changes
     "metadata.permissions_data",
+    # drive_id + item_id are Graph API IDs that are environment-specific;
+    # added by PLU-504 (SharePoint Teams file download) and absent from
+    # fixtures that predate that change
+    "metadata.record_locator.drive_id",
+    "metadata.record_locator.item_id",
 ]
 
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.4"  # pragma: no cover
+__version__ = "1.11.5"  # pragma: no cover


### PR DESCRIPTION
## What

Adds `metadata.record_locator.drive_id` and `metadata.record_locator.item_id` to `SHAREPOINT_SOURCE_EXCLUDE_FIELDS`, fixing 6 SharePoint source tests that fail with:

```
"dictionary_item_added": [
    "root['metadata']['record_locator']['drive_id']",
    "root['metadata']['record_locator']['item_id']"
]
```

## Why

PLU-504 (`dd22986d` — SharePoint Teams file download) started populating `drive_id` and `item_id` on the `record_locator` so the downloader can fetch files via `client.drives[drive_id].items[item_id]` regardless of which site they live on. Fixture files predating that change lack these keys.

Exclusion is correct here (not fixture regeneration) because Graph API drive/item IDs are environment-specific — they vary by tenant and would need re-committing on every fixture refresh. Same pattern as the existing `permissions_data` and `downloadUrl` exclusions in this list.

## Test

6 tests unblocked:
- `test_sharepoint_source`
- `test_sharepoint_source_with_path`
- `test_sharepoint_root_with_path`
- `test_sharepoint_shared_documents`
- `test_sharepoint_library`
- `test_sharepoint_library_with_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

