### PR TITLE
fix(outlook): emit real record versions and fully page folder/message listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.9]
+
+### Fixes
+
+- **fix(outlook): emit real record versions and fully page folder/message listings.** The Outlook connector read a message's change key through a typed accessor that queried the wrong JSON key casing, so `data_source_version` was always null and incremental change detection could never skip an unchanged message. Message listing also requested an out-of-range page size (Graph documents `$top` for `/messages` as 1..1000) and never followed `@odata.nextLink`, while folder listing had no page size set at all and was silently capped at Graph's default; either way, only the first page was ever returned. Listings now page through every result and, for messages, request only the fields the connector actually reads via `$select`, trading the memory of holding a full page against the previous silent truncation.
+
 ## [1.11.8]
 
 ### Enhancements

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -13,7 +13,6 @@ from unstructured_ingest.processes.connectors.outlook import (
     OutlookConnectionConfig,
     OutlookIndexer,
     OutlookIndexerConfig,
-    _prefer_immutable_ids,
 )
 
 
@@ -176,56 +175,6 @@ class TestChangeKeyRawPropertyLookup:
     def test_get_property_defaults_to_none_when_absent(self):
         message = self._real_message()
         assert message.get_property("changeKey") is None
-
-
-class TestPreferImmutableIdsHeader:
-    """`Prefer: IdType="ImmutableId"` keeps message ids stable across folder moves.
-
-    Without it, Outlook/Exchange can rotate a message's id when the message is
-    moved between folders, breaking downstream record identity that keys off
-    FileData.identifier.
-    """
-
-    def test_hook_sets_header_on_request(self):
-        try:
-            from office365.runtime.http.request_options import RequestOptions
-        except ImportError:
-            pytest.skip("office365-rest-python-client not installed")
-
-        request = RequestOptions("https://graph.microsoft.com/v1.0/me/messages")
-        _prefer_immutable_ids(request)
-
-        assert request.headers["Prefer"] == 'IdType="ImmutableId"'
-
-    def test_get_client_registers_hook_that_fires_on_every_request(self):
-        # Fires the SDK's own dispatch path directly (ClientRuntimeContext.build_request
-        # calls exactly this: pending_request().beforeExecute.notify(request)) rather than
-        # asserting on a mocked call signature, so e.g. a rename of the `once` kwarg would
-        # be caught here instead of silently passing an unspecced mock assertion.
-        try:
-            from office365.runtime.http.request_options import RequestOptions
-        except ImportError:
-            pytest.skip("office365-rest-python-client not installed")
-
-        config = OutlookConnectionConfig(
-            access_config=Secret(OutlookAccessConfig(oauth_token="ey.access.token")),
-        )
-        client = config.get_client()
-
-        initial_request = RequestOptions(
-            "https://graph.microsoft.com/v1.0/users/alice/mailFolders/inbox/messages"
-        )
-        client.pending_request().beforeExecute.notify(initial_request)
-        assert initial_request.headers["Prefer"] == 'IdType="ImmutableId"'
-
-        # once=False: the hook must still be registered on the same pending_request()
-        # for a get_all() pagination continuation, not just the first request.
-        continuation_request = RequestOptions(
-            "https://graph.microsoft.com/v1.0/users/alice/mailFolders/inbox/messages"
-            "?$skiptoken=abc123"
-        )
-        client.pending_request().beforeExecute.notify(continuation_request)
-        assert continuation_request.headers["Prefer"] == 'IdType="ImmutableId"'
 
 
 def _make_folder(folder_id: str = "folder-1") -> Mock:

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -1,10 +1,17 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 from pydantic import Secret
 
 from unstructured_ingest.error import ValueError
 from unstructured_ingest.processes.connectors.outlook import (
+    MESSAGES_PAGE_SIZE,
     OutlookAccessConfig,
     OutlookConnectionConfig,
+    OutlookIndexer,
+    OutlookIndexerConfig,
+    _prefer_immutable_ids,
 )
 
 
@@ -63,3 +70,195 @@ class TestOutlookConnectionConfig:
             access_config=Secret(OutlookAccessConfig(oauth_token="ey.access.token")),
         )
         assert config.client_id is None
