### PR TITLE
fix(registry): make emits_record_version a tri-state capability marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.11]
+
+### Fixes
+
+- **fix(registry): make `emits_record_version` a tri-state capability marker.** The registry defaulted the marker to a real `False`, so a connector that never considered record versions was indistinguishable from one that deliberately opted out, and a downstream consumer that treats an explicit bool as authoritative overrides its own fallback list with an unreviewed default the moment the field exists in the installed package. The field now defaults to `None`, meaning "no claim": consumers fall back to their own defaults exactly as they already do for the other unannotated capability markers, while an explicit `True`/`False` stays authoritative. Three entries whose mechanically-set `True` from the original capability-marker batch does not hold drop the claim rather than keep a false one: elasticsearch and opensearch only learn a document's `_version` at download time (their indexers emit batch items with no per-record version), and slack's two record kinds disagree: conversation packages emit a real index-time change token, but file records reuse the parent message timestamp, so no single connector-level claim is true. Entries whose indexers verifiably populate a per-record change value (s3, azure, gcs, dropbox, google_drive, onedrive, sharepoint, salesforce, confluence, outlook) keep their explicit `True`; outlook's emitted value itself is made real in a sibling change.
+
 ## [1.11.10]
 
 ### Fixes

--- a/test/unit/connectors/test_registry_markers.py
+++ b/test/unit/connectors/test_registry_markers.py
@@ -174,12 +174,47 @@ def test_unannotated_entry_is_unmarked():
 
 
 @pytest.mark.parametrize("connector_type", ["elasticsearch", "opensearch", "slack"])
-def test_download_time_version_sources_make_no_claim(connector_type):
-    # These indexers do not emit a per-record version at index time (elasticsearch
-    # and opensearch only see _version during download; slack file records reuse
-    # the parent message timestamp), so their entries carry no claim rather than
-    # an authoritative bool either way.
+def test_no_authoritative_version_claim(connector_type):
+    # No single connector-level bool is true for these: elasticsearch and
+    # opensearch only see _version during download (their indexers emit batch
+    # items with no per-record version), and slack's two record kinds disagree
+    # (conversation packages emit a real index-time change token, file records
+    # reuse the parent message timestamp). Their entries carry no claim rather
+    # than an authoritative bool either way.
     assert source_registry[connector_type].emits_record_version is None
+
+
+def test_version_claims_are_exactly_the_verified_set():
+    # Snapshot of every explicit emits_record_version claim in both registries.
+    # The original false claims arrived in one mechanical batch commit that no
+    # test caught; set equality forces every future claim change through a
+    # conscious edit here.
+    source_true = {
+        name for name, entry in source_registry.items() if entry.emits_record_version is True
+    }
+    assert source_true == {
+        "azure",
+        "confluence",
+        "dropbox",
+        "gcs",
+        "google_drive",
+        "onedrive",
+        "outlook",
+        "s3",
+        "salesforce",
+        "sharepoint",
+    }
+    # No entry anywhere claims an explicit False, and no destination entry makes
+    # any claim: an explicit False would authoritatively override consumers that
+    # vouch for a different implementation under the same subtype.
+    assert [
+        name for name, entry in source_registry.items() if entry.emits_record_version is False
+    ] == []
+    assert [
+        name
+        for name, entry in destination_registry.items()
+        if entry.emits_record_version is not None
+    ] == []
 
 
 def test_opensearch_dual_role_location_identity():

--- a/test/unit/connectors/test_registry_markers.py
+++ b/test/unit/connectors/test_registry_markers.py
@@ -9,7 +9,8 @@ from unstructured_ingest.processes.connector_registry import (
     source_registry,
 )
 
-# fsspec sources that emit a per-record version (box and sftp do not).
+# fsspec sources that emit a per-record version (box and sftp make no claim: their
+# entries stay unannotated so consumers fall back to their own defaults).
 VERSION_EMITTING_FSSPEC = ("s3", "azure", "gcs", "dropbox")
 FSSPEC_COHORT = VERSION_EMITTING_FSSPEC + ("box", "sftp")
 
@@ -19,7 +20,8 @@ def test_fsspec_source_entry_markers(connector_type):
     entry = source_registry[connector_type]
     assert entry.location_shape == LocationShape.FSSPEC_URL
     assert entry.location_identity == ("indexer_config.remote_url",)
-    assert entry.emits_record_version == (connector_type in VERSION_EMITTING_FSSPEC)
+    expected_version_claim = True if connector_type in VERSION_EMITTING_FSSPEC else None
+    assert entry.emits_record_version is expected_version_claim
 
     schema = entry.indexer_config.model_json_schema()
     assert schema["properties"]["remote_url"].get("x-runtime-eligible") is True
@@ -46,7 +48,7 @@ def test_sql_table_source_entry_markers():
         "indexer_config.table_name",
     )
     assert entry.supports_recursion is False
