### PR TITLE
chore(deps): upgrade office365-rest-python-client to 3.0.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3787,7 +3787,7 @@ wheels = [
 
 [[package]]
 name = "office365-rest-python-client"
-version = "2.6.2"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "msal" },
@@ -3795,9 +3795,9 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/04/6dce2d581c54a8e55a3b128cf79a93821a68a62bb9a956e65476c5bb247e/office365_rest_python_client-2.6.2.tar.gz", hash = "sha256:ce27f5a1c0cc3ff97041ccd9b386145692be4c64739f243f7d6ac3edbe0a3c46", size = 659460, upload-time = "2025-05-11T10:24:21.895Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/63/6ccc58f2e20c770b9409ea5a4794aa8515e1158b23df2dd2bfe90b04aacd/office365_rest_python_client-3.0.0.tar.gz", hash = "sha256:3f95d29794ee0adc58e0b16f6574257c885c74af108e1789e4b3c286bc2ce5ac", size = 949771, upload-time = "2026-08-02T11:54:01.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/a4/611155711f8af347875c15b8b83f5fd9e978bd4de45f90085b9a583b684d/Office365_REST_Python_Client-2.6.2-py3-none-any.whl", hash = "sha256:06fc6829c39b503897caa9d881db419d7f97a8e4f1c95c4c2d12db36ea6c955d", size = 1337139, upload-time = "2025-05-11T10:24:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/3abd5a09c4213fc57c2b563b599ebaa05aa51a2f9b74e68c681a881f4e95/office365_rest_python_client-3.0.0-py3-none-any.whl", hash = "sha256:3432a9780febe0aa571543d21288d97ef9e0a0287aa0a5047523a65557e41932", size = 2860038, upload-time = "2026-08-02T11:53:59.863Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The pinned `2.6.2` predates two upstream fixes this repo has been working around or blocked by.

**`Message.unique_body` did not exist before 3.0.0.** Graph exposes `uniqueBody`, the part of a message body that excludes quoted thread history. Without the property there was no supported way to request it, so any work on thread-aware email extraction was blocked on a library upgrade rather than on our own code. 3.0.0 adds it, correctly keyed to Graph's `uniqueBody` and decorated for `$select`.

**`IdentitySet`'s mutable-default-arg singleton is fixed.** That bug collapsed every `Permission` identity to whichever user happened to deserialize last in the process, which is why the OneDrive connector bypasses the SDK and fetches raw permission JSON through Graph `/$batch`.

## The one failing test is the point

`test_office365_sdk_typed_accessor_is_corrupted` is a canary. It asserts the SDK is *still broken*, so that the day upstream fixes it, CI says so. It now fails:

```
AssertionError: Upstream office365 IdentitySet may have been fixed;
consider removing the raw-JSON workaround in onedrive.py
assert 3 == 1
```

That is the canary doing its job, not a regression. Removing the workaround is a behaviour change with its own review surface, so this PR deliberately does not fold it in. **It should be the immediate follow-up**, and this PR should probably not merge until that is decided, since it otherwise lands a knowingly red test.

## Risk

Low, and narrower than a major version bump suggests. The lock delta is this package alone, with no transitive movement. 174 of 175 unit tests across the outlook, onedrive and sharepoint connectors pass unchanged; the 175th is the canary above.

## What this does not fix

`OutlookItem.change_key` still reads `properties.get("ChangeKey")` while Graph returns `changeKey`, so it continues to resolve to `None`. Sibling properties in the same class use Graph's casing correctly, so this looks like an upstream typo rather than a convention. Anything relying on `change_key` as a version or change-detection signal is unaffected by this upgrade and still needs attention.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

