### PR TITLE
feat(outlook): make Graph's immutable id type opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.8]
+
+### Fixes
+
+- **fix(outlook): make Graph's immutable id type opt-in.** Outlook/Exchange can rotate a message's id when the message moves between folders (including automatic moves, e.g. a rule filing a message into a subfolder), which breaks downstream record identity for anything keyed off `FileData.identifier`: the record locator, the sha256-derived output filename, and any destination that upserts by id. Graph will hand back ids that survive an in-mailbox move if every request carries `Prefer: IdType="ImmutableId"`, but switching an existing connection to those ids re-keys every record already indexed, so the next run reprocesses the whole mailbox and leaves one duplicate set of the old records at every destination. A new `use_immutable_message_ids` connection-config flag therefore gates the header and defaults to `False`, leaving current behavior and current ids exactly as they are unless a deployment opts in and accepts the one-time re-key. When enabled, the header is registered on the request handler's event notifier directly (`pending_request().beforeExecute`) rather than through the client-level `before_execute()` helper, which no-ops on a fresh client at office365-rest-python-client 3.0.0 and would not have survived a paginated continuation request either way.
+
 ## [1.11.7]
 
 ### Fixes

--- a/test/unit/connectors/test_outlook.py
+++ b/test/unit/connectors/test_outlook.py
@@ -13,6 +13,7 @@ from unstructured_ingest.processes.connectors.outlook import (
     OutlookConnectionConfig,
     OutlookIndexer,
     OutlookIndexerConfig,
+    _prefer_immutable_ids,
 )
 
 
@@ -71,6 +72,74 @@ class TestOutlookConnectionConfig:
             access_config=Secret(OutlookAccessConfig(oauth_token="ey.access.token")),
         )
         assert config.client_id is None
+
+
+class TestImmutableMessageIdsOptIn:
+    """`Prefer: IdType="ImmutableId"` keeps message ids stable across folder moves.
+
+    Without it, Outlook/Exchange can rotate a message's id when the message is moved
+    between folders, breaking downstream record identity that keys off
+    FileData.identifier. Sending it re-keys every already-indexed record once, so it
+    is opt-in and the default must stay off.
+    """
+
+    def _request_options(self, url: str = "https://graph.microsoft.com/v1.0/me/messages"):
+        try:
+            from office365.runtime.http.request_options import RequestOptions
+        except ImportError:
+            pytest.skip("office365-rest-python-client not installed")
+        return RequestOptions(url)
+
+    def _config(self, **kwargs) -> OutlookConnectionConfig:
+        return OutlookConnectionConfig(
+            access_config=Secret(OutlookAccessConfig(oauth_token="ey.access.token")),
+            **kwargs,
+        )
+
+    def test_opt_in_is_off_by_default(self):
+        # The default decides what an upgrade does to an existing deployment: off
+        # means the ids this connector already emitted keep working untouched.
+        assert self._config().use_immutable_message_ids is False
+
+    def test_hook_sets_header_on_request(self):
+        request = self._request_options()
+
+        _prefer_immutable_ids(request)
+
+        assert request.headers["Prefer"] == 'IdType="ImmutableId"'
+
+    def test_disabled_sends_no_prefer_header(self):
+        # Asserts on the header the SDK would actually put on the wire rather than on
+        # the absence of a subscriber, so an alternative registration path (e.g. a
+        # client-level before_execute) could not slip the header in unnoticed.
+        client = self._config().get_client()
+        request = self._request_options()
+
+        client.pending_request().beforeExecute.notify(request)
+
+        assert "Prefer" not in request.headers
+
+    def test_enabled_registers_hook_that_fires_on_every_request(self):
+        # Fires the SDK's own dispatch path directly (ClientRuntimeContext.build_request
+        # calls exactly this: pending_request().beforeExecute.notify(request)) rather than
+        # asserting on a mocked call signature, so e.g. a rename of the `once` kwarg would
+        # be caught here instead of silently passing an unspecced mock assertion.
+        client = self._config(use_immutable_message_ids=True).get_client()
+
+        initial_request = self._request_options(
+            "https://graph.microsoft.com/v1.0/users/alice/mailFolders/inbox/messages"
+        )
+        client.pending_request().beforeExecute.notify(initial_request)
+        assert initial_request.headers["Prefer"] == 'IdType="ImmutableId"'
+
+        # The hook must still be registered on the same pending_request() for a
+        # get_all() pagination continuation, not just the first request.
+        continuation_request = self._request_options(
+            "https://graph.microsoft.com/v1.0/users/alice/mailFolders/inbox/messages"
+            "?$skiptoken=abc123"
+        )
+        client.pending_request().beforeExecute.notify(continuation_request)
+        assert continuation_request.headers["Prefer"] == 'IdType="ImmutableId"'
 
 
 def _make_message(message_id: str = "msg-1", change_key: Optional[str] = "ck-123") -> Mock:

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.7"  # pragma: no cover
+__version__ = "1.11.8"  # pragma: no cover