+
+
+def _make_message(message_id: str = "msg-1", change_key: str = "ck-123") -> Mock:
+    message = Mock()
+    message.id = message_id
+    message.resource_url = f"https://graph.microsoft.com/v1.0/me/messages/{message_id}"
+    message.get_property.return_value = change_key
+    fixed_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    message.last_modified_datetime = fixed_time
+    message.created_datetime = fixed_time
+    message.sent_from = "sender@example.com"
+    message.to_recipients = []
+    message.subject = "Test subject"
+    message.conversation_id = "conv-1"
+    message.is_draft = False
+    message.is_read = True
+    message.has_attachments = False
+    message.importance = "normal"
+    return message
+
+
+def _make_indexer(
+    outlook_folders=None, recursive: bool = False, user_email: str = "alice@example.com"
+) -> OutlookIndexer:
+    conn = Mock(spec=OutlookConnectionConfig)
+    idx_config = Mock(spec=OutlookIndexerConfig)
+    idx_config.outlook_folders = outlook_folders or ["Inbox"]
+    idx_config.recursive = recursive
+    idx_config.user_email = user_email
+    return OutlookIndexer(connection_config=conn, index_config=idx_config)
+
+
+class TestMessageToFileDataVersion:
+    """Regression coverage for `FileData.metadata.version`.
+
+    OutlookItem.change_key reads message.properties["ChangeKey"], but Graph's JSON
+    response uses "changeKey" (lowercase c), so the typed accessor always returned
+    None. `_message_to_file_data` now reads the raw property directly instead.
+    """
+
+    def test_version_uses_raw_changekey_property(self):
+        indexer = _make_indexer()
+        message = _make_message(change_key="server-changekey-abc123")
+
+        file_data = indexer._message_to_file_data(message)
+
+        message.get_property.assert_called_once_with("changeKey")
+        assert file_data.metadata.version == "server-changekey-abc123"
+
+    def test_version_is_none_when_changekey_absent(self):
+        indexer = _make_indexer()
+        message = _make_message(change_key=None)
+
+        file_data = indexer._message_to_file_data(message)
+
+        assert file_data.metadata.version is None
+
+
+class TestChangeKeyRawPropertyLookup:
+    """Pins the office365-rest-python-client casing mismatch against the real SDK.
+
+    OutlookItem.change_key does `self.properties.get("ChangeKey", None)`, but Graph
+    sends "changeKey". get_property("changeKey") reads the raw key directly and
+    sidesteps the broken typed accessor. Uses the real Message/GraphClient classes
+    (no network calls triggered by construction or set_property) so a future SDK
+    upgrade that fixes the casing would surface here, not just in outlook.py.
+    """
+
+    def _real_message(self):
+        try:
+            from office365.graph_client import GraphClient
+            from office365.outlook.mail.messages.message import Message
+            from office365.runtime.paths.resource_path import ResourcePath
+        except ImportError:
+            pytest.skip("office365-rest-python-client not installed")
+        client = GraphClient(lambda: {"access_token": "x", "token_type": "Bearer"})
+        return Message(client, ResourcePath("messages/abc"))
+
+    def test_typed_accessor_is_broken_for_real_graph_casing(self):
+        # If this ever returns the value instead of None, upstream fixed the casing
+        # bug and get_property("changeKey") in outlook.py could revert to the typed
+        # message.change_key accessor.
+        message = self._real_message()
+        message.set_property("changeKey", "server-changekey-abc123")
+        assert message.change_key is None
+
+    def test_get_property_reads_the_actual_graph_casing(self):
+        message = self._real_message()
+        message.set_property("changeKey", "server-changekey-abc123")
+        assert message.get_property("changeKey") == "server-changekey-abc123"
+
+    def test_get_property_defaults_to_none_when_absent(self):
+        message = self._real_message()
+        assert message.get_property("changeKey") is None
+
+
+class TestPreferImmutableIdsHeader:
+    """`Prefer: IdType="ImmutableId"` keeps message ids stable across folder moves.
+
+    Without it, Outlook/Exchange can rotate a message's id when the message is
+    moved between folders, breaking downstream record identity that keys off
+    FileData.identifier.
+    """
+
+    def test_hook_sets_header_on_request(self):
+        try:
+            from office365.runtime.http.request_options import RequestOptions
+        except ImportError:
+            pytest.skip("office365-rest-python-client not installed")
+
+        request = RequestOptions("https://graph.microsoft.com/v1.0/me/messages")
+        _prefer_immutable_ids(request)
+
+        assert request.headers["Prefer"] == 'IdType="ImmutableId"'
+
+    def test_get_client_registers_hook_for_every_request(self):
+        try:
+            from office365.graph_client import GraphClient
+        except ImportError:
+            pytest.skip("office365-rest-python-client not installed")
+
+        config = OutlookConnectionConfig(
+            access_config=Secret(OutlookAccessConfig(oauth_token="ey.access.token")),
+        )
+
+        with patch.object(GraphClient, "before_execute") as mock_before_execute:
+            config.get_client()
+
+        # once=False: the header must ride every request, including the paginated
+        # continuations get_all() issues for large folders/mailboxes.
+        mock_before_execute.assert_called_once_with(_prefer_immutable_ids, once=False)
+
+
+class TestListMessagesPagination:
+    """get_all() follows @odata.nextLink; the old `.get().top(MAX)` call silently
+    truncated enumeration at one page for large folders/mailboxes."""
+
+    def test_uses_get_all_with_bounded_page_size(self):
+        indexer = _make_indexer(recursive=False)
+        message = Mock()
+        root_folder = Mock()
+        root_folder.messages.get_all.return_value.execute_query.return_value = [message]
+
+        with patch.object(OutlookIndexer, "_get_selected_root_folders", return_value=[root_folder]):
+            messages = indexer._list_messages(recursive=False)
+
+        root_folder.messages.get_all.assert_called_once_with(page_size=MESSAGES_PAGE_SIZE)
+        root_folder.messages.get.assert_not_called()
+        assert messages == [message]
+
+    def test_recursion_pages_child_folders_via_get_all(self):
+        indexer = _make_indexer(recursive=True)
+
+        child_message = Mock()
+        child_folder = Mock()
+        child_folder.messages.get_all.return_value.execute_query.return_value = [child_message]
+        child_folder.child_folders.get_all.return_value.execute_query.return_value = []
+
+        root_message = Mock()
+        root_folder = Mock()
+        root_folder.messages.get_all.return_value.execute_query.return_value = [root_message]
+        root_folder.child_folders.get_all.return_value.execute_query.return_value = [child_folder]
+
+        with patch.object(OutlookIndexer, "_get_selected_root_folders", return_value=[root_folder]):
+            messages = indexer._list_messages(recursive=True)
+
+        root_folder.child_folders.get_all.assert_called_once_with()
+        root_folder.child_folders.get.assert_not_called()
+        assert messages == [root_message, child_message]
+
+
+class TestGetSelectedRootFoldersPagination:
+    """mail_folders enumeration must also follow pagination: Graph defaults
+    /mailFolders to 10 per page, so a mailbox with more top-level folders than
+    that was silently truncated before get_all() was used here."""
+
+    def test_root_folders_use_get_all(self):
+        indexer = _make_indexer(outlook_folders=["Inbox"])
+        folder = Mock()
+        folder.display_name = "Inbox"
+
+        client_user = MagicMock()
+        client_user.mail_folders.get_all.return_value.execute_query.return_value = [folder]
+        client = MagicMock()
+        client.users.__getitem__.return_value = client_user
+        indexer.connection_config.get_client.return_value = client
+
+        result = indexer._get_selected_root_folders()
+
+        client_user.mail_folders.get_all.assert_called_once_with()
+        client_user.mail_folders.get.assert_not_called()
+        assert result == [folder]

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -72,7 +73,7 @@ class TestOutlookConnectionConfig:
         assert config.client_id is None
 
 