-    assert entry.emits_record_version is False
+    assert entry.emits_record_version is None
 
     conn = entry.connection_config.model_json_schema()
     assert conn["properties"]["database"].get("x-runtime-eligible") is True
@@ -79,7 +81,7 @@ def test_sql_table_destination_write_target_markers():
         "uploader_config.table_name",
     )
     assert entry.supports_recursion is False
-    assert entry.emits_record_version is False
+    assert entry.emits_record_version is None
 
     up = entry.uploader_config.model_json_schema()
     assert up["properties"]["table_name"].get("x-runtime-eligible") is True
@@ -163,9 +165,21 @@ def test_fsspec_url_delta_table_destination_marker():
 def test_unannotated_entry_is_unmarked():
     # A connector that sets no markers reports location_shape None so consumers
     # fall back to their own defaults rather than deriving an fsspec identity.
+    # emits_record_version is tri-state for the same reason: None means "no claim",
+    # so an unannotated connector is never mistaken for an explicit opt-out that
+    # would override a consumer's own fallback list.
     entry = SourceRegistryEntry(indexer=object, downloader=object)
     assert entry.location_shape is None
-    assert entry.emits_record_version is False
+    assert entry.emits_record_version is None
+
+
+@pytest.mark.parametrize("connector_type", ["elasticsearch", "opensearch", "slack"])
+def test_download_time_version_sources_make_no_claim(connector_type):
+    # These indexers do not emit a per-record version at index time (elasticsearch
+    # and opensearch only see _version during download; slack file records reuse
+    # the parent message timestamp), so their entries carry no claim rather than
+    # an authoritative bool either way.
+    assert source_registry[connector_type].emits_record_version is None
 
 
 def test_opensearch_dual_role_location_identity():
@@ -254,7 +268,7 @@ def test_unannotated_entries_are_ignored(registry, default_identity):
         # rather than location_shape would wrongly treat these as fsspec targets.
         assert entry.location_identity == default_identity, f"{name}: unexpected identity"
         assert entry.supports_recursion is True, f"{name}: recursion should stay default"
-        assert entry.emits_record_version is False, f"{name}: version should stay default"
+        assert entry.emits_record_version is None, f"{name}: version should stay unclaimed"
         for section in ("connection_config", "indexer_config", "uploader_config"):
             config = getattr(entry, section, None)
             if config is not None and _eligible(config):

--- a/unstructured_ingest/__version__.py
+++ b/unstructured_ingest/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.11.10"  # pragma: no cover
+__version__ = "1.11.11"  # pragma: no cover

--- a/unstructured_ingest/processes/connector_registry.py
+++ b/unstructured_ingest/processes/connector_registry.py
@@ -56,6 +56,8 @@ class SourceRegistryEntry(RegistryEntry):
 
     # Ordered reshaped-settings dot-paths that identify the targeted location.
     location_identity: tuple[str, ...] = field(default=("indexer_config.remote_url",), kw_only=True)
+    # Tri-state: None = no claim, consumers fall back to their own defaults;
+    # an explicit bool is authoritative and overrides those defaults.
     emits_record_version: Optional[bool] = field(default=None, kw_only=True)
 
 
@@ -82,6 +84,8 @@ class DestinationRegistryEntry(RegistryEntry):
     location_identity: tuple[str, ...] = field(
         default=("uploader_config.remote_url",), kw_only=True
     )
+    # Tri-state: None = no claim, consumers fall back to their own defaults;
+    # an explicit bool is authoritative and overrides those defaults.
     emits_record_version: Optional[bool] = field(default=None, kw_only=True)
 
 

--- a/unstructured_ingest/processes/connector_registry.py
+++ b/unstructured_ingest/processes/connector_registry.py
@@ -56,7 +56,7 @@ class SourceRegistryEntry(RegistryEntry):
 
     # Ordered reshaped-settings dot-paths that identify the targeted location.
     location_identity: tuple[str, ...] = field(default=("indexer_config.remote_url",), kw_only=True)
-    emits_record_version: bool = field(default=False, kw_only=True)
+    emits_record_version: Optional[bool] = field(default=None, kw_only=True)
 
 
 source_registry: dict[str, SourceRegistryEntry] = {}
@@ -82,7 +82,7 @@ class DestinationRegistryEntry(RegistryEntry):
     location_identity: tuple[str, ...] = field(
         default=("uploader_config.remote_url",), kw_only=True
     )
-    emits_record_version: bool = field(default=False, kw_only=True)
+    emits_record_version: Optional[bool] = field(default=None, kw_only=True)
 
 
 destination_registry: dict[str, DestinationRegistryEntry] = {}

--- a/unstructured_ingest/processes/connectors/elasticsearch/elasticsearch.py
+++ b/unstructured_ingest/processes/connectors/elasticsearch/elasticsearch.py
@@ -500,7 +500,6 @@ elasticsearch_source_entry = SourceRegistryEntry(
     downloader_config=ElasticsearchDownloaderConfig,
     location_shape=LocationShape.SEARCH_INDEX,
     location_identity=("connector_config.hosts", "indexer_config.index_name"),
-    emits_record_version=True,
     supports_recursion=False,
 )
 