--- a/unstructured_ingest/processes/connectors/outlook.py
+++ b/unstructured_ingest/processes/connectors/outlook.py
@@ -60,9 +60,22 @@ if TYPE_CHECKING:
     from office365.graph_client import GraphClient
     from office365.outlook.mail.folders.folder import MailFolder
     from office365.outlook.mail.messages.message import Message
+    from office365.runtime.http.request_options import RequestOptions
 
 
 CONNECTOR_TYPE = "outlook"
+
+
+def _prefer_immutable_ids(request: "RequestOptions") -> None:
+    """Ask Graph to return immutable ids for mail resources.
+
+    Without this header, Outlook/Exchange can rotate a message's id when the
+    message is moved between folders, breaking downstream record identity
+    that keys off FileData.identifier. Graph honors the preference per
+    request, so this has to run for every outbound request rather than once
+    at client construction.
+    """
+    request.set_header("Prefer", 'IdType="ImmutableId"')
 
 
 class OutlookAccessConfig(AccessConfig):
@@ -112,6 +125,18 @@ class OutlookConnectionConfig(ConnectionConfig):
         default="https://login.microsoftonline.com",
         description="Authentication token provider for Microsoft apps",
     )
+    use_immutable_message_ids: bool = Field(
+        default=False,
+        description=(
+            "Ask Graph for immutable message ids, so a message keeps its id when it is moved"
+            " between folders in the same mailbox. This changes record identity: enabling it"
+            " gives every message already indexed by this connection a new id, so the next run"
+            " reprocesses the entire mailbox as if it had never been seen and leaves one"
+            " duplicate set of the old records behind at every destination. Disabling it again"
+            " re-keys everything a second time at the same cost, so treat the switch as one-way."
+            " Leave it off to keep the ids this connection emits today."
+        ),
+    )
 
     @model_validator(mode="after")
     def _require_client_id_without_oauth(self) -> "OutlookConnectionConfig":
@@ -160,7 +185,16 @@ class OutlookConnectionConfig(ConnectionConfig):
     def get_client(self) -> "GraphClient":
         from office365.graph_client import GraphClient
 
-        return GraphClient(self._acquire_token)
+        client = GraphClient(self._acquire_token)
+        if self.use_immutable_message_ids:
+            # Registered directly on the pending request's event handler rather
+            # than via client.before_execute(): that context-level helper no-ops
+            # on a fresh client (office365-rest-python-client 3.0.0 early-returns
+            # when no query has been queued yet) and, once a query exists, scopes
+            # the hook to that single query's id, so it would never ride get_all()
+            # pagination continuations.
+            client.pending_request().beforeExecute += _prefer_immutable_ids
+        return client
 
 
 class OutlookIndexerConfig(IndexerConfig):


### PR DESCRIPTION
Adds a `use_immutable_message_ids` boolean to `OutlookConnectionConfig`, defaulting to `False`, which gates whether every Graph request carries `Prefer: IdType="ImmutableId"`. With the flag off, the connector behaves byte for byte as it does today and emits exactly the ids it emits today, so taking this upgrade changes nothing for any existing deployment.