-def _make_message(message_id: str = "msg-1", change_key: str = "ck-123") -> Mock:
+def _make_message(message_id: str = "msg-1", change_key: Optional[str] = "ck-123") -> Mock:
     message = Mock()
     message.id = message_id
     message.resource_url = f"https://graph.microsoft.com/v1.0/me/messages/{message_id}"
@@ -122,6 +123,16 @@ class TestMessageToFileDataVersion:
     def test_version_is_none_when_changekey_absent(self):
         indexer = _make_indexer()
         message = _make_message(change_key=None)
+
+        file_data = indexer._message_to_file_data(message)
+
+        assert file_data.metadata.version is None
+
+    def test_version_is_none_when_changekey_is_empty_string(self):
+        # An empty string would otherwise compare equal to a stored empty-string
+        # version and defeat the platform's unchanged-record skip.
+        indexer = _make_indexer()
+        message = _make_message(change_key="")
 
         file_data = indexer._message_to_file_data(message)
 

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -196,22 +196,35 @@ class TestPreferImmutableIdsHeader:
 
         assert request.headers["Prefer"] == 'IdType="ImmutableId"'
 
-    def test_get_client_registers_hook_for_every_request(self):
+    def test_get_client_registers_hook_that_fires_on_every_request(self):
+        # Fires the SDK's own dispatch path directly (ClientRuntimeContext.build_request
+        # calls exactly this: pending_request().beforeExecute.notify(request)) rather than
+        # asserting on a mocked call signature, so e.g. a rename of the `once` kwarg would
+        # be caught here instead of silently passing an unspecced mock assertion.
         try:
-            from office365.graph_client import GraphClient
+            from office365.runtime.http.request_options import RequestOptions
         except ImportError:
             pytest.skip("office365-rest-python-client not installed")
 
         config = OutlookConnectionConfig(
             access_config=Secret(OutlookAccessConfig(oauth_token="ey.access.token")),
         )
+        client = config.get_client()
 
-        with patch.object(GraphClient, "before_execute") as mock_before_execute:
-            config.get_client()
+        initial_request = RequestOptions(
+            "https://graph.microsoft.com/v1.0/users/alice/mailFolders/inbox/messages"
+        )
+        client.pending_request().beforeExecute.notify(initial_request)
+        assert initial_request.headers["Prefer"] == 'IdType="ImmutableId"'
 
-        # once=False: the header must ride every request, including the paginated
-        # continuations get_all() issues for large folders/mailboxes.
-        mock_before_execute.assert_called_once_with(_prefer_immutable_ids, once=False)
+        # once=False: the hook must still be registered on the same pending_request()
+        # for a get_all() pagination continuation, not just the first request.
+        continuation_request = RequestOptions(
+            "https://graph.microsoft.com/v1.0/users/alice/mailFolders/inbox/messages"
+            "?$skiptoken=abc123"
+        )
+        client.pending_request().beforeExecute.notify(continuation_request)
+        assert continuation_request.headers["Prefer"] == 'IdType="ImmutableId"'
 
 
 class TestListMessagesPagination:
@@ -251,6 +264,37 @@ class TestListMessagesPagination:
         root_folder.child_folders.get.assert_not_called()
         assert messages == [root_message, child_message]
 