--- a/unstructured_ingest/processes/connectors/elasticsearch/opensearch.py
+++ b/unstructured_ingest/processes/connectors/elasticsearch/opensearch.py
@@ -579,7 +579,6 @@ opensearch_source_entry = SourceRegistryEntry(
     downloader_config=OpenSearchDownloaderConfig,
     location_shape=LocationShape.SEARCH_INDEX,
     location_identity=("connector_config.hosts", "indexer_config.index_name"),
-    emits_record_version=True,
     supports_recursion=False,
 )
 

--- a/unstructured_ingest/processes/connectors/fsspec/sftp.py
+++ b/unstructured_ingest/processes/connectors/fsspec/sftp.py
@@ -501,7 +501,8 @@ class SftpUploader(FsspecUploader):
             raise self.wrap_error(e=e)
 
 
-# sftp does not emit a per-record version, so emits_record_version stays False.
+# sftp makes no claim: emits_record_version stays unset (None), so consumers fall
+# back to their own defaults rather than reading an authoritative opt-out.
 sftp_source_entry = SourceRegistryEntry(
     indexer=SftpIndexer,
     indexer_config=SftpIndexerConfig,

--- a/unstructured_ingest/processes/connectors/slack.py
+++ b/unstructured_ingest/processes/connectors/slack.py
@@ -664,6 +664,5 @@ slack_source_entry = SourceRegistryEntry(
     connection_config=SlackConnectionConfig,
     location_shape=LocationShape.API_FOLDER,
     location_identity=("indexer_config.channels",),
-    emits_record_version=True,
     supports_recursion=False,
 )


### PR DESCRIPTION
## Why

`SourceRegistryEntry.emits_record_version` (and its destination twin) default to a real `False`, so a connector that never considered record versions is indistinguishable from one that deliberately opted out. Any downstream consumer that treats an explicit bool as authoritative — the ETL incremental-support check reads this marker ahead of its own allowlists — silently flips behavior for every unannotated connector the moment the installed package carries the field: allowlisted connectors whose entries never opted in (box, github, notion) get their incremental support disabled by a default nobody chose.

The `True` side was never validated either: all 13 `emits_record_version=True` entries trace to one mechanical batch commit (f9230114, #752) that touched no indexer implementations. Auditing each indexer against what it actually emits at index time found three claims that do not hold.

## What

- `emits_record_version` becomes `Optional[bool]` defaulting to `None` on both `SourceRegistryEntry` and `DestinationRegistryEntry`. `None` means "no claim": consumers fall back to their own defaults, the same convention `location_shape` already uses. An explicit `True`/`False` stays authoritative.
- Three unverified `True` claims drop to no-claim:
  - **elasticsearch, opensearch**: the indexers emit batch items with no per-record version (`BatchItem(identifier=...)`, version never set); `_version` is only fetched at download time by the downloader's scan query. There is no index-time record version to claim.
  - **slack**: package records carry a real version (`max(ts, latest_reply, edited.ts)`), but file records reuse the parent message timestamp, which is not a per-file change token. A half-true claim is not a claim.
- Verified `True` entries keep it: s3, azure, gcs (etag), dropbox (content_hash), google_drive (Drive `version`), onedrive, sharepoint (etag), salesforce (SystemModstamp), confluence (page `version.number`), outlook (changeKey; the value read itself is fixed in #802).
- box and sftp stay unannotated on purpose. Their no-version state is a fact about *these* implementations; an explicit `False` here would authoritatively override consumers that vouch for a different implementation registered under the same subtype string.

## Consumer impact (both known consumers verified against their current code)

- ETL incremental check: the marker read guards with `isinstance(marker, bool)`, so `None` falls through to its allowlists — behavior for every unannotated connector is preserved with zero code change there. The three dropped claims also fall back to the allowlists, which matches today's deployed behavior (the deployed pin predates the field entirely).
- platform-api capability derivation: `bool(getattr(entry, "emits_record_version", False))` maps `None` to `False` — degrades to "not capable" rather than crashing or claiming falsely.

## Deliberately not here

- github (`file.sha`) and jira (`fields.updated`) populate real versions but never claimed `True`. Promoting them is a per-connector verification decision, separate from this contract fix.

## Testing

- `test_registry_markers.py`: unannotated entries now assert `None`; a new parametrized test pins the three no-claim entries; the fsspec cohort asserts `True`/`None` explicitly.
- Full unit suite green locally (1456 passed, 60 skipped).
- Downstream proof: the ETL repo's incremental unit tests, run against this branch installed in place of the locked package, go from 6 failed (github/notion/box disabled by the default-False override) to all passing, with no ETL code change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-ingest/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

