### PR TITLE
fix(ibm-watsonx-s3): retry COS IncompleteBody and RequestTimeTooSkewed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.6]
+
+### Fixes
+
+- **fix(ibm-watsonx-s3): retry COS IncompleteBody and RequestTimeTooSkewed during Iceberg upload.** s3fs maps those COS/S3 errors to `OSError`/`PermissionError` and then refuses to retry them. The uploader was wrapping them as `ProviderError`, turning a transient COS flake into a hard job failure. Both are now classified as retryable (without treating every `EINVAL` or `AccessDenied` as retryable), re-raised out of `upload_data_table` so `upload_dataframe`'s retry loop can start a fresh Iceberg transaction, and surfaced as `DestinationConnectionError` if retries are exhausted. The Iceberg transaction has not committed when these fire, so retrying delete+append is safe.
+
 ## [1.11.5]
 
 ### Fixes

--- a/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
+++ b/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
@@ -682,6 +682,33 @@ def test_is_retryable_cos_incomplete_body_walks_cause_chain():
     assert is_retryable_cos_incomplete_body(outer) is True
 
 
+def test_is_retryable_cos_incomplete_body_walks_cause_to_boto_code():
+    # s3fs translate_boto_error(set_cause=True): generic EINVAL outer, ClientError on __cause__.
+    inner = Exception("client")
+    inner.response = {"Error": {"Code": "IncompleteBody"}}  # type: ignore[attr-defined]
+    outer = OSError(22, "Invalid argument")
+    outer.__cause__ = inner
+    assert is_retryable_cos_incomplete_body(outer) is True
+    assert is_retryable_cos_io_error(outer) is True
+
+
+def test_is_retryable_cos_incomplete_body_walks_context_chain():
+    inner = Exception("client")
+    inner.response = {"Error": {"Code": "IncompleteBody"}}  # type: ignore[attr-defined]
+    outer = OSError(22, "Invalid argument")
+    outer.__context__ = inner
+    assert is_retryable_cos_incomplete_body(outer) is True
+
+
+def test_is_retryable_cos_incomplete_body_rejects_invalid_argument_boto_code():
+    inner = Exception("client")
+    inner.response = {"Error": {"Code": "InvalidArgument"}}  # type: ignore[attr-defined]
+    outer = OSError(22, "Invalid argument")
+    outer.__cause__ = inner
+    assert is_retryable_cos_incomplete_body(outer) is False
+    assert is_retryable_cos_io_error(outer) is False
+
+
 def test_ibm_watsonx_uploader_upload_dataframe_retries_incomplete_body(
     mocker: MockerFixture,
     uploader: IbmWatsonxUploader,
@@ -777,14 +804,30 @@ def test_is_retryable_cos_request_time_too_skewed_matches_boto_code():
 
 
 def test_is_retryable_cos_request_time_too_skewed_walks_cause_chain():
+    # Outer message is generic so only the ClientError on __cause__ can match.
     inner = Exception("client")
     inner.response = {"Error": {"Code": "RequestTimeTooSkewed"}}  # type: ignore[attr-defined]
-    outer = PermissionError(
-        "The difference between the request time and the server's time is too large."
-    )
+    outer = PermissionError("translated")
     outer.__cause__ = inner
     assert is_retryable_cos_request_time_too_skewed(outer) is True
     assert is_retryable_cos_io_error(outer) is True
+
+
+def test_is_retryable_cos_request_time_too_skewed_walks_context_chain():
+    inner = Exception("client")
+    inner.response = {"Error": {"Code": "RequestTimeTooSkewed"}}  # type: ignore[attr-defined]
+    outer = PermissionError("translated")
+    outer.__context__ = inner
+    assert is_retryable_cos_request_time_too_skewed(outer) is True
+
+
+def test_is_retryable_cos_request_time_too_skewed_rejects_access_denied_boto_code():
+    inner = Exception("client")
+    inner.response = {"Error": {"Code": "AccessDenied"}}  # type: ignore[attr-defined]
+    outer = PermissionError("Access Denied")
+    outer.__cause__ = inner
+    assert is_retryable_cos_request_time_too_skewed(outer) is False
+    assert is_retryable_cos_io_error(outer) is False
 
 
 def test_ibm_watsonx_uploader_upload_dataframe_retries_request_time_too_skewed(
@@ -805,6 +848,28 @@ def test_ibm_watsonx_uploader_upload_dataframe_retries_request_time_too_skewed(
 
     uploader.upload_dataframe(test_df, file_data)
 
+    assert mock_get_table.call_count == 2
+    assert mock_upload_data_table.call_count == 2
+
+
+def test_ibm_watsonx_uploader_upload_dataframe_request_time_too_skewed_exhausted(
+    mocker: MockerFixture,
+    uploader: IbmWatsonxUploader,
+    test_df: pd.DataFrame,
+    mock_get_table: MagicMock,
+    mock_data_table: MagicMock,
+    file_data: FileData,
+):
+    err = PermissionError(
+        "The difference between the request time and the server's time is too large."
+    )
+    mocker.patch.object(IbmWatsonxUploader, "_df_to_arrow_table", return_value=mock_data_table)
+    mock_upload_data_table = mocker.patch.object(
+        IbmWatsonxUploader, "upload_data_table", side_effect=err
+    )
+
+    with pytest.raises(DestinationConnectionError):
+        uploader.upload_dataframe(test_df, file_data)
     assert mock_get_table.call_count == 2
     assert mock_upload_data_table.call_count == 2
 

--- a/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
+++ b/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
@@ -669,6 +669,25 @@ def test_is_retryable_cos_incomplete_body_rejects_other_einval():
     assert is_retryable_cos_incomplete_body(ValueError("nope")) is False
 
 
+def test_is_retryable_cos_incomplete_body_rejects_non_oserror_message():
+    assert (
+        is_retryable_cos_incomplete_body(RuntimeError("The request body terminated unexpectedly"))
+        is False
+    )
+    assert is_retryable_cos_incomplete_body(ValueError("incompletebody")) is False
+
+
+def test_is_retryable_cos_incomplete_body_rejects_oserror_wrong_errno():
+    assert (
+        is_retryable_cos_incomplete_body(OSError(5, "The request body terminated unexpectedly"))
+        is False
+    )
+    assert (
+        is_retryable_cos_incomplete_body(OSError("The request body terminated unexpectedly"))
+        is False
+    )
+
+
 def test_is_retryable_cos_incomplete_body_matches_boto_code():
     err = Exception("client")
     err.response = {"Error": {"Code": "IncompleteBody"}}  # type: ignore[attr-defined]

--- a/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
+++ b/test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py
@@ -23,6 +23,9 @@ from unstructured_ingest.processes.connectors.ibm_watsonx.ibm_watsonx_s3 import 
     IbmWatsonxConnectionConfig,
     IbmWatsonxUploader,
     IbmWatsonxUploaderConfig,
+    is_retryable_cos_incomplete_body,
+    is_retryable_cos_io_error,
+    is_retryable_cos_request_time_too_skewed,
 )
 
 
@@ -653,6 +656,194 @@ def test_ibm_watsonx_uploader_upload_dataframe_exception(
         uploader.upload_dataframe(test_df, file_data)
     mock_get_table.assert_called_once()
     mock_upload_data_table.assert_called_once()
+
+
+def test_is_retryable_cos_incomplete_body_matches_s3fs_oserror():
+    err = OSError(22, "The request body terminated unexpectedly")
+    assert is_retryable_cos_incomplete_body(err) is True
+
+
+def test_is_retryable_cos_incomplete_body_rejects_other_einval():
+    assert is_retryable_cos_incomplete_body(OSError(22, "Invalid argument")) is False
+    assert is_retryable_cos_incomplete_body(OSError(22, "InvalidArgument")) is False
+    assert is_retryable_cos_incomplete_body(ValueError("nope")) is False
+
+
+def test_is_retryable_cos_incomplete_body_matches_boto_code():
+    err = Exception("client")
+    err.response = {"Error": {"Code": "IncompleteBody"}}  # type: ignore[attr-defined]
+    assert is_retryable_cos_incomplete_body(err) is True
+
+
+def test_is_retryable_cos_incomplete_body_walks_cause_chain():
+    inner = OSError(22, "The request body terminated unexpectedly")
+    outer = RuntimeError("wrapped")
+    outer.__cause__ = inner
+    assert is_retryable_cos_incomplete_body(outer) is True
+
+
+def test_ibm_watsonx_uploader_upload_dataframe_retries_incomplete_body(
+    mocker: MockerFixture,
+    uploader: IbmWatsonxUploader,
+    test_df: pd.DataFrame,
+    mock_get_table: MagicMock,
+    mock_data_table: MagicMock,
+    file_data: FileData,
+):
+    err = OSError(22, "The request body terminated unexpectedly")
+    mocker.patch.object(IbmWatsonxUploader, "_df_to_arrow_table", return_value=mock_data_table)
+    mock_upload_data_table = mocker.patch.object(
+        IbmWatsonxUploader, "upload_data_table", side_effect=[err, None]
+    )
+
+    uploader.upload_dataframe(test_df, file_data)
+
+    assert mock_get_table.call_count == 2
+    assert mock_upload_data_table.call_count == 2
+
+
+def test_ibm_watsonx_uploader_upload_dataframe_incomplete_body_exhausted(
+    mocker: MockerFixture,
+    uploader: IbmWatsonxUploader,
+    test_df: pd.DataFrame,
+    mock_get_table: MagicMock,
+    mock_data_table: MagicMock,
+    file_data: FileData,
+):
+    err = OSError(22, "The request body terminated unexpectedly")
+    mocker.patch.object(IbmWatsonxUploader, "_df_to_arrow_table", return_value=mock_data_table)
+    mock_upload_data_table = mocker.patch.object(
+        IbmWatsonxUploader, "upload_data_table", side_effect=err
+    )
+
+    with pytest.raises(DestinationConnectionError):
+        uploader.upload_dataframe(test_df, file_data)
+    assert mock_get_table.call_count == 2
+    assert mock_upload_data_table.call_count == 2
+
+
+def test_ibm_watsonx_uploader_upload_dataframe_other_einval_is_not_retried(
+    mocker: MockerFixture,
+    uploader: IbmWatsonxUploader,
+    test_df: pd.DataFrame,
+    mock_get_table: MagicMock,
+    mock_data_table: MagicMock,
+    file_data: FileData,
+):
+    err = OSError(22, "Invalid argument")
+    mocker.patch.object(IbmWatsonxUploader, "_df_to_arrow_table", return_value=mock_data_table)
+    mock_upload_data_table = mocker.patch.object(
+        IbmWatsonxUploader, "upload_data_table", side_effect=err
+    )
+
+    with pytest.raises(ProviderError):
+        uploader.upload_dataframe(test_df, file_data)
+    mock_get_table.assert_called_once()
+    mock_upload_data_table.assert_called_once()
+
+
+def test_ibm_watsonx_uploader_upload_data_table_reraises_incomplete_body(
+    uploader: IbmWatsonxUploader,
+    mock_table: MagicMock,
+    mock_transaction: MagicMock,
+    mock_data_table: MagicMock,
+    mock_delete: MagicMock,
+    file_data: FileData,
+):
+    err = OSError(22, "The request body terminated unexpectedly")
+    mock_transaction.append.side_effect = err
+
+    with pytest.raises(OSError, match="terminated unexpectedly"):
+        uploader.upload_data_table(mock_table, mock_data_table, file_data)
+
+
+def test_is_retryable_cos_request_time_too_skewed_matches_s3fs_permission_error():
+    err = PermissionError(
+        "The difference between the request time and the server's time is too large."
+    )
+    assert is_retryable_cos_request_time_too_skewed(err) is True
+    assert is_retryable_cos_io_error(err) is True
+
+
+def test_is_retryable_cos_request_time_too_skewed_rejects_access_denied():
+    assert is_retryable_cos_request_time_too_skewed(PermissionError("Access Denied")) is False
+    assert is_retryable_cos_io_error(PermissionError("Access Denied")) is False
+
+
+def test_is_retryable_cos_request_time_too_skewed_matches_boto_code():
+    err = Exception("client")
+    err.response = {"Error": {"Code": "RequestTimeTooSkewed"}}  # type: ignore[attr-defined]
+    assert is_retryable_cos_request_time_too_skewed(err) is True
+
+
+def test_is_retryable_cos_request_time_too_skewed_walks_cause_chain():
+    inner = Exception("client")
+    inner.response = {"Error": {"Code": "RequestTimeTooSkewed"}}  # type: ignore[attr-defined]
+    outer = PermissionError(
+        "The difference between the request time and the server's time is too large."
+    )
+    outer.__cause__ = inner
+    assert is_retryable_cos_request_time_too_skewed(outer) is True
+    assert is_retryable_cos_io_error(outer) is True
+
+
+def test_ibm_watsonx_uploader_upload_dataframe_retries_request_time_too_skewed(
+    mocker: MockerFixture,
+    uploader: IbmWatsonxUploader,
+    test_df: pd.DataFrame,
+    mock_get_table: MagicMock,
+    mock_data_table: MagicMock,
+    file_data: FileData,
+):
+    err = PermissionError(
+        "The difference between the request time and the server's time is too large."
+    )
+    mocker.patch.object(IbmWatsonxUploader, "_df_to_arrow_table", return_value=mock_data_table)
+    mock_upload_data_table = mocker.patch.object(
+        IbmWatsonxUploader, "upload_data_table", side_effect=[err, None]
+    )
+
+    uploader.upload_dataframe(test_df, file_data)
+
+    assert mock_get_table.call_count == 2
+    assert mock_upload_data_table.call_count == 2
+
+
+def test_ibm_watsonx_uploader_upload_dataframe_access_denied_is_not_retried(
+    mocker: MockerFixture,
+    uploader: IbmWatsonxUploader,
+    test_df: pd.DataFrame,
+    mock_get_table: MagicMock,
+    mock_data_table: MagicMock,
+    file_data: FileData,
+):
+    err = PermissionError("Access Denied")
+    mocker.patch.object(IbmWatsonxUploader, "_df_to_arrow_table", return_value=mock_data_table)
+    mock_upload_data_table = mocker.patch.object(
+        IbmWatsonxUploader, "upload_data_table", side_effect=err
+    )
+
+    with pytest.raises(ProviderError):
+        uploader.upload_dataframe(test_df, file_data)
+    mock_get_table.assert_called_once()
+    mock_upload_data_table.assert_called_once()
+
+
+def test_ibm_watsonx_uploader_upload_data_table_reraises_request_time_too_skewed(
+    uploader: IbmWatsonxUploader,
+    mock_table: MagicMock,
+    mock_transaction: MagicMock,
+    mock_data_table: MagicMock,
+    mock_delete: MagicMock,
+    file_data: FileData,
+):
+    err = PermissionError(
+        "The difference between the request time and the server's time is too large."
+    )
+    mock_transaction.append.side_effect = err
+
+    with pytest.raises(PermissionError, match="request time"):
+        uploader.upload_data_table(mock_table, mock_data_table, file_data)
 
 
 def test_ibm_watsonx_uploader_delete_can_delete(

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.5"  # pragma: no cover
+__version__ = "1.11.6"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
+++ b/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
@@ -55,6 +55,78 @@ DEFAULT_ICEBERG_CATALOG_TYPE = "rest"
 # the same stack as the S3 destination.
 DEFAULT_PY_IO_IMPL = "pyiceberg.io.fsspec.FsspecFileIO"
 
+# s3fs translates some retryable COS/S3 errors into OSError/PermissionError and
+# then refuses to retry them. Other 400s (InvalidArgument, AccessDenied, ...)
+# must not be retried. The Iceberg transaction has not committed when these
+# fire; retrying delete+append is safe.
+_INCOMPLETE_BODY_STRERROR = "terminated unexpectedly"
+_INCOMPLETE_BODY_CODE = "incompletebody"
+_REQUEST_TIME_SKEW_CODE = "requesttimetooskewed"
+_REQUEST_TIME_SKEW_MSG = "request time and the server's time is too large"
+
+
+def _boto_error_code(error: BaseException) -> Optional[str]:
+    response = getattr(error, "response", None)
+    if not isinstance(response, dict):
+        return None
+    err = response.get("Error")
+    if not isinstance(err, dict):
+        return None
+    code = err.get("Code")
+    return code if isinstance(code, str) else None
+
+
+def _walk_exception_chain(error: BaseException) -> Generator[BaseException, None, None]:
+    seen: set[int] = set()
+    cur: Optional[BaseException] = error
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        yield cur
+        cur = cur.__cause__ or cur.__context__
+
+
+def _exception_text(error: BaseException) -> str:
+    return f"{getattr(error, 'strerror', None) or ''} {error}".lower()
+
+
+def is_retryable_cos_incomplete_body(error: BaseException) -> bool:
+    """True for a COS/S3 PutObject IncompleteBody mapped through s3fs.
+
+    Do not treat every OSError(EINVAL) as retryable.
+    """
+    for cur in _walk_exception_chain(error):
+        code = _boto_error_code(cur)
+        if code is not None and code.lower() == _INCOMPLETE_BODY_CODE:
+            return True
+        text = _exception_text(cur)
+        if _INCOMPLETE_BODY_STRERROR in text or _INCOMPLETE_BODY_CODE in text.replace(" ", ""):
+            return True
+    return False
+
+
+def is_retryable_cos_request_time_too_skewed(error: BaseException) -> bool:
+    """True for COS/S3 RequestTimeTooSkewed mapped through s3fs to PermissionError.
+
+    A fresh Iceberg transaction re-signs with the current time. Do not retry
+    AccessDenied or other PermissionError.
+    """
+    for cur in _walk_exception_chain(error):
+        code = _boto_error_code(cur)
+        if code is not None and code.lower() == _REQUEST_TIME_SKEW_CODE:
+            return True
+        text = _exception_text(cur)
+        compact = text.replace(" ", "").replace("_", "")
+        if _REQUEST_TIME_SKEW_MSG in text or _REQUEST_TIME_SKEW_CODE in compact:
+            return True
+    return False
+
+
+def is_retryable_cos_io_error(error: BaseException) -> bool:
+    """COS I/O flakes that s3fs does not retry; Iceberg txn has not committed."""
+    return is_retryable_cos_incomplete_body(error) or is_retryable_cos_request_time_too_skewed(
+        error
+    )
+
 
 class IbmWatsonxAccessConfig(AccessConfig):
     iam_api_key: str = Field(description="IBM IAM API Key")
@@ -349,6 +421,16 @@ class IbmWatsonxUploader(SQLUploader):
             except RESTError as e:
                 raise DestinationConnectionError(safe_error_summary(e)) from None
             except Exception as e:
+                # IncompleteBody / RequestTimeTooSkewed must reach upload_dataframe's
+                # retry loop; wrapping them here as ProviderError made COS flakes a
+                # hard job failure. s3fs maps both to OSError/PermissionError and
+                # will not retry them itself.
+                if is_retryable_cos_io_error(e):
+                    logger.warning(
+                        "Retryable COS I/O error during Iceberg upload: %s",
+                        safe_error_summary(e),
+                    )
+                    raise
                 raise ProviderError(
                     f"Failed to upload data to table: {safe_error_summary(e)}"
                 ) from None
@@ -360,6 +442,8 @@ class IbmWatsonxUploader(SQLUploader):
         except ProviderError:
             raise
         except Exception as e:
+            if is_retryable_cos_io_error(e):
+                raise
             raise ProviderError(
                 f"Failed to upload data to table: {safe_error_summary(e)}"
             ) from None
@@ -370,18 +454,25 @@ class IbmWatsonxUploader(SQLUploader):
         from tenacity import (
             before_log,
             retry,
-            retry_if_exception_type,
+            retry_if_exception,
             stop_after_attempt,
             wait_exponential,
         )
 
         data_table = self._df_to_arrow_table(df)
 
-        # Retry connection in case of a connection error or token expiration
+        def _retryable_upload_error(error: BaseException) -> bool:
+            if isinstance(error, RESTError):
+                return True
+            return is_retryable_cos_io_error(error)
+
+        # Retry Iceberg REST blips and COS I/O flakes that s3fs will not retry
+        # (IncompleteBody, RequestTimeTooSkewed). The Iceberg transaction has
+        # not committed when these fire.
         @retry(
             stop=stop_after_attempt(self.connection_config.max_retries_connection),
             wait=wait_exponential(exp_base=2, multiplier=1, min=2, max=10),
-            retry=retry_if_exception_type(RESTError),
+            retry=retry_if_exception(_retryable_upload_error),
             before=before_log(logger, logging.DEBUG),
             reraise=True,
         )
@@ -394,6 +485,14 @@ class IbmWatsonxUploader(SQLUploader):
         except ProviderError:
             raise
         except Exception as e:
+            if is_retryable_cos_io_error(e):
+                logger.warning(
+                    "COS I/O error exhausted retries: %s",
+                    safe_error_summary(e),
+                )
+                raise DestinationConnectionError(
+                    f"Failed to upload data to table: {safe_error_summary(e)}"
+                ) from None
             raise ProviderError(
                 f"Failed to upload data to table: {safe_error_summary(e)}"
             ) from None

--- a/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
+++ b/unstructured_ingest/processes/connectors/ibm_watsonx/ibm_watsonx_s3.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import time
 from contextlib import contextmanager
@@ -92,15 +93,20 @@ def _exception_text(error: BaseException) -> str:
 def is_retryable_cos_incomplete_body(error: BaseException) -> bool:
     """True for a COS/S3 PutObject IncompleteBody mapped through s3fs.
 
-    Do not treat every OSError(EINVAL) as retryable.
+    Structured boto ``Code`` matching applies to any exception in the chain.
+    Message matching is restricted to ``OSError(EINVAL)``: that is what s3fs
+    ``translate_boto_error`` emits for IncompleteBody. Do not treat every
+    ``OSError(EINVAL)`` as retryable, and do not retry unrelated failures
+    whose message happens to contain ``terminated unexpectedly``.
     """
     for cur in _walk_exception_chain(error):
         code = _boto_error_code(cur)
         if code is not None and code.lower() == _INCOMPLETE_BODY_CODE:
             return True
-        text = _exception_text(cur)
-        if _INCOMPLETE_BODY_STRERROR in text or _INCOMPLETE_BODY_CODE in text.replace(" ", ""):
-            return True
+        if isinstance(cur, OSError) and cur.errno == errno.EINVAL:
+            text = _exception_text(cur)
+            if _INCOMPLETE_BODY_STRERROR in text or _INCOMPLETE_BODY_CODE in text.replace(" ", ""):
+                return True
     return False
 
 


### PR DESCRIPTION
## Summary
- Retry IBM COS `IncompleteBody` and `RequestTimeTooSkewed` during Iceberg upload instead of failing the job as `ProviderError`.
- s3fs maps those errors to `OSError`/`PermissionError` and will not retry them; the Iceberg transaction has not committed, so a fresh delete+append is safe.
- Other `EINVAL` / `AccessDenied` failures stay non-retryable (including when those boto Codes sit on `__cause__`). Exhausted retries surface as `DestinationConnectionError`. Bumps to 1.11.6.

## Test plan
- [x] Unit: `test/unit/connectors/ibm_watsonx/test_ibm_watsonx_s3.py` (74 passed)
  - Classifier: distinctive AWS messages, boto `Code`, `__cause__`/`__context__` chain (including generic outer EINVAL/AccessDenied with the real Code on the inner ClientError)
  - Uploader: retry, exhausted-retry → `DestinationConnectionError`, non-retryable `EINVAL`/`AccessDenied` → `ProviderError`
  - `upload_data_table` re-raises retryable COS errors so `upload_dataframe`'s loop can start a fresh Iceberg transaction
- [x] CI unit tests + changelog/version-sync checks (green on first push; this commit is tests-only)