### PR TITLE
fix(outlook): use Graph's immutable id type for mail resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.10]
+
+### Fixes
+
+- **fix(outlook): use immutable message ids.** Outlook/Exchange can rotate a message's id when the message is moved between folders (including automatic moves, like a rule filing a message into a subfolder), which breaks downstream record identity for anything that keys off `FileData.identifier`. Every Graph request now carries `Prefer: IdType="ImmutableId"`, so message ids stay stable across folder moves. This is a one-time migration event: existing pipelines will fully re-index once on upgrade, since the immutable id format differs from the default id format and records written before the upgrade will not match records written after.
+
 ## [1.11.9]
 
 ### Fixes

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import datetime, timezone
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
@@ -138,6 +139,30 @@ class TestMessageToFileDataVersion:
         file_data = indexer._message_to_file_data(message)
 
         assert file_data.metadata.version is None
+
+
+class TestMessageToFileDataIdentity:
+    """The message id must reach every identity field unmodified.
+
+    FileData.identifier keys incremental record identity downstream, the
+    record_locator's message_id is how the downloader re-fetches the message,
+    and the download filename is derived from the id. Any normalization,
+    hashing, or re-derivation of the id here silently re-keys entire
+    mailboxes, which is exactly the failure mode immutable ids exist to
+    prevent.
+    """
+
+    def test_identity_fields_pass_through_message_id(self):
+        indexer = _make_indexer()
+        message = _make_message(message_id="msg-identity-1")
+
+        file_data = indexer._message_to_file_data(message)
+
+        assert file_data.identifier == "msg-identity-1"
+        assert file_data.metadata.record_locator["message_id"] == "msg-identity-1"
+        expected_name = hashlib.sha256(b"msg-identity-1").hexdigest()[:16] + ".eml"
+        assert file_data.source_identifiers.fullpath == expected_name
+        assert file_data.source_identifiers.filename == expected_name
 
 
 class TestChangeKeyRawPropertyLookup:

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -13,6 +13,7 @@ from unstructured_ingest.processes.connectors.outlook import (
     OutlookConnectionConfig,
     OutlookIndexer,
     OutlookIndexerConfig,
+    _prefer_immutable_ids,
 )
 
 
@@ -352,3 +353,53 @@ class TestMessagesPageSizeConstant:
         # that only asserts get_all() was called with page_size=MESSAGES_PAGE_SIZE
         # would pass even if the constant itself were 0 or 100_000).
         assert 1 <= MESSAGES_PAGE_SIZE <= 1000
+
+
+class TestPreferImmutableIdsHeader:
+    """`Prefer: IdType="ImmutableId"` keeps message ids stable across folder moves.
+
+    Without it, Outlook/Exchange can rotate a message's id when the message is
+    moved between folders, breaking downstream record identity that keys off
+    FileData.identifier.
+    """
+
+    def test_hook_sets_header_on_request(self):
+        try:
+            from office365.runtime.http.request_options import RequestOptions
+        except ImportError:
+            pytest.skip("office365-rest-python-client not installed")
+
+        request = RequestOptions("https://graph.microsoft.com/v1.0/me/messages")
+        _prefer_immutable_ids(request)
+
+        assert request.headers["Prefer"] == 'IdType="ImmutableId"'
+
+    def test_get_client_registers_hook_that_fires_on_every_request(self):
+        # Fires the SDK's own dispatch path directly (ClientRuntimeContext.build_request
+        # calls exactly this: pending_request().beforeExecute.notify(request)) rather than
+        # asserting on a mocked call signature, so e.g. a rename of the `once` kwarg would
+        # be caught here instead of silently passing an unspecced mock assertion.
+        try:
+            from office365.runtime.http.request_options import RequestOptions
+        except ImportError:
+            pytest.skip("office365-rest-python-client not installed")
+
+        config = OutlookConnectionConfig(
+            access_config=Secret(OutlookAccessConfig(oauth_token="ey.access.token")),
+        )
+        client = config.get_client()
+
+        initial_request = RequestOptions(
+            "https://graph.microsoft.com/v1.0/users/alice/mailFolders/inbox/messages"
+        )
+        client.pending_request().beforeExecute.notify(initial_request)
+        assert initial_request.headers["Prefer"] == 'IdType="ImmutableId"'
+
+        # The hook must still be registered on the same pending_request() for a
+        # get_all() pagination continuation, not just the first request.
+        continuation_request = RequestOptions(
+            "https://graph.microsoft.com/v1.0/users/alice/mailFolders/inbox/messages"
+            "?$skiptoken=abc123"
+        )
+        client.pending_request().beforeExecute.notify(continuation_request)
+        assert continuation_request.headers["Prefer"] == 'IdType="ImmutableId"'

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.9"  # pragma: no cover
+__version__ = "1.11.10"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -173,11 +173,12 @@ class OutlookConnectionConfig(ConnectionConfig):
 
         client = GraphClient(self._acquire_token)
         # Registered directly on the pending request's event handler rather
