### PR TITLE
fix(PLU-543): update Milvus precheck test to expect UserError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.6]
+
+### Fixes
+
+- **fix(test): expect `UserError` in `test_precheck_fails_on_nonexistent_collection`.** PLU-543 reclassified a missing Milvus collection from `DestinationConnectionError` to `UserError` (a customer configuration problem, not a connection fault). `UserError` and `DestinationConnectionError` are sibling exception types, not parent/child, so the test's `pytest.raises(DestinationConnectionError, ...)` stopped catching the raised exception. Updated the test to expect `UserError` and match the actual message text (`"Milvus collection '{name}' does not exist"`).
+
 ## [1.11.5]
 
 ### Fixes

--- a/test/integration/connectors/test_milvus.py
+++ b/test/integration/connectors/test_milvus.py
@@ -27,7 +27,7 @@ from test.integration.connectors.utils.validation.destination import (
     stager_validation,
 )
 from unstructured_ingest.data_types.file_data import FileData, SourceIdentifiers
-from unstructured_ingest.error import DestinationConnectionError
+from unstructured_ingest.error import DestinationConnectionError, UserError
 from unstructured_ingest.processes.connectors.milvus import (
     CONNECTOR_TYPE,
     MilvusConnectionConfig,
@@ -524,8 +524,8 @@ def test_precheck_fails_on_nonexistent_collection(collection: str):
         ),
     )
     with pytest.raises(
-        DestinationConnectionError,
-        match=f"Collection '{NONEXISTENT_COLLECTION_NAME}' does not exist",
+        UserError,
+        match=f"Milvus collection '{NONEXISTENT_COLLECTION_NAME}' does not exist",
     ):
         uploader.precheck()
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.5"  # pragma: no cover
+__version__ = "1.11.6"  # pragma: no cover


### PR DESCRIPTION
## Summary
- PLU-543 reclassified a missing Milvus collection from `DestinationConnectionError` to `UserError` (correctly — it's a customer config issue, not a connection fault), but `test_precheck_fails_on_nonexistent_collection` still asserted the old exception type and message text, so it fails even though `precheck()` correctly raises an error.
- Updates the test to expect `UserError` and match the actual message (`"Milvus collection '{name}' does not exist"`).
- Version bump to 1.11.6 and CHANGELOG entry.

## Test plan
- [ ] CI passes for `test_precheck_fails_on_nonexistent_collection`
- [ ] Other Milvus precheck tests (`test_precheck_succeeds`, `test_precheck_fails_on_nonexisting_db`) remain green — unaffected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

