### PR TITLE
test(outlook): seed CI fixture mail and run the Outlook e2e without enforcing it yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.12]
+
+### Fixes
+
+- **test(outlook): seed CI fixture mail and run the Outlook E2E test without enforcing it yet.** `outlook.sh` was listed in `all_tests` but never added to `full_python_matrix_tests`, so `test-src.sh` skipped it on every run once CI standardized on Python 3.12, including the fixture-regeneration dispatch, which is why no Outlook fixtures could ever be produced. The python-version gate is removed so dispatch and nightly runs actually exercise the connector and can regenerate `test_e2e/expected-structured-output`; the test stays in `tests_to_ignore` for now, so its exit code does not gate CI while e2e enforcement consolidates in the orchestration repo. Because the test needs mail that actually exists in the target mailbox, and the connector derives each filename from `sha256(message.id)` (Graph-assigned, and unstable across a folder move), a tear-down-and-recreate strategy would churn every fixture name per run. `test_e2e/env_setup/outlook/` therefore seeds create-if-absent, keyed on a fixed extended-property marker, covering attachments, threading, a cross-folder move, and mutable read/flag/category state, and exits distinctly on a 403 so a missing `Mail.ReadWrite` grant is not mistaken for a code fault. The two Graph-native threading fixtures (reply and forward) currently fail against a never-sent base message and are deferred behind an opt-in (SEED_DEFERRED_FIXTURES=1), so a default seeding run seeds the remaining five and exits zero.
+
 ## [1.11.11]
 
 ### Fixes

--- a/test_e2e/env_setup/outlook/README.md
+++ b/test_e2e/env_setup/outlook/README.md
@@ -1,0 +1,120 @@
+# Outlook fixture seeding
+
+`seed_fixtures.py` guarantees that a fixed, known set of fixture messages exists in the
+Outlook mailbox the `outlook.sh` end-to-end test reads from, before that test runs. It is
+create-if-absent: every time it runs, it checks whether each fixture already exists and only
+creates the ones that do not.
+
+Fixture *content* lives in `fixtures.py`, one `SeedMessage` per fixture, each with a comment
+explaining the specific question that fixture exists to answer. This file explains how the two
+scripts fit into CI and why they have to work the way they do.
+
+This is a public repository. Every fixture is generic, synthetic test mail: no customer name,
+no real correspondence, no deployment-specific detail, anywhere in `fixtures.py`, in this file,
+or in commit history touching either. If you add a fixture, keep it that way.
+
+## How this gets invoked from CI
+
+`test_e2e/src/outlook.sh` calls `seed_fixtures.py` itself, right after its existing check that
+`MS_CLIENT_ID` / `MS_CLIENT_CRED` / `MS_TENANT_ID` / `MS_USER_EMAIL` are all set (and before it
+runs the actual ingest). `outlook.sh` is itself invoked by `test_e2e/test-src.sh`'s main loop,
+which is invoked by the `src_e2e_test` job in `.github/workflows/e2e.yml` (nightly / on-demand /
+post-merge only, never on pull requests) and by the `update-fixtures-and-pr` job in
+`.github/workflows/ingest-test-fixtures-update-pr.yml`. Both jobs already set the four
+credentials above from GitHub secrets and already install this project's `outlook` extra
+(`msal` + `Office365-REST-Python-Client`), so no CI configuration beyond this directory and the
+two-line `test-src.sh` gate fix (below) is needed to make seeding run.
+
+Because seeding sits inside `outlook.sh` rather than in its own `all_tests` entry, a seeding
+failure fails `outlook.sh` itself (via `set -e`, already at the top of that script) with the
+message this script printed to stderr, before any ingest is attempted. `test-src.sh` then
+treats that the same as any other test failure: a non-8, non-zero exit code stops the run
+(`test-src.sh` lines ~86-101 as of this change).
+
+Run it by hand the same way `outlook.sh` does, from the repository root:
+
+```bash
+PYTHONPATH=. test_e2e/env_setup/outlook/seed_fixtures.py
+```
+
+It reads `MS_CLIENT_ID`, `MS_CLIENT_CRED`, `MS_TENANT_ID`, `MS_USER_EMAIL` from the environment
+and nothing else. It never prints, logs, or writes any of their values; only fixture slugs,
+folder names, and Graph error codes appear in its output.
+
+## Why seeding has to be create-if-absent
+
+The mailbox this seeds into is a real, shared, persistent Microsoft 365 mailbox, not a
+container this test suite owns and can tear down between runs the way `couchbase.sh` and
+`sftp.sh` do. Recreating every fixture from scratch on every run would work functionally, but
+it would silently defeat the fixture-comparison mechanism the rest of `test_e2e` relies on --
+see the next section for exactly why.
+
+## The `sha256(message.id)` consequence
+
+`OutlookIndexer._generate_fullpath` (`unstructured_ingest/processes/connectors/outlook.py`)
+names every downloaded fixture file `sha256(message.id)[:16] + ".eml"`. `message.id` is an
+opaque identifier Microsoft Graph assigns when a message is created; this script never
+chooses it and cannot predict it ahead of creation.
+
+`test_e2e/check-diff-expected-output.py` (`check_files`) requires the *set* of output filenames
+to exactly match the set of files already committed under
+`test_e2e/expected-structured-output/outlook/`. Put those two facts together: if this script
+tore fixtures down and recreated them every run, every fixture would get a brand-new
+Graph-assigned `id` every run, therefore a brand-new sha256-derived filename every run, and
+`check_files` would fail on every single run, permanently, by design -- not because anything is
+actually wrong, but because the committed expected-output filenames can never keep up with
+freshly-minted ids. Create-if-absent is what keeps `message.id`, and therefore the filename,
+stable across runs: the same physical Graph messages persist, so the same hashes keep matching
+the same committed `<hash>.eml.json` files.
+
+This is also why `MOVE_TARGET` (see `fixtures.py`) is the one fixture worth reading closely if
+you're new to this: the vendored Graph client's own `Message.move()` docstring says a move
+creates a new copy and deletes the original, which means a *moved* message gets a new id too.
+Idempotency here cannot key off `message.id` at all -- it keys off a separate, stable marker
+this script controls (below), specifically so that survives.
+
+## Idempotency marker, not `message.id`
+
+Each fixture is tagged, at creation time, with a `singleValueLegacyExtendedProperty` whose
+`value` is the fixture's `slug` (see `fixtures.py`) and whose `id` is a fixed,
+script-owned GUID (`seed_fixtures.MARKER_PROPERTY_ID`). Before creating anything, the script
+filters the seed folder for a message carrying that GUID with the target slug as its value; if
+one is found, that fixture is skipped.
+
+The vendored client's own convenience method for this, `Message.add_extended_property()`,
+mints a fresh random GUID on every call, which would make every fixture "invisible" to every
+later run's existence check. This script builds the property dict directly instead, at one
+fixed GUID, for exactly that reason.
+
+## Permissions
+
+Every Graph call here needs only the **Mail.ReadWrite** application permission -- creating
+messages and drafts, tagging them, moving them, flagging them, marking them read, categorizing
+them. Nothing in this script calls send, reply, or forward (the operations that actually
+transmit mail and need **Mail.Send**); replies and forwards are created as Graph drafts
+(`createReply` / `createForward`) and left unsent.
+
+If the Azure AD app registration behind `MS_CLIENT_ID` does not hold Mail.ReadWrite, or holds
+it but has not been granted tenant admin consent, the first write call will come back `403`.
+This script treats that specifically as a **provisioning problem**, not a script bug: it prints
+a distinct fatal message naming Mail.ReadWrite and the app registration, rather than a generic
+traceback, and exits `2`. A missing seed folder is also its own distinct message and exit code
+(`3`) rather than folding into the same path. Missing environment variables exit `1`, and name
+only which variables are missing, never any value.
+
+## Open questions
+
+- Whether `createReply` / `createForward` place the new draft in Drafts by default, or next to
+  the original, was not confirmed against a live mailbox (this session was not permitted to
+  touch one). The script does not depend on the answer -- it explicitly moves the resulting
+  draft into the seed folder either way -- but a same-folder-to-same-folder move is an
+  unexercised path worth a first-run sanity check.
+- The first time this script actually runs against the real mailbox, it will create fixtures
+  whose `message.id` (and therefore filename) cannot be known ahead of time. `check-diff-expected-output.py`
+  already has a documented escape hatch for exactly this ("export OVERWRITE_FIXTURES=true and
+  rerun"); whoever runs seeding for the first time needs to use it once, review the new
+  `expected-structured-output/outlook/*.json` files it produces, and commit them. This PR does
+  not and cannot do that step itself.
+- Whether the mailbox's three pre-existing committed fixtures predate this marker (almost
+  certainly yes) and whether they should stay, was not resolved here; this script does not
+  touch or remove anything it did not itself create.