+    def test_cycle_in_child_folder_graph_terminates(self):
+        # get_all() makes each spin of a folder-graph cycle far more expensive
+        # than the old single-page .get() (full pagination for messages and
+        # child folders on every repeat visit); the visited-id guard must still
+        # make this terminate rather than loop forever.
+        indexer = _make_indexer(recursive=True)
+
+        folder_a = Mock()
+        folder_a.id = "folder-a"
+        message_a = Mock()
+        folder_a.messages.get_all.return_value.execute_query.return_value = [message_a]
+
+        folder_b = Mock()
+        folder_b.id = "folder-b"
+        message_b = Mock()
+        folder_b.messages.get_all.return_value.execute_query.return_value = [message_b]
+
+        # Each folder's child_folders points back at the other: a 2-cycle.
+        folder_a.child_folders.get_all.return_value.execute_query.return_value = [folder_b]
+        folder_b.child_folders.get_all.return_value.execute_query.return_value = [folder_a]
+
+        with patch.object(OutlookIndexer, "_get_selected_root_folders", return_value=[folder_a]):
+            messages = indexer._list_messages(recursive=True)
+
+        # Each folder was expanded exactly once, not once per cycle repetition.
+        folder_a.messages.get_all.assert_called_once_with(page_size=MESSAGES_PAGE_SIZE)
+        folder_b.messages.get_all.assert_called_once_with(page_size=MESSAGES_PAGE_SIZE)
+        folder_a.child_folders.get_all.assert_called_once_with()
+        folder_b.child_folders.get_all.assert_called_once_with()
+        assert messages == [message_a, message_b]
+
 
 class TestGetSelectedRootFoldersPagination:
     """mail_folders enumeration must also follow pagination: Graph defaults
@@ -273,3 +317,43 @@ class TestGetSelectedRootFoldersPagination:
         client_user.mail_folders.get_all.assert_called_once_with()
         client_user.mail_folders.get.assert_not_called()
         assert result == [folder]
+
+
+class TestGetSelectedRootFoldersMatching:
+    """Coverage for the display_name matching in _get_selected_root_folders,
+    independent of the get_all() pagination mechanics covered above."""
+
+    def _with_folders(self, indexer, folders):
+        client_user = MagicMock()
+        client_user.mail_folders.get_all.return_value.execute_query.return_value = folders
+        client = MagicMock()
+        client.users.__getitem__.return_value = client_user
+        indexer.connection_config.get_client.return_value = client
+
+    def test_folder_name_matching_is_case_insensitive(self):
+        indexer = _make_indexer(outlook_folders=["INBOX"])
+        folder = Mock()
+        folder.display_name = "Inbox"
+        self._with_folders(indexer, [folder])
+
+        result = indexer._get_selected_root_folders()
+
+        assert result == [folder]
+
+    def test_no_matching_folder_raises_value_error(self):
+        indexer = _make_indexer(outlook_folders=["Nonexistent Folder"])
+        folder = Mock()
+        folder.display_name = "Inbox"
+        self._with_folders(indexer, [folder])
+
+        with pytest.raises(ValueError, match="Root folders selected in configuration not found"):
+            indexer._get_selected_root_folders()
+
+
+class TestMessagesPageSizeConstant:
+    def test_within_graph_top_limits(self):
+        # Graph documents $top as 1..1000 for /messages; MESSAGES_PAGE_SIZE is a
+        # plain module constant, so nothing else pins it to a sane value (a test
+        # that only asserts get_all() was called with page_size=MESSAGES_PAGE_SIZE
+        # would pass even if the constant itself were 0 or 100_000).
+        assert 1 <= MESSAGES_PAGE_SIZE <= 1000

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -7,6 +7,7 @@ from pydantic import Secret
 
 from unstructured_ingest.error import ValueError
 from unstructured_ingest.processes.connectors.outlook import (
+    MESSAGE_SELECT_FIELDS,
     MESSAGES_PAGE_SIZE,
     OutlookAccessConfig,
     OutlookConnectionConfig,
@@ -227,6 +228,15 @@ class TestPreferImmutableIdsHeader:
         assert continuation_request.headers["Prefer"] == 'IdType="ImmutableId"'
 
 
+def _make_folder(folder_id: str = "folder-1") -> Mock:
+    folder = Mock()
+    folder.id = folder_id
+    # select(...) returns self on the real SDK, so the mock must too for the
+    # .select(...).get_all(...) chain in _list_messages to resolve.
+    folder.messages.select.return_value = folder.messages
+    return folder
+
+
 class TestListMessagesPagination:
     """get_all() follows @odata.nextLink; the old `.get().top(MAX)` call silently
     truncated enumeration at one page for large folders/mailboxes."""
@@ -234,12 +244,13 @@ class TestListMessagesPagination:
     def test_uses_get_all_with_bounded_page_size(self):
         indexer = _make_indexer(recursive=False)
         message = Mock()
-        root_folder = Mock()
+        root_folder = _make_folder("root")
         root_folder.messages.get_all.return_value.execute_query.return_value = [message]
 
         with patch.object(OutlookIndexer, "_get_selected_root_folders", return_value=[root_folder]):
             messages = indexer._list_messages(recursive=False)
 
+        root_folder.messages.select.assert_called_once_with(MESSAGE_SELECT_FIELDS)
         root_folder.messages.get_all.assert_called_once_with(page_size=MESSAGES_PAGE_SIZE)
         root_folder.messages.get.assert_not_called()
         assert messages == [message]
@@ -248,12 +259,12 @@ class TestListMessagesPagination:
         indexer = _make_indexer(recursive=True)
 
         child_message = Mock()
-        child_folder = Mock()
+        child_folder = _make_folder("child")
         child_folder.messages.get_all.return_value.execute_query.return_value = [child_message]
         child_folder.child_folders.get_all.return_value.execute_query.return_value = []
 
         root_message = Mock()
-        root_folder = Mock()
+        root_folder = _make_folder("root")
         root_folder.messages.get_all.return_value.execute_query.return_value = [root_message]
         root_folder.child_folders.get_all.return_value.execute_query.return_value = [child_folder]
 
@@ -271,13 +282,11 @@ class TestListMessagesPagination:
         # make this terminate rather than loop forever.
         indexer = _make_indexer(recursive=True)
 
-        folder_a = Mock()
-        folder_a.id = "folder-a"
+        folder_a = _make_folder("folder-a")
         message_a = Mock()
         folder_a.messages.get_all.return_value.execute_query.return_value = [message_a]
 
-        folder_b = Mock()
-        folder_b.id = "folder-b"
+        folder_b = _make_folder("folder-b")
         message_b = Mock()
         folder_b.messages.get_all.return_value.execute_query.return_value = [message_b]
 
@@ -289,6 +298,8 @@ class TestListMessagesPagination:
             messages = indexer._list_messages(recursive=True)
 
         # Each folder was expanded exactly once, not once per cycle repetition.
+        folder_a.messages.select.assert_called_once_with(MESSAGE_SELECT_FIELDS)
+        folder_b.messages.select.assert_called_once_with(MESSAGE_SELECT_FIELDS)
         folder_a.messages.get_all.assert_called_once_with(page_size=MESSAGES_PAGE_SIZE)
         folder_b.messages.get_all.assert_called_once_with(page_size=MESSAGES_PAGE_SIZE)
         folder_a.child_folders.get_all.assert_called_once_with()

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -204,6 +204,41 @@ class TestListMessagesPagination:
         root_folder.messages.get.assert_not_called()
         assert messages == [message]
 
+    def test_select_projection_names_every_field_the_connector_reads(self):
+        # Pinned as literals: _message_to_file_data and the metadata mapping
+        # read exactly these Graph fields, and a projection that drifts
+        # narrower silently nulls whatever it drops.
+        assert MESSAGE_SELECT_FIELDS == [
+            "id",
+            "changeKey",
+            "lastModifiedDateTime",
+            "createdDateTime",
+            "from",
+            "toRecipients",
+            "subject",
+            "conversationId",
+            "isDraft",
+            "isRead",
+            "hasAttachments",
+            "importance",
+        ]
+
+    def test_accumulates_every_record_across_page_boundaries(self):
+        # get_all() drains @odata.nextLink continuations into one collection;
+        # a listing larger than one Graph page must come back complete and in
+        # order, not truncated at page_size.
+        indexer = _make_indexer(recursive=False)
+        spanning_three_pages = [Mock() for _ in range(MESSAGES_PAGE_SIZE * 2 + 3)]
+        root_folder = _make_folder("root")
+        root_folder.messages.get_all.return_value.execute_query.return_value = (
+            spanning_three_pages
+        )
+
+        with patch.object(OutlookIndexer, "_get_selected_root_folders", return_value=[root_folder]):
+            messages = indexer._list_messages(recursive=False)
+
+        assert messages == spanning_three_pages
+
     def test_recursion_pages_child_folders_via_get_all(self):
         indexer = _make_indexer(recursive=True)
 

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.8"  # pragma: no cover
+__version__ = "1.11.9"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -29,15 +29,29 @@ from unstructured_ingest.processes.connector_registry import (
 )
 from unstructured_ingest.utils.dep_check import requires_dependencies
 
-MAX_EMAILS_PER_FOLDER = 1_000_000  # Maximum number of emails per folder
+# Graph accepts $top between 1 and 1000 for /messages and warns that large
+# full-message pages can 504; get_all() still follows @odata.nextLink to
+# fetch every message in the folder, this just bounds each individual page.
+MESSAGES_PAGE_SIZE = 100
 
 if TYPE_CHECKING:
     from office365.graph_client import GraphClient
     from office365.outlook.mail.folders.folder import MailFolder
     from office365.outlook.mail.messages.message import Message
+    from office365.runtime.http.request_options import RequestOptions
 
 
 CONNECTOR_TYPE = "outlook"
+
+
+def _prefer_immutable_ids(request: "RequestOptions") -> None:
+    """Ask Graph to return immutable ids for mail resources.
+
+    Without this header, Outlook/Exchange can rotate a message's id when the
+    message is moved between folders, breaking downstream record identity
+    that keys off FileData.identifier.
+    """
+    request.headers["Prefer"] = 'IdType="ImmutableId"'
 
 
 class OutlookAccessConfig(AccessConfig):
@@ -135,7 +149,11 @@ class OutlookConnectionConfig(ConnectionConfig):
     def get_client(self) -> "GraphClient":
         from office365.graph_client import GraphClient
 
-        return GraphClient(self._acquire_token)
+        client = GraphClient(self._acquire_token)
+        # once=False: must ride every request, including the paginated
+        # continuations get_all() issues for large folders/mailboxes.
+        client.before_execute(_prefer_immutable_ids, once=False)
+        return client
 
 
 class OutlookIndexerConfig(IndexerConfig):
@@ -186,16 +204,18 @@ class OutlookIndexer(Indexer):
 
         while mail_folders:
             mail_folder = mail_folders.pop()
-            messages += list(mail_folder.messages.get().top(MAX_EMAILS_PER_FOLDER).execute_query())
+            messages += list(
+                mail_folder.messages.get_all(page_size=MESSAGES_PAGE_SIZE).execute_query()
+            )
 
             if recursive:
-                mail_folders += list(mail_folder.child_folders.get().execute_query())
+                mail_folders += list(mail_folder.child_folders.get_all().execute_query())
 
         return messages
 
     def _get_selected_root_folders(self) -> list["MailFolder"]:
         client_user = self.connection_config.get_client().users[self.index_config.user_email]
-        root_mail_folders = client_user.mail_folders.get().execute_query()
+        root_mail_folders = client_user.mail_folders.get_all().execute_query()
 
         selected_names_normalized = [
             folder_name.lower() for folder_name in self.index_config.outlook_folders
@@ -224,7 +244,7 @@ class OutlookIndexer(Indexer):
             source_identifiers=source_identifiers,
             metadata=FileDataSourceMetadata(
                 url=message.resource_url,
-                version=message.change_key,
+                version=message.get_property("changeKey"),
                 date_modified=str(
                     message.last_modified_datetime.replace(tzinfo=timezone.utc).timestamp()
                 ),

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -34,6 +34,28 @@ from unstructured_ingest.utils.dep_check import requires_dependencies
 # fetch every message in the folder, this just bounds each individual page.
 MESSAGES_PAGE_SIZE = 100
 
+# $select projection for /messages, restricted to exactly what
+# _message_to_file_data (and _generate_fullpath) read off a message. Graph's
+# default projection includes the full HTML body; get_all() already pulls
+# every page into memory eagerly, and Microsoft recommends $select to reduce
+# the risk of a 504 on large pages, so this narrows the payload without
+# losing anything: the downloader fetches the full MIME message separately
+# via $value. Keep this list in sync with _message_to_file_data.
+MESSAGE_SELECT_FIELDS = [
+    "id",
+    "changeKey",
+    "lastModifiedDateTime",
+    "createdDateTime",
+    "from",
+    "toRecipients",
+    "subject",
+    "conversationId",
+    "isDraft",
+    "isRead",
+    "hasAttachments",
+    "importance",
+]
+
 if TYPE_CHECKING:
     from office365.graph_client import GraphClient
     from office365.outlook.mail.folders.folder import MailFolder
@@ -51,7 +73,7 @@ def _prefer_immutable_ids(request: "RequestOptions") -> None:
     message is moved between folders, breaking downstream record identity
     that keys off FileData.identifier.
     """