-        # than via client.before_execute(): that context-level helper no-ops
-        # on a fresh client (office365-rest-python-client 3.0.0 early-returns
-        # when no query has been queued yet) and, once a query exists, scopes
-        # the hook to that single query's id, so it would never ride get_all()
-        # pagination continuations.
+        # than via client.before_execute(): on the pinned 2.6.2 that
+        # context-level helper defaults to once=True, unregistering after the
+        # first request, and on 3.0.0 it additionally no-ops on a fresh client
+        # (early-returns when no query has been queued yet) and scopes the hook
+        # to the last queued query's id. Registering here rides every request,
+        # including get_all() pagination continuations, on both versions.
         client.pending_request().beforeExecute += _prefer_immutable_ids
         return client
 

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -60,9 +60,20 @@ if TYPE_CHECKING:
     from office365.graph_client import GraphClient
     from office365.outlook.mail.folders.folder import MailFolder
     from office365.outlook.mail.messages.message import Message
+    from office365.runtime.http.request_options import RequestOptions
 
 
 CONNECTOR_TYPE = "outlook"
+
+
+def _prefer_immutable_ids(request: "RequestOptions") -> None:
+    """Ask Graph to return immutable ids for mail resources.
+
+    Without this header, Outlook/Exchange can rotate a message's id when the
+    message is moved between folders, breaking downstream record identity
+    that keys off FileData.identifier.
+    """
+    request.set_header("Prefer", 'IdType="ImmutableId"')
 
 
 class OutlookAccessConfig(AccessConfig):
@@ -160,7 +171,15 @@ class OutlookConnectionConfig(ConnectionConfig):
     def get_client(self) -> "GraphClient":
         from office365.graph_client import GraphClient
 
-        return GraphClient(self._acquire_token)
+        client = GraphClient(self._acquire_token)
+        # Registered directly on the pending request's event handler rather
+        # than via client.before_execute(): that context-level helper no-ops
+        # on a fresh client (office365-rest-python-client 3.0.0 early-returns
+        # when no query has been queued yet) and, once a query exists, scopes
+        # the hook to that single query's id, so it would never ride get_all()
+        # pagination continuations.
+        client.pending_request().beforeExecute += _prefer_immutable_ids
+        return client
 
 
 class OutlookIndexerConfig(IndexerConfig):


### PR DESCRIPTION
## Why this is in the chain, and why now

This makes Graph's immutable id format the default for the Outlook connector, so a message keeps its id when it moves between folders inside the same mailbox.

It is a one-time identity change, and the cost is real: every Outlook record a deployment has already indexed gets a new id on the first run after upgrade, so that run reprocesses the mailbox and leaves one duplicate set of the old records behind at every destination. The full blast radius is documented below.

The reason to take it now rather than later is that waiting does not shrink that cost, and right now it is as small as it will ever be. The Outlook connector has never been eligible for incremental processing on the platform side, so there is no incremental state to migrate, and every Outlook run already reprocesses the whole mailbox anyway. Nothing yet depends on an Outlook record keeping its identity between runs. Once incremental processing is switched on for this connector, the same re-key costs the same amount with considerably more riding on it.

The alternative is not cheaper, it is recurring. Keep the default id format and every folder move mints a new record id, so the message is reprocessed and its old rows survive at the destination, because the delete is keyed on the new id and matches nothing. Mail rules that file messages into subfolders make that routine rather than rare, and unlike the re-key it never stops.