--- a/test_e2e/env_setup/outlook/fixtures.py
+++ b/test_e2e/env_setup/outlook/fixtures.py
@@ -1,0 +1,193 @@
+"""Fixture mail definitions seeded into the Outlook integration-test mailbox.
+
+This module holds data only: what each fixture message is, and the one question it exists
+to answer. seed_fixtures.py holds the logic that turns this data into Graph API calls.
+
+Every fixture is generic, synthetic test mail. None of it names a customer, a deployment, or
+any real correspondence -- see the module docstring in seed_fixtures.py and the README in this
+directory for why that matters (this repository is public).
+
+Each SeedMessage.slug is a permanent idempotency key (see seed_fixtures.py): once a slug has
+shipped, its wording may still change, but the slug string itself must not, or the script will
+create a second, duplicate message under the old identity instead of recognizing the existing one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Folder the connector is configured to read (test_e2e/src/outlook.sh: --outlook-folders).
+SEED_FOLDER_NAME = "EmailsWithAttachments"
+
+# Graph well-known folder name used as the "somewhere else" starting point for MOVE_TARGET.
+# Using the well-known literal "drafts" means there's no separate staging folder to create
+# and idempotency-check on its own; every mailbox already has exactly one Drafts folder.
+STAGING_WELL_KNOWN_FOLDER = "drafts"
+
+POST_CREATE_MARK_READ = "mark_read"
+POST_CREATE_FLAG = "flag"
+POST_CREATE_CATEGORIZE = "categorize"
+
+
+@dataclass(frozen=True)
+class Attachment:
+    """A small file attachment added to a message at creation time."""
+
+    filename: str
+    content_type: str
+    text_content: str
+
+
+@dataclass(frozen=True)
+class SeedMessage:
+    """One fixture message the script guarantees exists in SEED_FOLDER_NAME.
+
+    Only one of reply_to / forward_of / attachment / stage_in_well_known_folder is expected
+    to be set per fixture; seed_fixtures.py dispatches creation on whichever is set. A plain
+    message (none of them set) is created directly in the seed folder via folder.messages.add.
+    """
+
+    slug: str
+    subject: str
+    body_text: str
+    comment: str
+    body_content_type: str = "Text"  # "Text" or "HTML"
+    reply_to: str | None = None  # slug of the message this is a Graph createReply of
+    forward_of: str | None = None  # slug of the message this is a Graph createForward of
+    attachment: Attachment | None = None
+    stage_in_well_known_folder: str | None = None
+    post_create_actions: tuple[str, ...] = field(default_factory=tuple)
+
+
+THREAD_STARTER = SeedMessage(
+    slug="thread-starter",
+    subject="[unstructured-ingest fixture] weekly status placeholder",
+    body_text=(
+        "This is a placeholder message used only by unstructured-ingest's automated tests. "
+        "It intentionally carries no real content."
+    ),
+    comment=(
+        "Answers nothing on its own. It exists only so THREAD_REPLY and THREAD_FORWARD have "
+        "a real prior message to attach Graph-native threading to."
+    ),
+)
+
+THREAD_REPLY = SeedMessage(
+    slug="thread-reply",
+    subject=THREAD_STARTER.subject,
+    body_text="Thanks, no action needed on my end.",
+    reply_to=THREAD_STARTER.slug,
+    comment=(
+        "A reply sitting inside an existing thread, not a standalone message. Answers: does "
+        "the connector surface Graph's own conversationId / reply relationship correctly, "
+        "instead of every message looking like an unrelated one-off?"
+    ),
+)
+
+THREAD_FORWARD = SeedMessage(
+    slug="thread-forward",
+    subject=THREAD_STARTER.subject,
+    body_text="Forwarding for visibility, nothing needed from you.",
+    forward_of=THREAD_STARTER.slug,
+    comment=(
+        "A forward of the same starter message, sent back to the same mailbox so no second "
+        "address is needed. Answers: does the connector distinguish a forward from a reply "
+        "and from a standalone message, rather than collapsing all three to the same shape?"
+    ),
+)
+
+INLINE_QUOTED_HISTORY = SeedMessage(
+    slug="inline-quoted-history",
+    subject="[unstructured-ingest fixture] re: placeholder thread",
+    body_content_type="HTML",
+    body_text=(
+        "<p>Following up on the note below.</p>"
+        "<blockquote>"
+        "<p>On Mon, Jan 1, 2001, Fixture Sender &lt;fixture-sender@example.com&gt; wrote:</p>"
+        "<p>&gt; This is the quoted portion of an earlier message, embedded directly in the "
+        "body text&lt;br&gt;&gt; rather than represented through Graph's reply/forward "
+        "relationship.</p>"
+        "</blockquote>"
+    ),
+    comment=(
+        "A message whose body contains manually embedded quoted history (the way a mail "
+        "client renders an inline quote), as opposed to Graph-native threading. Answers: "
+        "does the partitioner handle an inline blockquote in HTML body without mistaking "
+        "the quoted portion for the message's own primary content?"
+    ),
+)
+
+SMALL_ATTACHMENT = SeedMessage(
+    slug="small-attachment",
+    subject="[unstructured-ingest fixture] note with attachment",
+    body_text="See attached.",
+    attachment=Attachment(
+        filename="fixture-note.txt",
+        content_type="text/plain",
+        text_content=(
+            "This attachment is deliberately tiny and boring.\n"
+            "It exists only so the partitioner has a real attachment to open.\n"
+        ),
+    ),
+    comment=(
+        "A message carrying one small, deliberately dull attachment. Answers: does the "
+        "connector's downloader and the hosted partitioning API round-trip a message that "
+        "actually has attachment bytes -- has_attachments true, attachment content "
+        "partitioned -- without the fixture drifting because of what the attachment says. "
+        "An elaborate attachment would give the hosted partitioner more surface area to "
+        "change its output on, silently breaking this fixture on unrelated model updates."
+    ),
+)
+
+MOVE_TARGET = SeedMessage(
+    slug="move-target",
+    subject="[unstructured-ingest fixture] moved into place",
+    body_text="This message did not start in the seed folder; the seeding script moved it here.",
+    stage_in_well_known_folder=STAGING_WELL_KNOWN_FOLDER,
+    comment=(
+        "A message created in Drafts, then explicitly moved into the seed folder. Graph's "
+        "move creates a new copy and deletes the original (see office365 Message.move's own "
+        "docstring), which assigns a brand-new id and therefore a brand-new "
+        "sha256(message.id)-derived fixture filename. This fixture specifically exercises "
+        "that the idempotency marker -- not message.id -- is what lets a second run of this "
+        "script recognize the message as already seeded."
+    ),
+)
+
+FLAG_READ_CATEGORIZE_TARGET = SeedMessage(
+    slug="flag-read-categorize-target",
+    subject="[unstructured-ingest fixture] mutable state placeholder",
+    body_text="This message exists to be flagged, marked read, and categorized after creation.",
+    post_create_actions=(POST_CREATE_MARK_READ, POST_CREATE_FLAG, POST_CREATE_CATEGORIZE),
+    comment=(
+        "A message the script marks read, flags for follow-up, and assigns a category to, "
+        "all after creation. Answers: does the connector's metadata mapping correctly "
+        "reflect a message's mutable state (is_read, flag, categories) rather than only the "
+        "content it was created with?"
+    ),
+)
+
+# Order matters: seed_fixtures.py processes this tuple left to right and keeps a slug -> handle
+# map of what it has created or found so far. A fixture that sets reply_to/forward_of looks its
+# base up in that map, so the base must appear earlier in this tuple than any fixture that
+# depends on it (checked below, since getting this wrong would fail as a runtime KeyError deep
+# inside a Graph call sequence instead of at import time).
+ALL_FIXTURES: tuple[SeedMessage, ...] = (
+    THREAD_STARTER,
+    THREAD_REPLY,
+    THREAD_FORWARD,
+    INLINE_QUOTED_HISTORY,
+    SMALL_ATTACHMENT,
+    MOVE_TARGET,
+    FLAG_READ_CATEGORIZE_TARGET,
+)
+
+_slugs = [f.slug for f in ALL_FIXTURES]
+assert len(_slugs) == len(set(_slugs)), "fixture slugs must be unique: %r" % _slugs
+for _i, _f in enumerate(ALL_FIXTURES):
+    for _dep in (_f.reply_to, _f.forward_of):
+        assert _dep is None or _dep in _slugs[:_i], (
+            f"fixture '{_f.slug}' depends on '{_dep}', which must appear earlier in "
+            "ALL_FIXTURES than the fixture that depends on it"
+        )
+del _slugs, _i, _f, _dep

--- a/test_e2e/env_setup/outlook/fixtures.py
+++ b/test_e2e/env_setup/outlook/fixtures.py
@@ -167,27 +167,39 @@ FLAG_READ_CATEGORIZE_TARGET = SeedMessage(
     ),
 )
 
-# Order matters: seed_fixtures.py processes this tuple left to right and keeps a slug -> handle
+# Order matters: seed_fixtures.py processes these tuples left to right and keeps a slug -> handle
 # map of what it has created or found so far. A fixture that sets reply_to/forward_of looks its
-# base up in that map, so the base must appear earlier in this tuple than any fixture that
-# depends on it (checked below, since getting this wrong would fail as a runtime KeyError deep
-# inside a Graph call sequence instead of at import time).
+# base up in that map, so the base must appear earlier in the seeding order than any fixture
+# that depends on it (checked below, since getting this wrong would fail as a runtime KeyError
+# deep inside a Graph call sequence instead of at import time).
 ALL_FIXTURES: tuple[SeedMessage, ...] = (
     THREAD_STARTER,
-    THREAD_REPLY,
-    THREAD_FORWARD,
     INLINE_QUOTED_HISTORY,
     SMALL_ATTACHMENT,
     MOVE_TARGET,
     FLAG_READ_CATEGORIZE_TARGET,
 )
 
-_slugs = [f.slug for f in ALL_FIXTURES]
+# Not seeded by default: neither thread fixture currently seeds when its base message was only
+# ever created via the raw message-create API and never actually sent, and THREAD_STARTER is
+# exactly such a message. Against the real mailbox, createReply 400s (ErrorInvalidReferenceItem)
+# and createForward fails client-side inside the SDK with no HTTP response at all. The root cause
+# is unconfirmed (Microsoft documents no sent-through-mail-flow constraint), so seeding these two
+# is opt-in (SEED_DEFERRED_FIXTURES=1 in the environment) until a Graph-native threading route is
+# settled; a default run then succeeds on the five fixtures that do work instead of always
+# exiting non-zero. When opted in they are seeded after ALL_FIXTURES, so their THREAD_STARTER
+# base is already in the handle map.
+DEFERRED_FIXTURES: tuple[SeedMessage, ...] = (
+    THREAD_REPLY,
+    THREAD_FORWARD,
+)
+
+_slugs = [f.slug for f in ALL_FIXTURES + DEFERRED_FIXTURES]
 assert len(_slugs) == len(set(_slugs)), "fixture slugs must be unique: %r" % _slugs
-for _i, _f in enumerate(ALL_FIXTURES):
+for _i, _f in enumerate(ALL_FIXTURES + DEFERRED_FIXTURES):
     for _dep in (_f.reply_to, _f.forward_of):
         assert _dep is None or _dep in _slugs[:_i], (
             f"fixture '{_f.slug}' depends on '{_dep}', which must appear earlier in "
-            "ALL_FIXTURES than the fixture that depends on it"
+            "the seeding order than the fixture that depends on it"
         )
 del _slugs, _i, _f, _dep

--- a/test_e2e/env_setup/outlook/seed_fixtures.py
+++ b/test_e2e/env_setup/outlook/seed_fixtures.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Create-if-absent seeding for the Outlook connector's CI fixture mailbox.
+
+Run from the repository root (matching test_e2e/src/outlook.sh's own convention) with:
+
+    PYTHONPATH=. test_e2e/env_setup/outlook/seed_fixtures.py
+
+See the README in this directory for why this has to be create-if-absent rather than
+tear-down-and-recreate, and for how CI actually invokes it.
+
+Credentials (MS_CLIENT_ID, MS_CLIENT_CRED, MS_TENANT_ID, MS_USER_EMAIL) are read from the
+environment only. They are never printed, logged, or written anywhere by this script. Only
+non-secret material -- fixture slugs, folder names, Graph error codes -- appears in output.
+
+Every Graph call this script makes needs only the Mail.ReadWrite application permission. It
+never calls send/reply/forward (the API operations that transmit real mail), only the
+create-a-draft equivalents; see README.md for why.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TYPE_CHECKING
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fixtures import (  # noqa: E402
+    ALL_FIXTURES,
+    POST_CREATE_CATEGORIZE,
+    POST_CREATE_FLAG,
+    POST_CREATE_MARK_READ,
+    SEED_FOLDER_NAME,
+    SeedMessage,
+)
+
+if TYPE_CHECKING:
+    from office365.graph_client import GraphClient
+    from office365.outlook.mail.folders.folder import MailFolder
+    from office365.outlook.mail.messages.message import Message
+
+REQUIRED_ENV_VARS = ("MS_CLIENT_ID", "MS_CLIENT_CRED", "MS_TENANT_ID", "MS_USER_EMAIL")
+
+# Fixed, script-owned marker used as the idempotency key for every fixture this script creates.
+# The GUID has no meaning beyond namespacing this property away from anything else that might
+# set extended properties in the same mailbox; it must never change once fixtures exist under it,
+# or every existing fixture would look "absent" on the next run and get recreated as a duplicate.
+# Format matches Microsoft Graph's singleValueLegacyExtendedProperty id convention, confirmed
+# directly against the vendored client's own (unrelated) use of it in
+# office365/outlook/mail/messages/message.py Message.add_extended_property.
+_MARKER_GUID = "d529fed5-efc1-4260-86dd-4cbc201d634d"
+_MARKER_NAME = "UnsIngestFixtureId"
+MARKER_PROPERTY_ID = f"String {{{_MARKER_GUID}}} Name {_MARKER_NAME}"
+
+
+def _require_env_vars() -> dict[str, str]:
+    """Read required credentials from the environment, or fail loudly without exposing them.
+
+    Only variable *names* are ever printed here, never values.
+    """
+    missing = [name for name in REQUIRED_ENV_VARS if not os.environ.get(name)]
+    if missing:
+        print(
+            "FATAL: missing required environment variable(s): " + ", ".join(missing),
+            file=sys.stderr,
+        )
+        print(
+            "This script reads credentials from the environment only; set these and re-run.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return {name: os.environ[name] for name in REQUIRED_ENV_VARS}
+
+
+def _build_client(env: dict[str, str]) -> "GraphClient":
+    """Build an authenticated Graph client via the connector's own config/auth classes.
+
+    Reusing OutlookAccessConfig/OutlookConnectionConfig from the connector itself -- rather
+    than re-implementing MSAL token acquisition here -- means this script exercises the exact
+    same auth path the connector uses, and this script's own code never sees a raw token or
+    client secret; both stay inside the imported classes.
+    """
+    # Imported lazily so a missing/broken outlook extra fails inside _require_env_vars's
+    # caller with a normal traceback rather than at module import time.
+    from unstructured_ingest.processes.connectors.outlook import (
+        OutlookAccessConfig,
+        OutlookConnectionConfig,
+    )
+
+    connection_config = OutlookConnectionConfig(
+        access_config=OutlookAccessConfig(client_cred=env["MS_CLIENT_CRED"]),
+        client_id=env["MS_CLIENT_ID"],
+        tenant=env["MS_TENANT_ID"],
+    )
+    return connection_config.get_client()
+
+
+def _run(client: "GraphClient", description: str) -> None:
+    """Execute whatever Graph queries are currently queued on `client`.
+
+    A 403 here means the Azure AD app registration behind MS_CLIENT_ID does not hold (or has
+    not been granted tenant admin consent for) the permission this call needed. That is a
+    provisioning problem for whoever owns the app registration, not a bug in this script, so
+    it gets a distinct, loud message and its own exit code instead of a bare stack trace.
+    """
+    from office365.runtime.client_request_exception import ClientRequestException
+
+    try:
+        client.execute_query()
+    except ClientRequestException as exc:
+        status = getattr(exc.response, "status_code", None)
+        code = exc.code
+        if status == 403:
+            print(
+                f"FATAL while {description}: Microsoft Graph returned 403 Forbidden.",
+                file=sys.stderr,
+            )
+            print(
+                "A token was issued, so the credential is valid and this is not an expired "
+                "secret; the app it authenticates as is not permitted to write to this "
+                "mailbox. That is a provisioning problem, not a bug in this script.",
+                file=sys.stderr,
+            )
+            if code:
+                print(f"Graph error code: {code}", file=sys.stderr)
+            print(
+                "Check, in this order:\n"
+                "  1. Does the Client ID in MS_CLIENT_ID match the app registration where "
+                "Mail.ReadWrite was granted? Several registrations exist for this tenant, and "
+                "granting on the wrong one produces exactly this error.\n"
+                "  2. Is Mail.ReadWrite of type Application (not Delegated), and admin "
+                "consented?\n"
+                "  3. Is an Exchange ApplicationAccessPolicy scoping which mailboxes this app "
+                "may touch? A policy that excludes this mailbox returns ErrorAccessDenied even "
+                "when the role is correctly granted and consented.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        print(f"FATAL while {description}: Graph request failed (HTTP {status}).", file=sys.stderr)
+        if code:
+            print(f"Graph error code: {code}", file=sys.stderr)
+        raise
+
+
+def _find_seed_folder(client: "GraphClient", user_email: str) -> "MailFolder":
+    """Find SEED_FOLDER_NAME among the mailbox's root folders, case-insensitively.
+
+    Mirrors OutlookIndexer._get_selected_root_folders' own matching rule (outlook.py) so a
+    folder this script considers "found" is the same one the connector will read from. Uses
+    an explicit .top() beyond Graph's default page size, which that method does not, so this
+    lookup does not miss the folder in a mailbox with many root folders.
+    """
+    user = client.users[user_email]
+    root_folders = user.mail_folders
+    root_folders.get().top(999)
+    _run(client, "listing root mail folders")
+    for folder in root_folders:
+        if (folder.display_name or "").lower() == SEED_FOLDER_NAME.lower():
+            return folder
+    print(
+        f"FATAL: no root mail folder named '{SEED_FOLDER_NAME}' exists for {user_email}.",
+        file=sys.stderr,
+    )
+    print(
+        "This script only seeds fixtures into an existing folder; it does not create the "
+        "seed folder itself. Create it once (e.g. via Outlook) and re-run.",
+        file=sys.stderr,
+    )
+    sys.exit(3)
+
+
+def _fixture_exists(client: "GraphClient", folder: "MailFolder", slug: str) -> "Message | None":
+    """Return the existing fixture message for `slug`, or None if it has not been seeded yet.
+
+    Scoped to `folder` only (not recursive): every fixture this script creates ends up living
+    directly in the seed folder by the time creation finishes (MOVE_TARGET is moved there
+    explicitly; replies/forwards are moved there after creation -- see _create_reply_fixture /
+    _create_forward_fixture), so a non-recursive check of the seed folder is sufficient.
+    """
+    filter_expr = (
+        "singleValueExtendedProperties/Any(ep: ep/id eq '{}' and ep/value eq '{}')"
+    ).format(MARKER_PROPERTY_ID, slug)
+    matches = folder.messages
+    matches.get().filter(filter_expr).top(1)
+    _run(client, f"checking whether fixture '{slug}' already exists")
+    return matches[0] if len(matches) > 0 else None
+
+
+def _marker_property_value(slug: str) -> list[dict]:
+    """The singleValueExtendedProperties value (a one-item list) that tags a message as `slug`.
+
+    Deliberately not using the vendored client's own Message.add_extended_property(): it
+    mints a fresh random uuid4 as the property's GUID on every call (see
+    office365/outlook/mail/messages/message.py), which makes it useless as a *stable*,
+    later-queryable key. Building the property dict directly, keyed on one fixed, script-owned
+    GUID (MARKER_PROPERTY_ID), makes the same marker id findable on every future run.
+    """
+    return [{"id": MARKER_PROPERTY_ID, "value": slug}]
+
+
+def _marker_kwarg(slug: str) -> dict:
+    """The singleValueExtendedProperties kwarg to merge into a folder.messages.add(...) call."""
+    return {"singleValueExtendedProperties": _marker_property_value(slug)}
+
+
+def _create_reply_capturing_draft(original: "Message", comment: str) -> "Message":
+    """Create a reply draft off `original`, returning a handle to the NEW draft.
+
+    office365's own Message.create_reply() (message.py) builds a `return_type` object meant
+    to receive the createReply response, then returns `self` -- the ORIGINAL message --
+    instead of that return_type. Contrast with MailFolder.copy() in the same client, which
+    returns its own return_type correctly; create_reply's `return self` looks like an
+    oversight rather than an intentional fluent-interface choice. Calling .move() on
+    create_reply()'s return value would silently move the ORIGINAL seed message, not the new
+    reply. This reproduces the same call exactly, with only that return value fixed.
+    """
+    from office365.outlook.mail.messages.message import Message
+    from office365.runtime.queries.service_operation import ServiceOperationQuery
+
+    new_draft = Message(original.context)
+    qry = ServiceOperationQuery(
+        original, "createReply", None, {"comment": comment}, None, new_draft
+    )
+    original.context.add_query(qry)
+    return new_draft
+
+
+def _create_forward_capturing_draft(
+    original: "Message", to_recipients: list[str], comment: str
+) -> "Message":
+    """Create a forward draft off `original`, returning a handle to the NEW draft.
+
+    Same return-value bug as create_reply (see _create_reply_capturing_draft) in office365's
+    Message.create_forward(). Also note create_forward's own ToRecipients handling does not
+    convert plain email strings the way MessageCollection.add's to_recipients does -- it
+    expects Recipient objects already built, so Recipient.from_email is applied here.
+    """
+    from office365.outlook.mail.messages.message import Message
+    from office365.outlook.mail.recipient import Recipient
+    from office365.runtime.client_value_collection import ClientValueCollection
+    from office365.runtime.queries.service_operation import ServiceOperationQuery
+
+    new_draft = Message(original.context)
+    payload = {
+        "ToRecipients": ClientValueCollection(
+            Recipient, [Recipient.from_email(addr) for addr in to_recipients]
+        ),
+        "Message": None,
+        "Comment": comment,
+    }
+    qry = ServiceOperationQuery(original, "createForward", None, payload, None, new_draft)
+    original.context.add_query(qry)
+    return new_draft
+
+
+def _create_plain_fixture(
+    client: "GraphClient", folder: "MailFolder", fixture: SeedMessage
+) -> "Message":
+    from office365.outlook.mail.item_body import ItemBody
+
+    body = ItemBody(content=fixture.body_text, content_type=fixture.body_content_type)
+    msg = folder.messages.add(subject=fixture.subject, body=body, **_marker_kwarg(fixture.slug))
+    if fixture.attachment is not None:
+        msg.add_file_attachment(
+            name=fixture.attachment.filename,
+            content=fixture.attachment.text_content,
+            content_type=fixture.attachment.content_type,
+        )
+    _run(client, f"creating fixture '{fixture.slug}'")
+    return msg
+
+
+def _create_reply_fixture(
+    client: "GraphClient", folder: "MailFolder", fixture: SeedMessage, base: "Message"
+) -> "Message":
+    draft = _create_reply_capturing_draft(base, fixture.body_text)
+    _run(client, f"creating reply draft for fixture '{fixture.slug}'")
+
+    # Tag the marker in a follow-up call: createReply's request body only accepts `comment`,
+    # so the idempotency marker cannot be set in the same call that creates the draft.
+    draft.set_property("singleValueExtendedProperties", _marker_property_value(fixture.slug))
+    draft.update()
+    _run(client, f"tagging fixture '{fixture.slug}' with its idempotency marker")
+
+    # Always move the draft into the seed folder explicitly rather than trusting where Graph
+    # happened to place it: whether createReply's draft defaults into Drafts or next to the
+    # original was not confirmed against a live mailbox (see README "Open questions"), so this
+    # makes the end state correct either way instead of depending on that undocumented default.
+    draft.move(folder)
+    _run(client, f"moving fixture '{fixture.slug}' into {SEED_FOLDER_NAME}")
+    return draft
+
+
+def _create_forward_fixture(
+    client: "GraphClient",
+    folder: "MailFolder",
+    fixture: SeedMessage,
+    base: "Message",
+    user_email: str,
+) -> "Message":
+    # Forwarded to the same mailbox that owns it, so no second address needs to exist.
+    draft = _create_forward_capturing_draft(base, [user_email], fixture.body_text)
+    _run(client, f"creating forward draft for fixture '{fixture.slug}'")
+
+    draft.set_property("singleValueExtendedProperties", _marker_property_value(fixture.slug))
+    draft.update()
+    _run(client, f"tagging fixture '{fixture.slug}' with its idempotency marker")
+
+    draft.move(folder)
+    _run(client, f"moving fixture '{fixture.slug}' into {SEED_FOLDER_NAME}")
+    return draft
+
+
+def _create_staged_fixture(
+    client: "GraphClient", folder: "MailFolder", fixture: SeedMessage, user_email: str
+) -> "Message":
+    from office365.outlook.mail.item_body import ItemBody
+
+    staging_folder = client.users[user_email].mail_folders[fixture.stage_in_well_known_folder]
+    body = ItemBody(content=fixture.body_text, content_type=fixture.body_content_type)
+    msg = staging_folder.messages.add(
+        subject=fixture.subject, body=body, **_marker_kwarg(fixture.slug)
+    )
+    _run(client, f"creating fixture '{fixture.slug}' in {fixture.stage_in_well_known_folder}")
+
+    msg.move(folder)
+    _run(client, f"moving fixture '{fixture.slug}' into {SEED_FOLDER_NAME}")
+    return msg
+
+
+def _apply_post_create_actions(client: "GraphClient", fixture: SeedMessage, msg: "Message") -> None:
+    if not fixture.post_create_actions:
+        return
+    if POST_CREATE_MARK_READ in fixture.post_create_actions:
+        msg.set_property("isRead", True)
+    if POST_CREATE_FLAG in fixture.post_create_actions:
+        msg.set_property("flag", {"flagStatus": "flagged"})
+    if POST_CREATE_CATEGORIZE in fixture.post_create_actions:
+        msg.set_property("categories", ["unstructured-ingest-fixture"])
+    msg.update()
+    _run(client, f"applying post-create actions to fixture '{fixture.slug}'")
+
+
+def _seed_one(
+    client: "GraphClient",
+    folder: "MailFolder",
+    fixture: SeedMessage,
+    handles: dict[str, "Message"],
+    user_email: str,
+) -> None:
+    existing = _fixture_exists(client, folder, fixture.slug)
+    if existing is not None:
+        print(f"exists, skipping: {fixture.slug}")
+        handles[fixture.slug] = existing
+        return
+
+    print(f"creating: {fixture.slug}")
+    if fixture.reply_to is not None:
+        msg = _create_reply_fixture(client, folder, fixture, handles[fixture.reply_to])
+    elif fixture.forward_of is not None:
+        base = handles[fixture.forward_of]
+        msg = _create_forward_fixture(client, folder, fixture, base, user_email)
+    elif fixture.stage_in_well_known_folder is not None:
+        msg = _create_staged_fixture(client, folder, fixture, user_email)
+    else:
+        msg = _create_plain_fixture(client, folder, fixture)
+
+    _apply_post_create_actions(client, fixture, msg)
+    handles[fixture.slug] = msg
+
+
+def main() -> int:
+    env = _require_env_vars()
+    client = _build_client(env)
+    user_email = env["MS_USER_EMAIL"]
+
+    folder = _find_seed_folder(client, user_email)
+
+    handles: dict[str, "Message"] = {}
+    for fixture in ALL_FIXTURES:
+        _seed_one(client, folder, fixture, handles, user_email)
+
+    print(f"done: {len(ALL_FIXTURES)} fixture(s) confirmed present in {SEED_FOLDER_NAME}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_e2e/env_setup/outlook/seed_fixtures.py
+++ b/test_e2e/env_setup/outlook/seed_fixtures.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from fixtures import (  # noqa: E402
     ALL_FIXTURES,
+    DEFERRED_FIXTURES,
     POST_CREATE_CATEGORIZE,
     POST_CREATE_FLAG,
     POST_CREATE_MARK_READ,
@@ -115,25 +116,15 @@ def _run(client: "GraphClient", description: str) -> None:
                 file=sys.stderr,
             )
             print(
-                "A token was issued, so the credential is valid and this is not an expired "
-                "secret; the app it authenticates as is not permitted to write to this "
-                "mailbox. That is a provisioning problem, not a bug in this script.",
+                "The Azure AD app registration behind MS_CLIENT_ID does not currently hold "
+                "(or has not been granted tenant admin consent for) the Mail.ReadWrite "
+                "application permission this call needed. This is a provisioning problem "
+                "with the app registration, not a bug in this script -- fix the "
+                "registration's permissions/consent, then re-run.",
                 file=sys.stderr,
             )
             if code:
                 print(f"Graph error code: {code}", file=sys.stderr)
-            print(
-                "Check, in this order:\n"
-                "  1. Does the Client ID in MS_CLIENT_ID match the app registration where "
-                "Mail.ReadWrite was granted? Several registrations exist for this tenant, and "
-                "granting on the wrong one produces exactly this error.\n"
-                "  2. Is Mail.ReadWrite of type Application (not Delegated), and admin "
-                "consented?\n"
-                "  3. Is an Exchange ApplicationAccessPolicy scoping which mailboxes this app "
-                "may touch? A policy that excludes this mailbox returns ErrorAccessDenied even "
-                "when the role is correctly granted and consented.",
-                file=sys.stderr,
-            )
             sys.exit(2)
         print(f"FATAL while {description}: Graph request failed (HTTP {status}).", file=sys.stderr)
         if code:
@@ -333,7 +324,25 @@ def _apply_post_create_actions(client: "GraphClient", fixture: SeedMessage, msg:
     if POST_CREATE_MARK_READ in fixture.post_create_actions:
         msg.set_property("isRead", True)
     if POST_CREATE_FLAG in fixture.post_create_actions:
-        msg.set_property("flag", {"flagStatus": "flagged"})
+        from office365.outlook.mail.messages.followup_flag import FollowupFlag
+
+        # FollowupFlag's own constructor defaults completed/due/start_datetime to a fresh
+        # DateTimeTimeZone() rather than None (office365/outlook/mail/messages/followup_flag.py).
+        # A raw {"flagStatus": ...} dict passed to set_property() merges into that broken
+        # default instead of replacing it (ClientObject.set_property's dict branch), so every
+        # unset date field still serializes as a present-but-empty {} sub-object, and Graph
+        # rejects the implied empty timeZone with TimeZoneNotSupportedException. Passing a
+        # fully-constructed FollowupFlag with the three date fields explicitly nulled bypasses
+        # the broken default and sends only flagStatus, which is all this fixture wants.
+        msg.set_property(
+            "flag",
+            FollowupFlag(
+                flag_status="flagged",
+                completed_datetime=None,
+                due_datetime=None,
+                start_datetime=None,
+            ),
+        )
     if POST_CREATE_CATEGORIZE in fixture.post_create_actions:
         msg.set_property("categories", ["unstructured-ingest-fixture"])
     msg.update()
@@ -376,10 +385,38 @@ def main() -> int:
     folder = _find_seed_folder(client, user_email)
 
     handles: dict[str, "Message"] = {}
-    for fixture in ALL_FIXTURES:
-        _seed_one(client, folder, fixture, handles, user_email)
+    failed: list[str] = []
+    fixtures_to_seed = ALL_FIXTURES + (
+        DEFERRED_FIXTURES if os.environ.get("SEED_DEFERRED_FIXTURES") else ()
+    )
+    for fixture in fixtures_to_seed:
+        # A fixture whose base failed to seed has nothing to attach to; skip it without
+        # attempting the call at all, rather than letting it fail on a KeyError that would
+        # misreport as a problem of its own.
+        base_slug = fixture.reply_to or fixture.forward_of
+        if base_slug is not None and base_slug not in handles:
+            print(f"skipping (base '{base_slug}' did not seed): {fixture.slug}", file=sys.stderr)
+            failed.append(fixture.slug)
+            continue
+        try:
+            _seed_one(client, folder, fixture, handles, user_email)
+        except Exception as exc:
+            # A real provisioning problem (missing permission, missing seed folder) exits the
+            # process directly via sys.exit() inside _run() and is deliberately NOT caught here,
+            # since SystemExit does not subclass Exception. This only isolates one fixture's own
+            # Graph request failing, so the run still attempts every other fixture instead of
+            # aborting on the first surprise.
+            print(f"skipping '{fixture.slug}' after failure: {exc}", file=sys.stderr)
+            failed.append(fixture.slug)
 
-    print(f"done: {len(ALL_FIXTURES)} fixture(s) confirmed present in {SEED_FOLDER_NAME}")
+    seeded = len(fixtures_to_seed) - len(failed)
+    print(
+        f"done: {seeded}/{len(fixtures_to_seed)} fixture(s) confirmed present in "
+        f"{SEED_FOLDER_NAME}"
+    )
+    if failed:
+        print(f"NOT seeded, needs follow-up: {', '.join(failed)}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/test_e2e/src/outlook.sh
+++ b/test_e2e/src/outlook.sh
@@ -29,6 +29,11 @@ if [ -z "$MS_CLIENT_ID" ] || [ -z "$MS_CLIENT_CRED" ] || [ -z "$MS_TENANT_ID" ] 
   exit 8
 fi
 
+# Create-if-absent: guarantees the fixed set of fixture messages exists before indexing below.
+# A no-op on every run after the first; see env_setup/outlook/README.md for why seeding has to
+# be create-if-absent rather than tear-down-and-recreate, and for what this script fails on.
+PYTHONPATH=${PYTHONPATH:-.} "$SCRIPT_DIR"/env_setup/outlook/seed_fixtures.py
+
 RUN_SCRIPT=${RUN_SCRIPT:-./unstructured_ingest/main.py}
 PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
   outlook \
@@ -45,7 +50,7 @@ PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
   --client-id "$MS_CLIENT_ID" \
   --tenant "$MS_TENANT_ID" \
   --user-email "$MS_USER_EMAIL" \
-  --outlook-folders IntegrationTest \
+  --outlook-folders EmailsWithAttachments \
   --recursive \
   --work-dir "$WORK_DIR" \
   local \

--- a/test_e2e/test-src.sh
+++ b/test_e2e/test-src.sh
@@ -43,6 +43,7 @@ full_python_matrix_tests=(
   'google-drive.sh'
   'gcs.sh'
   'azure.sh'
+  'outlook.sh'
 )
 
 CURRENT_TEST="none"
@@ -61,7 +62,6 @@ python_version=$(python --version 2>&1)
 
 # TODO: remove lines committed with this comment once the tests are fixed
 tests_to_ignore=(
-  'outlook.sh'
   's3.sh'
   'azure.sh'
 )

--- a/test_e2e/test-src.sh
+++ b/test_e2e/test-src.sh
@@ -62,6 +62,10 @@ python_version=$(python --version 2>&1)
 
 # TODO: remove lines committed with this comment once the tests are fixed
 tests_to_ignore=(
+  # outlook runs so dispatch/nightly can regenerate fixtures and gather evidence,
+  # but its exit code stays non-enforcing while e2e enforcement consolidates in
+  # the orchestration repo
+  'outlook.sh'
   's3.sh'
   'azure.sh'
 )

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.11"  # pragma: no cover
+__version__ = "1.11.12"  # pragma: no cover


### PR DESCRIPTION
## Why

`outlook.sh` has not run in CI since the e2e jobs moved to Python 3.12 on 2026-02-06. `test-src.sh` only runs scripts outside `full_python_matrix_tests` when the interpreter is 3.10, and `outlook.sh` was never added to that array. It is *also* listed in `tests_to_ignore`, so even when it did run its exit code was discarded.

The result is the worst kind of green: `src_e2e_test` reports success while the Outlook connector is not exercised at all. As far as I can tell from the run history, there is no confirmed-passing run of this test in the repository.

## What this enables, and what it deliberately does not

The Python-version gate is removed, so nightly and dispatched runs actually execute `outlook.sh`, and the fixture-update workflow can regenerate `test_e2e/expected-structured-output` for Outlook for the first time. The `tests_to_ignore` entry **stays**: the test runs for fixture generation and evidence, but its exit code does not yet gate CI. Connector e2e enforcement is consolidating in the orchestration repo, so enforcing here would build a gate in the place it is being moved away from. If and when the team wants enforcement here after all, it is the one `tests_to_ignore` line.

## Why the gate could not just be flipped

Turning it on needs fixture mail that actually exists in the target mailbox and survives being re-run. The connector names each downloaded file `sha256(message.id)[:16] + ".eml"`, and `message.id` is Graph-assigned and unstable across a folder move. A tear-down-and-recreate seeding strategy would therefore churn every fixture filename on every run.

So seeding is **create-if-absent**, keyed on a fixed extended-property marker rather than on `message.id`.

## What is here

A seeding script under `test_e2e/env_setup/outlook/`, following the shape of the existing `env_setup` provisioning for airtable, couchbase and sftp. It authenticates through the connector's own connection config rather than reimplementing token handling, and it fails distinctly and immediately on a 403, because that specifically means the app registration is missing `Mail.ReadWrite` rather than anything being wrong with the script.

The seeded set is deliberately small and generic. Five fixtures seed successfully and reproducibly against the live mailbox today: a thread starter, a message carrying inline quoted history, one with a small attachment, a cross-folder move target, and a target for mutable state (read, flag, category). Attachments are kept trivial on purpose: they are partitioned through the live hosted API, so elaborate ones would make fixtures drift with that API's releases rather than with connector behaviour.

The two Graph-native threading fixtures, reply and forward, do **not** seed, and are deferred behind an opt-in `SEED_DEFERRED_FIXTURES=1`. `createReply` comes back as a Graph 400 `ErrorInvalidReferenceItem`, and `createForward` fails client-side inside the SDK with no HTTP response at all. Both happen when the base message was only ever created through the raw message-create API and never actually sent. The root cause is unconfirmed and Microsoft documents no such constraint, so the deferral is a parking spot rather than a diagnosis. The practical consequence is that a default seeding run seeds the five that work and exits zero, which is what `outlook.sh` requires, since it invokes the seeder under `set -e`.

Two robustness fixes fell out of getting there:

- `main()` isolates failures per fixture, so one fixture's Graph request failing no longer aborts the whole run. A genuine provisioning failure, such as a missing permission or a missing seed folder, still exits immediately.
- `FollowupFlag`'s own constructor defaults its three date sub-fields to empty `DateTimeTimeZone` objects, which Graph rejects with `TimeZoneNotSupportedException`. The fix nulls them explicitly so only `flagStatus` is sent.

Also in the diff: `test_e2e/src/outlook.sh` and `test_e2e/test-src.sh` (the invocation path; the python-matrix gate removed, the `tests_to_ignore` entry deliberately kept per the section above), the version bump to 1.11.11, and its `CHANGELOG.md` entry.

## Branch history

Rebased onto `main`, with the history rebuilt into four commits: the seeder plus the CI run-enable, the per-fixture fixes and the threading deferral, the version bump, and the non-enforcing exit-code hold. Nothing under `.github/` is touched by this branch.

## Sequencing

Lands after #802 and #803. #803 changes every fixture's expected-output filename (a hash of the message id) and #802 changes `data_source.version`, so fixtures generated before those merge would be regenerated again immediately.

## Before this can go green

The first seeding run creates messages whose Graph-assigned ids, and therefore whose fixture filenames, cannot be known in advance. `check-diff-expected-output.py` will fail until someone runs the suite once with `OVERWRITE_FIXTURES=true` against the live mailbox and commits the resulting fixture JSON. That is a deliberate two-step.

It is also not something this PR's own checks will show either way. The live e2e jobs in this repo never run on pull requests: they run nightly, on manual dispatch, and post-merge on push to `main`. And with the exit code non-enforcing, a seeding failure in those runs shows up in the run log and as missing fixture regeneration rather than as a red job — the distinct 403 fast-fail still prints, it just does not gate. The fixture regeneration is a separate deliberate step someone has to take.

Two things worth a reviewer's attention:

- **The app registration now holds `Mail.ReadWrite`** (creation) on top of `Mail.Read` (existence checks), with admin consent, and real mailbox writes have since succeeded against it. This no longer stalls on provisioning.
- **`test_e2e/src/outlook.sh` is edited** to invoke the seeder after its existing credential gate. Without that there is no invocation path at all, but it is the one change here that goes beyond test data and configuration.

## An upstream bug worth knowing about

In `office365-rest-python-client` 2.6.2, `Message.create_reply()` and `create_forward()` both return `self` rather than the draft they build internally, unlike `MailFolder.copy()` in the same version which returns its own object correctly. Used naively this silently operates on the wrong message. There is a small documented bypass helper for it here.

## Checks

`ruff check`, `ruff format --diff`, `py_compile`, `shellcheck` and `shfmt` via the repo's own recipe are clean on every touched file, plus zero-network smoke tests exercising each build path. The seeder has also been run against the live mailbox, where the five fixtures above seed reproducibly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