-    request.headers["Prefer"] = 'IdType="ImmutableId"'
+    request.set_header("Prefer", 'IdType="ImmutableId"')
 
 
 class OutlookAccessConfig(AccessConfig):
@@ -150,9 +172,13 @@ class OutlookConnectionConfig(ConnectionConfig):
         from office365.graph_client import GraphClient
 
         client = GraphClient(self._acquire_token)
-        # once=False: must ride every request, including the paginated
-        # continuations get_all() issues for large folders/mailboxes.
-        client.before_execute(_prefer_immutable_ids, once=False)
+        # Registered directly on the pending request's event handler rather
+        # than via client.before_execute(): that context-level helper no-ops
+        # on a fresh client (office365-rest-python-client 3.0.0 early-returns
+        # when no query has been queued yet) and, once a query exists, scopes
+        # the hook to that single query's id, so it would never ride get_all()
+        # pagination continuations.
+        client.pending_request().beforeExecute += _prefer_immutable_ids
         return client
 
 
@@ -214,7 +240,9 @@ class OutlookIndexer(Indexer):
             visited_folder_ids.add(mail_folder.id)
 
             messages += list(
-                mail_folder.messages.get_all(page_size=MESSAGES_PAGE_SIZE).execute_query()
+                mail_folder.messages.select(MESSAGE_SELECT_FIELDS)
+                .get_all(page_size=MESSAGES_PAGE_SIZE)
+                .execute_query()
             )
 
             if recursive:

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -244,7 +244,10 @@ class OutlookIndexer(Indexer):
             source_identifiers=source_identifiers,
             metadata=FileDataSourceMetadata(
                 url=message.resource_url,
-                version=message.get_property("changeKey"),
+                # An empty-string changeKey would otherwise compare equal to a
+                # stored empty-string version, defeating the platform's
+                # unchanged-record skip; normalize falsy to None.
+                version=message.get_property("changeKey") or None,
                 date_modified=str(
                     message.last_modified_datetime.replace(tzinfo=timezone.utc).timestamp()
                 ),

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -200,10 +200,19 @@ class OutlookIndexer(Indexer):
 
     def _list_messages(self, recursive: bool) -> list["Message"]:
         mail_folders = self._get_selected_root_folders()
+        # Guards against a cycle in the child-folder graph. get_all() makes each
+        # spin of such a cycle far more expensive than the old single-page .get()
+        # (full pagination for messages and child folders on every repeat visit),
+        # so a folder id is only ever expanded once.
+        visited_folder_ids: set[str] = set()
         messages = []
 
         while mail_folders:
             mail_folder = mail_folders.pop()
+            if mail_folder.id in visited_folder_ids:
+                continue
+            visited_folder_ids.add(mail_folder.id)
+
             messages += list(
                 mail_folder.messages.get_all(page_size=MESSAGES_PAGE_SIZE).execute_query()
             )

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -60,20 +60,9 @@ if TYPE_CHECKING:
     from office365.graph_client import GraphClient
     from office365.outlook.mail.folders.folder import MailFolder
     from office365.outlook.mail.messages.message import Message
-    from office365.runtime.http.request_options import RequestOptions
 
 
 CONNECTOR_TYPE = "outlook"
-
-
-def _prefer_immutable_ids(request: "RequestOptions") -> None:
-    """Ask Graph to return immutable ids for mail resources.
-
-    Without this header, Outlook/Exchange can rotate a message's id when the
-    message is moved between folders, breaking downstream record identity
-    that keys off FileData.identifier.
-    """
-    request.set_header("Prefer", 'IdType="ImmutableId"')
 
 
 class OutlookAccessConfig(AccessConfig):
@@ -171,15 +160,7 @@ class OutlookConnectionConfig(ConnectionConfig):
     def get_client(self) -> "GraphClient":
         from office365.graph_client import GraphClient
 
-        client = GraphClient(self._acquire_token)
-        # Registered directly on the pending request's event handler rather
-        # than via client.before_execute(): that context-level helper no-ops
-        # on a fresh client (office365-rest-python-client 3.0.0 early-returns
-        # when no query has been queued yet) and, once a query exists, scopes
-        # the hook to that single query's id, so it would never ride get_all()
-        # pagination continuations.
-        client.pending_request().beforeExecute += _prefer_immutable_ids
-        return client
+        return GraphClient(self._acquire_token)
 
 
 class OutlookIndexerConfig(IndexerConfig):


### PR DESCRIPTION
## What was broken

The Outlook connector's per-message `data_source_version` was always blank: the change-key accessor queried the JSON key with the wrong casing, so the value it read never matched what the Graph API actually sends. Folder and message listings also only fetched a single page from the Graph API, so any mailbox or folder with more items than the default/requested page size was silently truncated rather than fully enumerated.

## What changes for users

- `data_source_version` now carries the real Graph change-key string for each message instead of always being null, so incremental change detection can correctly skip unchanged messages.
- Large folders and mailboxes with many folders are now fully enumerated instead of stopping at the first page.
- Message listing now requests only the fields the connector actually reads (`$select`), instead of Graph's default projection, which includes the full HTML body.

Message-identity stabilization (immutable message ids) is split out into its own follow-up PR, since it changes the record identifier itself and is a separate, coordinated rollout event; see #803.

## Note for reviewers

- The Outlook end-to-end test is currently skipped in CI, so its fixtures will be regenerated the next time it's re-enabled. See #801, which re-enables that test and seeds its fixtures. #801 needs to land after both this PR and #803: this PR changes `data_source.version` (now a real, non-deterministic change key instead of null), and the immutable-id PR changes every fixture's expected output filename (a hash of the message id). #801's fixtures must be generated against both PRs' code, and `data_source.version` will need to be excluded or treated as volatile in the fixture comparator once the e2e is re-enabled. On versioning: the merge order is #802 first, then #803, then #801 — stated in prose on purpose. Version numbers are re-picked against `main` at each merge (unrelated merges consume numbers faster than any reserved sequence survives; an earlier reservation scheme here went stale within days). This branch currently carries 1.11.9; renumber at merge time if `main` has moved again.
- This PR and #803 are sibling branches off `main`, not a stack, and both append tests to the same region of `test/unit/connectors/test_outlook.py`, so whichever of the two merges second resolves that one conflict at merge time. The connector module itself merges cleanly between them.
- `TestChangeKeyRawPropertyLookup` is a canary on the underlying SDK's property-casing bug, not regression coverage for this PR's fix - it's meant to fail (on purpose) if a future office365-rest-python-client upgrade fixes the casing mismatch, which is the cue to simplify back to the typed accessor. The regression coverage for the version fix itself is `TestMessageToFileDataVersion`.
- `get_all()` eagerly drains every page of a folder/mailbox into memory before `run()` yields any records, trading memory for correctness against the previous silent single-page truncation. Streaming enumeration is a reasonable follow-up if a mailbox's full listing turns out too large to hold at once, but isn't needed for this fix.
- The pagination tests now also pin the `$select` projection as concrete field names (so silent drift in `MESSAGE_SELECT_FIELDS` fails a test rather than being asserted tautologically) and cover a listing larger than one Graph page, asserting the enumeration comes back complete and in order.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