This still deserves a coordinated release decision, since it changes record identity for every existing deployment on upgrade. It is not a routine bugfix merge.

## What was broken

Outlook/Exchange can silently change a message's id when the message moves between folders, including automatic moves such as a rule filing a message into a subfolder. `FileData.identifier` is set directly from that id, so a routine move could make the connector treat an already-processed message as brand new.

## What changes

Every Graph request the connector makes now carries `Prefer: IdType="ImmutableId"`, so Graph returns the immutable id format for `message.id` instead of the default (mutable) one. Ids are now stable across in-mailbox folder moves.

## One-time re-key of every existing record

The immutable id is a **different value** than the default id existing deployments have been using; it is not a superset or a compatible extension. Every message the connector has already indexed gets a new id on the next run after upgrading. That single change propagates through the whole pipeline:

**Every pipeline stage cache-misses and recomputes.** Each stage's skip check is a `filepath.exists()` test against a hash that has `file_data.identifier` baked into it, so a changed identifier is a guaranteed miss at every stage, not just at the destination:
- The index step's own cache file is named `sha256(index_config + connection_config + file_data.identifier)[:12]` (`pipeline/steps/index.py`, `get_hash`, called with `extras=[file_data.identifier]`), and partition/chunk/embed/stage each key their own cache file the same way.
- The download step's `should_download` check (`pipeline/steps/download.py:48-52`) tests whether `get_download_path(file_data)` already exists. For this connector that path is `source_identifiers.relative_path` (`interfaces/downloader.py:36-45`, resolving through `SourceIdentifiers.relative_path` in `data_types/file_data.py:20-22`), which is exactly the `sha256(message.id)`-derived filename below. Because the path itself is id-derived here, the file at the old path is invisible to a lookup keyed on the new id, and the message is downloaded again under a new filename. (A downloader whose path did not depend on the record id would behave differently; this one's does.)

**Every element gets a new id at 11 destinations.** `get_enhanced_element_id` (`unstructured_ingest/utils/data_prep.py:323-326`) computes each element's id as `uuid5(NAMESPACE_DNS, f"{element_id}{file_data.identifier}")` - the record identifier is part of the seed. It's called from the upload stagers for Pinecone, Qdrant, Azure AI Search, Elasticsearch, Chroma, KDB.AI, DuckDB, SQL, Teradata, VastDB, and Databricks Volumes. For all of them, every element belonging to a message gets a new id too, not just the message-level record.