## Why opt-in

`message.id` is part of record identity: it feeds the record locator, the sha256-derived output filename, and any destination that upserts by id. Sending the `Prefer` header unconditionally changes that id for every message an existing connection has already indexed, so the first run after upgrade sees a mailbox full of records it has never seen before. It reprocesses all of them and leaves one duplicate set of the old records at every destination.

That is a real cost and it should be paid by the deployment that decides it wants stable identity, at a moment it picks, rather than by everyone who takes a routine version bump and did not ask for a re-index.

The flag is deliberately not marked runtime-eligible. Flipping the id format for a single run would re-key that run's records and leave the connection straddling two id schemes, which is precisely the failure mode this design keeps out of reach.

## What you get if you turn it on

Message ids survive a move between folders inside the same mailbox, including automatic moves: a rule filing an incoming message into a subfolder, or a user dragging it out of the inbox, no longer looks like a delete plus a new message to anything downstream. That is the whole point of the header, and it is the case that actually bites in practice.

The honest caveats, per Microsoft's documentation:

- The id is immutable only while the item stays in the same mailbox. Moving a message to an archive mailbox still changes it, and so does an export followed by a re-import.
- Graph treats `Prefer` as a per-request preference, not client state. That is why the hook registers on the request handler's event notifier (`pending_request().beforeExecute`) rather than once at client construction: it has to ride every outbound request, including the `@odata.nextLink` continuations that `get_all()` issues during pagination.

## What turning it on costs

The one-time re-key, stated plainly. Every already-indexed message gets a new identifier, so:

- Every pipeline stage cache-misses, because the caches are keyed on the identifier.
- Every element id changes, since they derive from it.
- Record-keyed destinations orphan the old rows: the delete targets the new id and misses, so the old row stays.
- File-based destinations orphan the old objects the same way, via a changed output path.

The net outcome is one duplicate set of records, once, plus a full reprocess of the mailbox. It does not repeat on subsequent runs, and turning the flag back off would re-key everything a second time at the same cost, so the switch is best treated as one-way.

If you would rather migrate an existing id store than re-index, Graph exposes [`translateExchangeIds`](https://learn.microsoft.com/en-us/graph/api/user-translateexchangeids) for exactly this: it converts ids between formats in batches, without re-fetching the messages themselves. That is the documented path for converting what you already have.

## Relationship to the unconditional version

This PR and #803 are mutually exclusive alternatives to the same problem, and only one should merge.

- #803 makes immutable ids the default and pays the migration once, fleet-wide, for every deployment on upgrade.
- This PR defers the decision to each deployment, at the price of the capability being off until somebody asks for it.

Both currently claim version `1.11.8`, which is deliberate given that only one can land; whichever merges first makes the other re-bump.

Stacked on #802, so the diff here is only the flag, the gated hook, and its tests. The base retargets to `main` automatically once #802 merges.

## Testing

Added `TestImmutableMessageIdsOptIn` to `test/unit/connectors/test_outlook.py`, covering: the flag defaults to `False`; the hook function sets `Prefer: IdType="ImmutableId"` on a real `RequestOptions`; with the flag off, driving the SDK's own dispatch path (`pending_request().beforeExecute.notify(...)`) produces no `Prefer` header at all; and with the flag on, both an initial request and a `$skiptoken` pagination continuation come out carrying the header.

The off-by-default test asserts on the header the SDK would actually put on the wire rather than on the absence of a subscriber, so a header slipped in through some other registration path would still fail the test.

`make test-unit` for this file passes (24 tests, none skipped), and `ruff check` plus `ruff format --check` are clean on the touched files.


Worth knowing before reading the checks tab: **the unit-test workflow does not run on this PR**. `.github/workflows/unit_tests.yml` triggers on `pull_request: branches: [main, release/*]`, and that filter matches the base branch, so while this PR is based on #802's branch only the Socket Security checks fire. The two passing checks are those, not the suite. The full 27-check set starts running the moment #802 merges and GitHub retargets this PR's base to `main`. Until then the numbers above are local runs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