**Every destination this connector's records reach orphans and duplicates, record-keyed or file-based alike - neither is immune, they just do it through different mechanisms:**
- **Record-keyed destinations** (the SQL family - Postgres, Snowflake, SingleStore, Teradata, VastDB, SQLite; and vector stores - Weaviate, Qdrant, AstraDB, Milvus, LanceDB, Pinecone, Delta Table, Databricks Volumes) key writes and deletes off `file_data.identifier` directly - e.g. `sql.py`'s uploader stages `data[RECORD_ID_LABEL] = file_data.identifier` and later deletes existing rows with `record_id_key=file_data.identifier`; Weaviate's `delete_by_record_id` (`weaviate.py:447-465`) filters on the same field. Re-keying orphans via a **delete miss**: the old row/object, filed under the old id, is never matched by a delete keyed on the new id, so it's left behind while a new one is inserted under the new id. Elasticsearch is a sharper case of the same problem: its uploader has no delete path at all, so there's no code path that would even attempt cleanup.
- **File-based destinations** (S3, GCS, Azure, Box, Dropbox, SFTP - all share `FsspecUploader`) derive the remote path from `file_data.source_identifiers.relative_path` (`fsspec.py`'s `get_upload_path`), which for this connector is exactly the sha256-derived filename below. Re-keying orphans via a **filename change**: the uploader just uploads to whatever path it's given (`client.upload(lpath=..., rpath=...)`, no delete step anywhere), so a new id produces a new object at a new path while the old object at the old path is never touched.
- Either way, the outcome is the same: one full duplicate set of records/objects/elements, one time, on the first run after upgrading.

For reference, the two identifiers that everything above traces back to:
- `FileData.identifier` and `record_locator["message_id"]` (`unstructured_ingest/processes/connectors/outlook.py`, `_message_to_file_data`).
- The downloaded output filename, which is `sha256(message.id)[:16] + ".eml"` (`_generate_fullpath`).

This is a one-time cost of moving to stable identity, not an ongoing behavior: ids are stable going forward, so this re-key does not repeat on subsequent runs.

## "Immutable" has real caveats

Per [Microsoft's own documentation](https://learn.microsoft.com/en-us/graph/outlook-immutable-id):

- The id still changes if the item is moved to an **archive mailbox**, or **exported and re-imported** (PST, MSG, etc.). It is immutable only "so long as the item stays in the same mailbox."
- The header is **per-request**, not a mailbox- or session-level setting: "If you want to always use immutable IDs, you must include this header with every API request." That's why this PR registers the hook on every outbound request rather than once at client construction.

One further limitation not in Microsoft's docs but corroborated by multiple independent reports ([msgraph-sdk-dotnet#698](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/698), several Microsoft Q&A threads) rather than the canonical page itself, so treated here as a known community-reported issue, not confirmed platform behavior: **`$search` does not honor the header** and returns the default (mutable) id format regardless. The connector doesn't currently use `$search` (it lists via `/messages` and `/mailFolders`), so this isn't a live bug today, but it's a trap for any future code path that adds search. Related: the general OData `Prefer` contract ([RFC 7240](https://www.rfc-editor.org/rfc/rfc7240)) lets a server optionally echo a `Preference-Applied` response header when it honors a preference — optional even when honored, so its absence proves nothing, and Microsoft's immutable-id page never promises it for this header. This connector does not check it either way, so a case where Graph silently ignores the preference (such as `$search`, or another edge case) would not currently be detected. Noted as a known limitation, not fixed here.

## Migration alternative deliberately not built

Graph's [`translateExchangeIds`](https://learn.microsoft.com/en-us/graph/api/user-translateexchangeids) function can convert existing stored ids from `restId` (default) to `restImmutableEntryId` (immutable) in batches of up to 1000 ids per call, without needing to re-fetch or reprocess the underlying messages. That would avoid the full re-index above for anyone with an existing id store to translate. It's deliberately not built here: the connector doesn't own a durable id store to translate (that lives in each deployment's destination and any incremental-state tracking), so a generic translation script would need per-deployment integration work disproportionate to a one-time re-index. Flagging it as the alternative for anyone who needs to avoid the full re-index cost.

One permission nuance for anyone who does build it: `/me/translateExchangeIds` supports delegated auth only — Application permissions are not supported on that path at all — so a deployment using this connector's app-only (client-credentials) mode must call `/users/{userPrincipalName}/translateExchangeIds` with the Application permission `User.Read.All` instead.

## Rollback

Removing the `Prefer` header reverts to Graph's default (mutable) id format. Since this is a one-time re-key in either direction, rolling back after this PR has been live re-keys every record a second time, the same way upgrading did.

## Coordination

Split out of #802 (which keeps the change-key fix, full pagination, and the `$select` projection) because this is a substantially different kind of change: #802 is a routine bugfix, this is an identity migration. #802 should land first.

#804 explored putting this behind an opt-in flag defaulting to the current id format. It is closed: if immutable ids are the right default, a setting that defaults to the wrong one is permanent configuration surface for a capability we would then be telling everyone to switch on.

On versioning: the merge order is #802 first, then this PR, then #801 — stated in prose on purpose. Version numbers are re-picked against `main` at each merge (unrelated merges consume numbers faster than any reserved sequence survives; an earlier reservation scheme here went stale within days). This branch currently carries 1.11.10; renumber at merge time if `main` has moved again.

#801 (fixture seeding, re-enables the Outlook e2e test) lands after both #802 and this PR. Fixture filenames are `sha256(message.id)` and change here, and `data_source.version` changes in #802, so its fixtures have to be generated against both. `data_source.version` will also need excluding or treating as volatile in the fixture comparator once the e2e test is re-enabled.

This PR and #802 are sibling branches off `main`, not a stack, and both append tests to the same region of `test/unit/connectors/test_outlook.py`, so whichever of the two merges second resolves that one conflict at merge time. The connector module itself merges cleanly between them.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->






